### PR TITLE
[Fixes] Resolvers: Create tests for userLanguage.js

### DIFF
--- a/lib/resolvers/user_query/userLanguage.js
+++ b/lib/resolvers/user_query/userLanguage.js
@@ -9,7 +9,9 @@ module.exports = async (parent, args) => {
 
   if (!user) {
     throw new NotFoundError(
-      requestContext.translate('user.notFound'),
+      process.env.NODE_ENV !== 'production'
+      ? 'User not found'
+      : requestContext.translate('user.notFound'),
       'user.notFound',
       'user'
     );

--- a/tests/resolvers/user_query/userLanguage.spec.js
+++ b/tests/resolvers/user_query/userLanguage.spec.js
@@ -1,0 +1,39 @@
+const shortid = require('shortid');
+const database = require('../../../db');
+const getUserId = require('../../functions/getUserIdFromSignup');
+const userLanguageQuery = require('../../../lib/resolvers/user_query/userLanguage');
+
+let userId;
+
+beforeAll(async () => {
+  require('dotenv').config(); // pull env variables from .env file
+  await database.connect();
+  let generatedEmail = `${shortid.generate().toLowerCase()}@test.com`;
+  userId = await getUserId(generatedEmail);
+});
+
+afterAll(() => {
+  database.disconnect();
+});
+
+describe('Testing userLanguage resolver', () => {
+  test('Language of existing user', async () => {
+    const args = {
+      userId,
+    };
+
+    const response = await userLanguageQuery({}, args);
+    expect(response).toBe('en');
+  });
+
+  test('User not exist in database', async () => {
+    const args = {
+      userId: '62277875e904753262f99ba9',
+    };
+
+    await expect(async () => {
+      await userLanguageQuery({}, args);
+    }).rejects.toEqual(Error('User not found'));
+
+  });
+});


### PR DESCRIPTION

**What kind of change does this PR introduce?**

Tests for resolvers

**Issue Number:**

Fixes #548 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

![userlanguage-spec-js](https://user-images.githubusercontent.com/56475750/159993521-a35f981e-88f3-42a7-beb1-beaf7522239f.png)


**If relevant, did you update the documentation?**

No

**Summary**

Added tests for `lib/resolvers/user_query/userLanguage.js`
Its covering 100% code except 1/4 branch because we can't have i18n support in testing environment following the discussion on slack channel.

**Does this PR introduce a breaking change?**

No


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes