### PR TITLE
Fix commentsByPost

### DIFF
--- a/lib/resolvers/post_query/commentsByPost.js
+++ b/lib/resolvers/post_query/commentsByPost.js
@@ -8,7 +8,7 @@ module.exports = async (parent, args) => {
     .populate('creator', '-password')
     .populate('post')
     .populate('likedBy');
-  if (!commentFound) {
+  if (!commentFound.length) {
     throw new NotFoundError(
       requestContext.translate('comment.notFound'),
       'comment.notFound',


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Issue Number:**

Fixes  #658 

**Did you add tests for your changes?**
No

**Summary**

In the current code, commentFound returns an empty object which results in `(!commentFound)` to be false everytime, even when there was no comment found

To fix this, I've changed `(!commentFound) to (!commentFound.length)`, when there is no comment found it will result in true and will throw an error.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes 
