### PR TITLE
Depth issue solved

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ const httpServer = http.createServer(app);
 const apolloServer = new ApolloServer({
   typeDefs,
   resolvers,
-  validationRules: [depthLimit(3)],
+  validationRules: [depthLimit(5)],
   schemaDirectives: {
     auth: AuthenticationDirective,
     role: RoleAuthorizationDirective,


### PR DESCRIPTION
Depth increased to 5.


**What kind of change does this PR introduce?**
The fronted talawa app is having a problem accessing the data so the depth limit is increased to 5 to achieve proper fetching of data.
**Issue Number:**
#704 
Fixes #<!--Add related issue number here.-->

**Summary**
This is a temporary fix and subject to change  as we cannot expose the depth of query to such an extent. This is part of series of changes needed to fix the login/signup issue which is currently happening.

**Does this PR introduce a breaking change?**
Yes
