### PR TITLE
[Fixes] Resolvers: Create tests for creatorCheck.js

### DIFF
--- a/lib/resolvers/functions/creatorCheck.js
+++ b/lib/resolvers/functions/creatorCheck.js
@@ -5,7 +5,9 @@ const creatorCheck = (context, org) => {
   const isCreator = String(org.creator) === context.userId;
   if (!isCreator) {
     throw new UnauthorizedError(
-      requestContext.translate('user.notAuthorized'),
+      process.env.NODE_ENV !== 'production'
+      ? 'User is not authorized for performing this operation'
+      : requestContext.translate('user.notAuthorized'),
       'user.notAuthorized',
       'userAuthorization'
     );

--- a/tests/functions/creatorCheck.spec.js
+++ b/tests/functions/creatorCheck.spec.js
@@ -1,0 +1,26 @@
+const shortid = require('shortid');
+const getUserId = require('./getUserIdFromSignup');
+const creatorCheck = require('../../lib/resolvers/functions/creatorCheck');
+
+let userId, creatorId;
+
+beforeAll(async () => {
+  let generatedUserEmail = `${shortid.generate().toLowerCase()}@test.com`;
+  userId = await getUserId(generatedUserEmail);
+  let generatedCreatorEmail = `${shortid.generate().toLowerCase()}@test.com`;
+  creatorId = await getUserId(generatedCreatorEmail);
+});
+
+describe('Testing the user to be org creator', () => {
+  test('User is the organization creator', () => {
+    expect(() => {
+      creatorCheck({ userId: userId }, { creator: userId });
+    }).not.toThrow('User is not authorized for performing this operation');
+  });
+
+  test('User is not the organization creator', () => {
+    expect(() => {
+      creatorCheck({ userId: userId }, { creator: creatorId });
+    }).toThrow('User is not authorized for performing this operation');
+  });
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Tests for resolvers

**Issue Number:**

Fixes #558 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

![creatorCheck-1](https://user-images.githubusercontent.com/56475750/161684885-f71aee28-3a46-4878-9aef-03efb9b941a2.png)
![creatorCheck-2](https://user-images.githubusercontent.com/56475750/161684897-6697f7bc-91ef-41f6-87a7-509dec4b0883.png)
![creatorCheck-3](https://user-images.githubusercontent.com/56475750/161684910-82e38886-753b-4911-8272-fe0d0e57f3eb.png)


**If relevant, did you update the documentation?**

No

**Summary**

Added tests for `lib/resolvers/functions/creatorCheck.js`.
It is covering 100% code except for 1/4 branch because of the same previous issue of not having i18n support in the testing environment.

**Does this PR introduce a breaking change?**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes
