### PR TITLE
Test: Revamped All Users Query, SignUp and Login Mutation Tests

### DIFF
--- a/tests/functions/getToken.js
+++ b/tests/functions/getToken.js
@@ -22,5 +22,33 @@ module.exports = async () => {
   });
 
   const { data } = response;
+
+  if (data.errors && data.errors[0].message === 'User not found') {
+    const signUpResponse = await axios.post(URL, {
+      query: `
+            mutation {
+                signUp(data: {
+                  firstName:"testdb2",
+                  lastName:"testdb2"
+                  email: "testdb2@test.com"
+                  password:"password"
+                }) {
+                    user {
+                      _id
+                      firstName
+                      lastName
+                      email
+                      userType
+                      appLanguageCode
+                      image
+                    }
+                    accessToken
+                  }
+                }
+                `,
+    });
+    const { data } = signUpResponse;
+    return data.data.signUp.accessToken;
+  }
   return data.data.login.accessToken;
 };

--- a/tests/user.spec.js
+++ b/tests/user.spec.js
@@ -1,49 +1,10 @@
 const axios = require('axios');
-const shortid = require('shortid');
 const { URL } = require('../constants');
-const getToken = require('./functions/getToken');
 
 let token;
-beforeAll(async () => {
-  token = await getToken();
-});
 
 describe('user resolvers', () => {
-  test('allUsers', async () => {
-    const response = await axios.post(
-      URL,
-      {
-        query: `query {
-                users {
-                  _id
-                  firstName
-                  lastName
-                  email
-                }
-              }`,
-      },
-      {
-        headers: {
-          authorization: `Bearer ${token}`,
-        },
-      }
-    );
-    const { data } = response;
-    expect(Array.isArray(data.data.users)).toBeTruthy();
-
-    expect(data.data.users[0]).toEqual(
-      //Tested First Object in Array as others will be similar.
-      expect.objectContaining({
-        _id: expect.any(String),
-        firstName: expect.any(String),
-        lastName: expect.any(String),
-        email: expect.any(String),
-      })
-    );
-  });
-
-  const id = shortid.generate().toLowerCase();
-  const email = `${id}@test.com`;
+  const email = 'testdb2@test.com';
 
   test('signUp', async () => {
     const response = await axios.post(URL, {
@@ -97,7 +58,6 @@ describe('user resolvers', () => {
                   lastName
                   email
                   userType
-                  appLanguageCode
                   image
                 }
                 accessToken
@@ -106,6 +66,7 @@ describe('user resolvers', () => {
             `,
     });
     const { data } = response;
+    token = data.data.login.accessToken;
     expect(data.data.login).toEqual(
       expect.objectContaining({
         user: expect.objectContaining({
@@ -114,10 +75,42 @@ describe('user resolvers', () => {
           lastName: 'testdb2',
           email: `${email}`,
           userType: 'USER',
-          appLanguageCode: 'en',
           image: null,
         }),
         accessToken: expect.any(String),
+      })
+    );
+  });
+
+  test('allUsers', async () => {
+    const response = await axios.post(
+      URL,
+      {
+        query: `query {
+                users {
+                  _id
+                  firstName
+                  lastName
+                  email
+                }
+              }`,
+      },
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      }
+    );
+    const { data } = response;
+    expect(Array.isArray(data.data.users)).toBeTruthy();
+
+    expect(data.data.users[0]).toEqual(
+      //Tested First Object in Array as others will be similar.
+      expect.objectContaining({
+        _id: expect.any(String),
+        firstName: expect.any(String),
+        lastName: expect.any(String),
+        email: expect.any(String),
       })
     );
   });

--- a/tests/user.spec.js
+++ b/tests/user.spec.js
@@ -18,9 +18,10 @@ describe('user resolvers', () => {
     expect(Array.isArray(data.data.users)).toBeTruthy();
   });
 
+  const id = shortid.generate().toLowerCase();
+  const email = `${id}@test.com`;
+
   test('signUp', async () => {
-    var id = shortid.generate();
-    var email = `${id}@test.com`;
     const response = await axios.post(URL, {
       query: `
             mutation {
@@ -30,17 +31,32 @@ describe('user resolvers', () => {
                   email: "${email}"
                   password:"password"
                 }) {
-                  user{
-                    _id
+                    user {
+                      _id
+                      firstName
+                      lastName
+                      email
+                      userType
+                      appLanguageCode
+                      image
+                    }
+                    accessToken
                   }
-                  accessToken
                 }
-              }
               `,
     });
     const { data } = response;
     expect(data.data.signUp).toEqual(
       expect.objectContaining({
+        user: expect.objectContaining({
+          _id: expect.any(String),
+          firstName: 'testdb2',
+          lastName: 'testdb2',
+          email: `${email}`,
+          userType: 'USER',
+          appLanguageCode: 'en',
+          image: null,
+        }),
         accessToken: expect.any(String),
       })
     );
@@ -51,7 +67,7 @@ describe('user resolvers', () => {
       query: `
             mutation{
                 login(data: {
-                  email:"testdb2@test.com",
+                  email:"${email}",
                   password:"password"
                 }) {
                   user{


### PR DESCRIPTION
**What kind of change does this PR introduce?**

testing

**Issue Number:**

Fixes #362 , #363 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

![image](https://user-images.githubusercontent.com/57038543/147887430-17f913ef-82cc-4819-8f0a-9be1ec66a86e.png)

**If relevant, did you update the documentation?**

No

**Summary**

- To precisely test the signup, login mutation, and all users Query.
- To Fix issue #362 
- To Fix issue  #363
-  `tests/functions/getToken.js` was modified because whenever a test runs it checks for `token` using `beforeAll` in jest. But when tests run without the user existing, it doesn't return the token. Because of this, many tests are getting failed. To deal with this, I have added `SignUp` to it and it returns the token for the first time. Later, since the user exists, all the tests which require token run correctly.
- This is a high-priority issue for dealing with testing and getting test coverage with `codecov`. 

**Does this PR introduce a breaking change?**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes
