### PR TITLE
Fixes #275: Changed comparison operator 

### DIFF
--- a/resolvers/member_mutations/removeMember.js
+++ b/resolvers/member_mutations/removeMember.js
@@ -45,7 +45,7 @@ module.exports = async (parent, args, context) => {
     }
 
     //ensure the user the admin is trying to remove isn't the creator
-    if (org._doc.creator === user.id) {
+    if (org._doc.creator.equals(user.id)) {
       errors.push(
         'Administratos cannot remove the creator of the organization from the organization'
       );


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug Fix

**Issue Number:**

Fixes #275 

**Did you add tests for your changes?**
No

**Snapshots/Videos:**
NA

**If relevant, did you update the documentation?**

NA

**Summary**

comparison between user ID from the MongoDB document and `args.data.organizationId` with ===  is invalid, however we are supposed to use `.equals()` for this

**Does this PR introduce a breaking change?**

No
**Other information**

NA

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes
