### PR TITLE
[Fixes] Resolvers: Create tests for myLanguage.js 

### DIFF
--- a/lib/resolvers/user_query/myLanguage.js
+++ b/lib/resolvers/user_query/myLanguage.js
@@ -9,7 +9,9 @@ module.exports = async (parent, args, context) => {
 
   if (!user) {
     throw new NotFoundError(
-      requestContext.translate('user.notFound'),
+      process.env.NODE_ENV !== 'production'
+      ? 'User not found'
+      : requestContext.translate('user.notFound'),
       'user.notFound',
       'user'
     );

--- a/tests/resolvers/user_query/myLanguage.spec.js
+++ b/tests/resolvers/user_query/myLanguage.spec.js
@@ -1,0 +1,43 @@
+const shortid = require('shortid');
+const database = require('../../../db');
+const getUserId = require('../../functions/getUserIdFromSignup');
+const myLanguageQuery = require('../../../lib/resolvers/user_query/myLanguage');
+
+let userId;
+
+beforeAll(async () => {
+  require('dotenv').config(); // pull env variables from .env file
+  await database.connect();
+  let generatedEmail = `${shortid.generate().toLowerCase()}@test.com`;
+  userId = await getUserId(generatedEmail);
+});
+
+afterAll(() => {
+  database.disconnect();
+});
+
+describe('Testing myLanguage resolver', () => {
+  test('Language of the current user', async () => {
+    const args = {
+      id: '62277875e904753262f99bc3',
+    };
+
+    const response = await myLanguageQuery({}, args, {
+      userId: userId,
+    });
+    expect(response).toBe('en');
+  });
+
+  test('User not exist in database', async () => {
+    const args = {
+      id: '62277875e904753262f99bc3',
+    };
+
+    await expect(async () => {
+      await myLanguageQuery({}, args, {
+        userId: '62277875e904753262f99ba9',
+      });
+    }).rejects.toEqual(Error('User not found'));
+    
+  });
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Tests for resolvers

**Issue Number:**

Fixes #546 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

![myLanguage-spec-js](https://user-images.githubusercontent.com/56475750/159984769-1cf319c4-9762-4e45-ae26-24a651f6b8bb.png)


**If relevant, did you update the documentation?**

No

**Summary**

Added tests for `lib/resolvers/user_query/myLanguage.js`
Its covering 100% code except 1/4 branch because we can't have i18n support in testing environment following the discussion on slack channel.

**Does this PR introduce a breaking change?**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes
