### PR TITLE
Fixed Create Event Mutation: Fixes #276

### DIFF
--- a/resolvers/event_mutations/createEvent.js
+++ b/resolvers/event_mutations/createEvent.js
@@ -14,7 +14,6 @@ const createEvent = async (parent, args, context) => {
       'user'
     );
   }
-
   // ensure organization exists
   const org = await Organization.findOne({ _id: args.data.organizationId });
   if (!org) {
@@ -25,30 +24,61 @@ const createEvent = async (parent, args, context) => {
     );
   }
 
-  const newEvent = new Event({
-    ...args.data,
-    creator: context.userId,
-    registrants: [context.userId],
-    admins: [context.userId],
-    organization: args.data.organizationId,
-  });
-  await newEvent.save();
+  let flag = 0;
+  let JoinedOrg = user.joinedOrganizations;
+  let CreatedOrg = user.createdOrganizations;
 
-  // add event to the user record
-  await User.updateOne(
-    { _id: user.id },
-    {
-      $push: {
-        eventAdmin: newEvent,
-        createdEvents: newEvent,
-        registeredEvents: newEvent,
-      },
+  // Check if user has joined the org in which they are creating event
+  JoinedOrg.forEach((orgID) => {
+    if (orgID.equals(args.data.organizationId)) {
+      flag = 1;
     }
-  );
+  });
 
-  return {
-    ...newEvent._doc,
-  };
+  // If user hasn't joined the org then check if they have created the org
+  if (!flag) {
+    CreatedOrg.forEach((orgID) => {
+      if (orgID.equals(args.data.organizationId)) {
+        flag = 1;
+      }
+    });
+  }
+
+  // If user have joined or created the org then proceed with creating the event
+  if (flag) {
+    console.log('FLAG: ', flag);
+
+    const newEvent = new Event({
+      ...args.data,
+      creator: context.userId,
+      registrants: [context.userId],
+      admins: [context.userId],
+      organization: args.data.organizationId,
+    });
+    await newEvent.save();
+
+    // add event to the user record
+    await User.updateOne(
+      { _id: user.id },
+      {
+        $push: {
+          eventAdmin: newEvent,
+          createdEvents: newEvent,
+          registeredEvents: newEvent,
+        },
+      }
+    );
+
+    return {
+      ...newEvent._doc,
+    };
+  }
+  // If user hasen't joined or created the org then throw an error
+  throw new NotFoundError(
+    requestContext.translate('org.notAuthorized'),
+    'org.notAuthorized',
+    'org'
+  );
 };
 
 module.exports = createEvent;


### PR DESCRIPTION

**What kind of change does this PR introduce?**

BugFix

**Issue Number:**

Fixes #276 

**Did you add tests for your changes?**

No


**Snapshots/Videos:**

![Screenshot from 2021-08-08 00-56-48](https://user-images.githubusercontent.com/72073401/128611891-3f09f50d-ceb0-4dab-a7e9-87736bb4e2d1.png)

The above image shows a user who isn't a part of org trying to create an event in org and received an error 

**If relevant, did you update the documentation?**

No

**Summary**

Previously a user was able to create an event in an org even if they aren't a member of the org, This PR tends to resolve this issue.

Here `flag` is a variable that is used to handle condition. if `flag = 0` that means the user isn't a part of org and the API returns an error. If `flag = 1` this means that the user is a part of the org and we proceed with further steps.

```  
JoinedOrg.forEach((orgID) => {
    if (orgID.equals(args.data.organizationId)) {
      flag = 1;
    }
  });
```
The above function tries to check if the org in which the user is trying to create an event exists in the `JoinedOrg` array which is fetched from DB. If the user is a part of that org then the value of `flag` is changed to `1`

```
    CreatedOrg.forEach((orgID) => {
      if (orgID.equals(args.data.organizationId)) {
        flag = 1;
      }
    });
 ```
The above function tries to check if the org in which the user is trying to create an event exists in the `CreatedOrg` array which is fetched from DB. If the user is a part of that org then the value of `flag` is changed to `1`


**Does this PR introduce a breaking change?**

No

**Other information**

Na

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes
