### PR TITLE
removing redundant file operations in case of invalid extension

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,4 +1,4 @@
-const URL = 'http://calico.palisadoes.org/talawa/graphql';
+const URL = 'https://talawa-graphql-api.herokuapp.com/graphql';
 // const URL = "http://localhost:4000/graphql";
 
 module.exports.URL = URL;

--- a/helper_functions/imageExtensionCheck.js
+++ b/helper_functions/imageExtensionCheck.js
@@ -1,9 +1,6 @@
-const deleteImage = require('./deleteImage');
-
 module.exports = async (filename) => {
   const extension = filename.split('.').pop();
   if (extension !== 'png' && extension !== 'jpg' && extension !== 'jpeg') {
-    await deleteImage(filename);
     throw new Error('Invalid file Type. Only .jpg and .png files are accepted');
   }
 };

--- a/helper_functions/uploadImage.js
+++ b/helper_functions/uploadImage.js
@@ -9,6 +9,9 @@ module.exports = async (file, itemImage) => {
   const id = shortid.generate();
   const { createReadStream, filename } = await file;
 
+  // throw an error if file is not png or jpg
+  await imageExtensionCheck(filename);
+
   // upload new image
   await new Promise((res) =>
     createReadStream()
@@ -19,10 +22,8 @@ module.exports = async (file, itemImage) => {
       )
       .on('close', res)
   );
-  let imageJustUploadedPath = `images/${id}-${filename}`;
 
-  // throw an error if file is not png or jpg
-  await imageExtensionCheck(imageJustUploadedPath);
+  let imageJustUploadedPath = `images/${id}-${filename}`;
 
   //return imagePath;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Refactoring image upload and extension check util.

**Did you add tests for your changes?**

No.

**If relevant, did you update the documentation?**

Not required.

**Summary**

The image upload and image extension check function has been refactored to avoid redundant file operations in case of invalid extension, Its just that now we are avoiding writing to the disk if we have invalid file extension instead of first writing and then deleting the file.

Also, I've removed delete function call from extension validator as it should not be responsible for deleting the files.

**Does this PR introduce a breaking change?**

No. Essentially the end result will be the same.