### PR TITLE
[Fixes] Resolvers: Create tests for superAdminCheck.js

### DIFF
--- a/lib/resolvers/functions/superAdminCheck.js
+++ b/lib/resolvers/functions/superAdminCheck.js
@@ -5,7 +5,9 @@ const superAdminCheck = (context, user) => {
   const isSuperAdmin = user.userType === 'SUPERADMIN';
   if (!isSuperAdmin) {
     throw new UnauthorizedError(
-      requestContext.translate('user.notAuthorized'),
+      process.env.NODE_ENV !== 'production'
+        ? 'User is not authorized for performing this operation'
+        : requestContext.translate('user.notAuthorized'),
       'user.notAuthorized',
       'userAuthorization'
     );

--- a/tests/functions/superAdminCheck.spec.js
+++ b/tests/functions/superAdminCheck.spec.js
@@ -1,0 +1,30 @@
+const shortid = require('shortid');
+const getUserId = require('./getUserIdFromSignup');
+const superAdminCheck = require('../../lib/resolvers/functions/superAdminCheck');
+
+let userId;
+
+beforeAll(async () => {
+  let generatedEmail = `${shortid.generate().toLowerCase()}@test.com`;
+  userId = await getUserId(generatedEmail);
+});
+
+describe('Testing is the user is Super Admin', () => {
+  test('should not throw an error if current user is of type : SUPERADMIN', () => {
+    expect(() => {
+      superAdminCheck({ userId: userId }, { userType: 'SUPERADMIN' });
+    }).not.toThrow('User is not authorized for performing this operation');
+  });
+
+  test('should throw an error if current user is of type : USER', () => {
+    expect(() => {
+      superAdminCheck({ userId: userId }, { userType: 'USER' });
+    }).toThrow('User is not authorized for performing this operation');
+  });
+
+  test('should throw an error if current user is of type : ADMIN', () => {
+    expect(() => {
+      superAdminCheck({ userId: userId }, { userType: 'ADMIN' });
+    }).toThrow('User is not authorized for performing this operation');
+  });
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Tests for resolvers

**Issue Number:**

Fixes #557 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

![superAdminCheck - 1](https://user-images.githubusercontent.com/56475750/161689384-874f5f46-b3d4-4033-b542-3bbb25d5e327.png)
![superAdminCheck - 2](https://user-images.githubusercontent.com/56475750/161689453-455be5bc-f9aa-48dd-bcf7-3db9e9712e26.png)
![superAdminCheck - 3](https://user-images.githubusercontent.com/56475750/161689515-7f63f9e9-330f-4816-9671-36e684155b14.png)


**If relevant, did you update the documentation?**

No

**Summary**

Added tests for `lib/resolvers/functions/superAdminCheck.js`.
It is covering 100% code except for 1/4 branch because of the same previous issue of not having i18n support in the testing environment.

**Does this PR introduce a breaking change?**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes
