### PR TITLE
Fix: Block user mutation with Tests

### DIFF
--- a/resolvers/block_user_mutations/block_user.js
+++ b/resolvers/block_user_mutations/block_user.js
@@ -14,8 +14,10 @@ module.exports = async (parent, args, context) => {
   adminCheck(context, org);
   // ensure user isnt already blocked
   const blocked = org._doc.blockedUsers.filter(
-    (blockedUser) => blockedUser === user.id
+    (blockedUser) => blockedUser.toString() === user.id
   );
+  console.log(blocked);
+
   if (blocked[0]) {
     throw new UnauthorizedError(
       requestContext.translate('user.notAuthorized'),

--- a/resolvers/block_user_mutations/unblock_user.js
+++ b/resolvers/block_user_mutations/unblock_user.js
@@ -16,7 +16,7 @@ module.exports = async (parent, args, context) => {
 
   // ensure user is blocked
   const blocked = org._doc.blockedUsers.filter(
-    (blockedUser) => blockedUser === user.id
+    (blockedUser) => blockedUser.toString() === user.id
   );
   if (!blocked[0]) {
     throw new UnauthorizedError(
@@ -30,7 +30,7 @@ module.exports = async (parent, args, context) => {
   org.overwrite({
     ...org._doc,
     blockedUsers: org._doc.blockedUsers.filter(
-      (blockedUser) => blockedUser !== user.id
+      (blockedUser) => blockedUser.toString() !== user.id
     ),
   });
   await org.save();
@@ -39,7 +39,7 @@ module.exports = async (parent, args, context) => {
   user.overwrite({
     ...user._doc,
     organizationsBlockedBy: user._doc.organizationsBlockedBy.filter(
-      (organization) => organization !== org.id
+      (organization) => organization.toString() !== org.id
     ),
   });
   await user.save();

--- a/tests/block_user_functionality_tests.spec.js
+++ b/tests/block_user_functionality_tests.spec.js
@@ -68,12 +68,11 @@ describe('Block user functionality tests', () => {
       URL,
       {
         query: `
-                    mutation{
-                      blockUser(organizationId: "${createdOrganizationId}", userId: "${newUserId}"){
-                        _id
-                      }
-                    }
-                    `,
+          mutation{
+            blockUser(organizationId: "${createdOrganizationId}", userId: "${newUserId}"){
+              _id
+            }
+          }`,
       },
       {
         headers: {
@@ -91,18 +90,56 @@ describe('Block user functionality tests', () => {
     );
   });
 
+  test('Organization Blocks User after being blocked already', async () => {
+    const blockUserResponse = await axios.post(
+      URL,
+      {
+        query: `
+          mutation{
+            blockUser(organizationId: "${createdOrganizationId}", userId: "${newUserId}"){
+              _id
+            }
+          }`,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+
+    const { data } = blockUserResponse;
+
+    expect(data.errors[0]).toEqual(
+      expect.objectContaining({
+        message: 'User is not authorized for performing this operation',
+        status: 422,
+      })
+    );
+
+    expect(data.errors[0].data[0]).toEqual(
+      expect.objectContaining({
+        message: 'User is not authorized for performing this operation',
+        code: 'user.notAuthorized',
+        param: 'userAuthorization',
+        metadata: {},
+      })
+    );
+
+    expect(data.data).toEqual(null);
+  });
+
   // TEST: ORGANIZATION UNBLOCKS USER
   test('Organization unblocks user', async () => {
     const unblockUserResponse = await axios.post(
       URL,
       {
         query: `
-                      mutation{
-                        unblockUser(organizationId: "${createdOrganizationId}", userId: "${newUserId}"){
-                          _id
-                        }
-                      }
-                      `,
+          mutation{
+            unblockUser(organizationId: "${createdOrganizationId}", userId: "${newUserId}"){
+              _id
+            }
+          }`,
       },
       {
         headers: {
@@ -118,5 +155,44 @@ describe('Block user functionality tests', () => {
         _id: expect.any(String),
       })
     );
+  });
+
+  test('Organization unblocks user after being unblocked already', async () => {
+    const unblockUserResponse = await axios.post(
+      URL,
+      {
+        query: `
+          mutation{
+            unblockUser(organizationId: "${createdOrganizationId}", userId: "${newUserId}"){
+              _id
+            }
+          }`,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+
+    const { data } = unblockUserResponse;
+
+    expect(data.errors[0]).toEqual(
+      expect.objectContaining({
+        message: 'User is not authorized for performing this operation',
+        status: 422,
+      })
+    );
+
+    expect(data.errors[0].data[0]).toEqual(
+      expect.objectContaining({
+        message: 'User is not authorized for performing this operation',
+        code: 'user.notAuthorized',
+        param: 'userAuthorization',
+        metadata: {},
+      })
+    );
+
+    expect(data.data).toEqual(null);
   });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Issue Number:**

Fixes #439 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

![image](https://user-images.githubusercontent.com/57038543/150844328-663b5e3b-7042-4efe-92f0-e59a383659b2.png)

**If relevant, did you update the documentation?**

N/A

**Summary**

- `blockUser` mutation works correctly.
- `unblockUser` mutation works correctly.
- Tests run correctly.
- To resolve #439 
**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->
