### PR TITLE
Upgrade nanoid to 3.1.31

### DIFF
--- a/lib/helper_lib/request-tracing/index.js
+++ b/lib/helper_lib/request-tracing/index.js
@@ -1,6 +1,6 @@
 const cls = require('cls-hooked');
 const clsBluebird = require('cls-bluebird');
-const generate = require('nanoid/generate');
+const { customAlphabet } = require('nanoid');
 
 const alphabet = '0123456789abcdefghijklmnopqrstuvwxyz';
 
@@ -10,7 +10,8 @@ clsBluebird(requestTracingNamespace);
 const tracingIdHeaderName = 'X-Tracing-Id';
 const tracingIdContextKeyName = 'tracingId';
 
-const _newTraceId = () => generate(alphabet, 10); // 10 character unique request ID
+const nanoid = customAlphabet(alphabet, 10);
+const _newTraceId = () => nanoid(); // 10 character unique request ID
 
 const setTracingId = (tracingId) => {
   return requestTracingNamespace.set(tracingIdContextKeyName, tracingId);

--- a/lib/helper_lib/request-tracing/package-lock.json
+++ b/lib/helper_lib/request-tracing/package-lock.json
@@ -1,0 +1,158 @@
+{
+    "name": "request-tracing",
+    "version": "1.0.0",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "request-tracing",
+            "version": "1.0.0",
+            "license": "GNU General Public License v3.0",
+            "dependencies": {
+                "cls-bluebird": "^2.1.0",
+                "cls-hooked": "^4.2.2",
+                "nanoid": "^3.1.31"
+            }
+        },
+        "node_modules/async-hook-jl": {
+            "version": "1.7.6",
+            "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+            "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+            "dependencies": {
+                "stack-chain": "^1.3.7"
+            },
+            "engines": {
+                "node": "^4.7 || >=6.9 || >=7.3"
+            }
+        },
+        "node_modules/cls-bluebird": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.1.0.tgz",
+            "integrity": "sha1-N+8eCAqP+1XC9BZPU28ZGeeWiu4=",
+            "dependencies": {
+                "is-bluebird": "^1.0.2",
+                "shimmer": "^1.1.0"
+            }
+        },
+        "node_modules/cls-hooked": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
+            "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
+            "dependencies": {
+                "async-hook-jl": "^1.7.6",
+                "emitter-listener": "^1.0.1",
+                "semver": "^5.4.1"
+            },
+            "engines": {
+                "node": "^4.7 || >=6.9 || >=7.3 || >=8.2.1"
+            }
+        },
+        "node_modules/emitter-listener": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+            "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+            "dependencies": {
+                "shimmer": "^1.2.0"
+            }
+        },
+        "node_modules/is-bluebird": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
+            "integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/nanoid": {
+            "version": "3.1.31",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.31.tgz",
+            "integrity": "sha512-ZivnJm0o9bb13p2Ot5CpgC2rQdzB9Uxm/mFZweqm5eMViqOJe3PV6LU2E30SiLgheesmcPrjquqraoolONSA0A==",
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
+        },
+        "node_modules/semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/shimmer": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+            "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+        },
+        "node_modules/stack-chain": {
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+            "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
+        }
+    },
+    "dependencies": {
+        "async-hook-jl": {
+            "version": "1.7.6",
+            "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+            "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+            "requires": {
+                "stack-chain": "^1.3.7"
+            }
+        },
+        "cls-bluebird": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.1.0.tgz",
+            "integrity": "sha1-N+8eCAqP+1XC9BZPU28ZGeeWiu4=",
+            "requires": {
+                "is-bluebird": "^1.0.2",
+                "shimmer": "^1.1.0"
+            }
+        },
+        "cls-hooked": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
+            "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
+            "requires": {
+                "async-hook-jl": "^1.7.6",
+                "emitter-listener": "^1.0.1",
+                "semver": "^5.4.1"
+            }
+        },
+        "emitter-listener": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+            "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+            "requires": {
+                "shimmer": "^1.2.0"
+            }
+        },
+        "is-bluebird": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
+            "integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI="
+        },
+        "nanoid": {
+            "version": "3.1.31",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.31.tgz",
+            "integrity": "sha512-ZivnJm0o9bb13p2Ot5CpgC2rQdzB9Uxm/mFZweqm5eMViqOJe3PV6LU2E30SiLgheesmcPrjquqraoolONSA0A=="
+        },
+        "semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        },
+        "shimmer": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+            "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+        },
+        "stack-chain": {
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+            "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
+        }
+    }
+}

--- a/lib/helper_lib/request-tracing/package.json
+++ b/lib/helper_lib/request-tracing/package.json
@@ -14,6 +14,6 @@
     "dependencies": {
         "cls-bluebird": "^2.1.0",
         "cls-hooked": "^4.2.2",
-        "nanoid": "^2.1.0"
+        "nanoid": "^3.1.31"
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Fixes a bug by upgrading `nanoid` to `3.1.31`. Updates `lib/helper_lib/request-tracing/index.js` file to use the upgraded version of  `nanoid`.

**Issue Number:**

Fixes #477 

**Did you add tests for your changes?**

No

**Snapshots/Videos:**

Not required

**If relevant, did you update the documentation?**

Not required

**Does this PR introduce a breaking change?**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes
