### PR TITLE
Update creatorCheck.js

### DIFF
--- a/resolvers/functions/creatorCheck.js
+++ b/resolvers/functions/creatorCheck.js
@@ -1,5 +1,5 @@
 const creatorCheck = (context, org) => {
-  const isCreator = org.creator === context.userId;
+  const isCreator = org.creator + '' === context.userId;  //Casted org.creator to string to have matching types with === operator
   if (!isCreator) {
     throw new Error("Users cannot delete organizations they didn't create");
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

This PR solves a bug where the organization creator could not delete said organization, because the API didn't recognize the creator properly.



<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Did you add tests for your changes?** No.

**If relevant, did you update the documentation?** No, it was not necessary.

**Summary**

Resolved bug where users could not delete organizations they created. Concretely this issue [#568](https://github.com/PalisadoesFoundation/talawa/issues/568) in the frontend
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

This happened because the operator `===` is used to validate between the organization's creator ID and the ID of the user making the request. There should be no problem using the `===`, but the creator's ID is stored as a regular ID in the Organization, while it is stored as a string at the context used as parameter. Concretely it was like this:

organization:
```
{
    ...
    creator: 6064ebf16526980032c72859,
    _id: 6064ec376526980032c7285a,
    ...
}
```

context:
```
{
    ...
    userId: '6064ebf16526980032c72859',
    ...
}
```

In that case, using the `===` operator would return a `false` value, which was not the expected behavior. This PR suggests one solution for that problem, casting the `org.creator` id to a string, so the `===` operator would be valid.

Other solution was just using the `==` operator, but there it would have been way more flexible to the typing, which would represent a bigger security concern,

**Does this PR introduce a breaking change?**

No, the API continues to work properly
