### PR TITLE
Bump image-hash to fix file-type vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "graphql-upload": "^12.0.0",
         "helmet": "^4.6.0",
         "i18n": "^0.13.4",
-        "image-hash": "^4.0.1",
+        "image-hash": "^5.3.1",
         "jsonwebtoken": "^9.0.0",
         "jwt-decode": "^3.1.2",
         "lodash": "^4.17.21",
@@ -1372,6 +1372,11 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@canvas/image-data": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@canvas/image-data/-/image-data-1.0.0.tgz",
+      "integrity": "sha512-BxOqI5LgsIQP1odU5KMwV9yoijleOPzHL18/YvNqF9KFSGF2K/DLlYAbDQsWqd/1nbaFuSkYD/191dpMtNh4vw=="
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -1400,6 +1405,14 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@cwasm/webp": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@cwasm/webp/-/webp-0.1.5.tgz",
+      "integrity": "sha512-ceIZQkyxK+s7mmItNcWqqHdOBiJAxYxTnrnPNgUNjldB1M9j+Bp/3eVIVwC8rUFyN/zoFwuT0331pyY3ackaNA==",
+      "dependencies": {
+        "@canvas/image-data": "^1.0.0"
       }
     },
     "node_modules/@dabh/diagnostics": {
@@ -7607,17 +7620,16 @@
       }
     },
     "node_modules/file-type": {
-      "version": "14.7.1",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-14.7.1.tgz",
-      "integrity": "sha512-sXAMgFk67fQLcetXustxfKX+PZgHIUFn96Xld9uH8aXPdX3xOp0/jg9OdouVTvQrf7mrn+wAa4jN/y9fUOOiRA==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
       "dependencies": {
-        "readable-web-to-node-stream": "^2.0.0",
-        "strtok3": "^6.0.3",
-        "token-types": "^2.0.0",
-        "typedarray-to-buffer": "^3.1.5"
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
@@ -8812,13 +8824,14 @@
       }
     },
     "node_modules/image-hash": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/image-hash/-/image-hash-4.0.1.tgz",
-      "integrity": "sha512-RoNf9UH91p+SlAWT7vgIzfXn5EgAR+LgPGSkk5PRK6QW2PPLWzANh3GwCh9wICFsz7+vfaa12ug6k3tfPwgoSg==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/image-hash/-/image-hash-5.3.1.tgz",
+      "integrity": "sha512-tIOI//XqSnuzb60PBGPoulXNWWAZ2gww2z9P2VYgLpoCl3x8YwlhDVaR/1fgxTZObRshwEcaXYax4zF9MXBCKQ==",
       "dependencies": {
-        "file-type": "^14.6.2",
+        "@cwasm/webp": "^0.1.5",
+        "file-type": "^16.5.3",
         "jpeg-js": "^0.4.0",
-        "pngjs": "^3.3.3",
+        "pngjs": "^6.0.0",
         "request": "^2.81.0"
       }
     },
@@ -11311,11 +11324,11 @@
       }
     },
     "node_modules/pngjs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=12.13.0"
       }
     },
     "node_modules/postcss": {
@@ -11642,9 +11655,19 @@
       }
     },
     "node_modules/readable-web-to-node-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-2.0.0.tgz",
-      "integrity": "sha512-+oZJurc4hXpaaqsN68GoZGQAQIA3qr09Or4fqEsargABnbe5Aau8hFn6ISVleT3cpY/0n/8drn7huyyEvTbghA=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "dependencies": {
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -12881,25 +12904,20 @@
       }
     },
     "node_modules/token-types": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-2.1.1.tgz",
-      "integrity": "sha512-wnQcqlreS6VjthyHO3Y/kpK/emflxDBNhlNUPfh7wE39KnuDdOituXomIbyI79vBtF0Ninpkh72mcuRHo+RG3Q==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
       "dependencies": {
-        "@tokenizer/token": "^0.1.1",
+        "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
       },
       "engines": {
-        "node": ">=0.1.98"
+        "node": ">=10"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
       }
-    },
-    "node_modules/token-types/node_modules/@tokenizer/token": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.1.tgz",
-      "integrity": "sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w=="
     },
     "node_modules/tough-cookie": {
       "version": "2.5.0",
@@ -13119,6 +13137,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "optional": true,
       "dependencies": {
         "is-typedarray": "^1.0.0"
       }
@@ -14873,6 +14892,11 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@canvas/image-data": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@canvas/image-data/-/image-data-1.0.0.tgz",
+      "integrity": "sha512-BxOqI5LgsIQP1odU5KMwV9yoijleOPzHL18/YvNqF9KFSGF2K/DLlYAbDQsWqd/1nbaFuSkYD/191dpMtNh4vw=="
+    },
     "@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -14897,6 +14921,14 @@
             "@jridgewell/sourcemap-codec": "^1.4.10"
           }
         }
+      }
+    },
+    "@cwasm/webp": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@cwasm/webp/-/webp-0.1.5.tgz",
+      "integrity": "sha512-ceIZQkyxK+s7mmItNcWqqHdOBiJAxYxTnrnPNgUNjldB1M9j+Bp/3eVIVwC8rUFyN/zoFwuT0331pyY3ackaNA==",
+      "requires": {
+        "@canvas/image-data": "^1.0.0"
       }
     },
     "@dabh/diagnostics": {
@@ -19759,14 +19791,13 @@
       }
     },
     "file-type": {
-      "version": "14.7.1",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-14.7.1.tgz",
-      "integrity": "sha512-sXAMgFk67fQLcetXustxfKX+PZgHIUFn96Xld9uH8aXPdX3xOp0/jg9OdouVTvQrf7mrn+wAa4jN/y9fUOOiRA==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
       "requires": {
-        "readable-web-to-node-stream": "^2.0.0",
-        "strtok3": "^6.0.3",
-        "token-types": "^2.0.0",
-        "typedarray-to-buffer": "^3.1.5"
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
       }
     },
     "file-uri-to-path": {
@@ -20654,13 +20685,14 @@
       "dev": true
     },
     "image-hash": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/image-hash/-/image-hash-4.0.1.tgz",
-      "integrity": "sha512-RoNf9UH91p+SlAWT7vgIzfXn5EgAR+LgPGSkk5PRK6QW2PPLWzANh3GwCh9wICFsz7+vfaa12ug6k3tfPwgoSg==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/image-hash/-/image-hash-5.3.1.tgz",
+      "integrity": "sha512-tIOI//XqSnuzb60PBGPoulXNWWAZ2gww2z9P2VYgLpoCl3x8YwlhDVaR/1fgxTZObRshwEcaXYax4zF9MXBCKQ==",
       "requires": {
-        "file-type": "^14.6.2",
+        "@cwasm/webp": "^0.1.5",
+        "file-type": "^16.5.3",
         "jpeg-js": "^0.4.0",
-        "pngjs": "^3.3.3",
+        "pngjs": "^6.0.0",
         "request": "^2.81.0"
       }
     },
@@ -22556,9 +22588,9 @@
       }
     },
     "pngjs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="
     },
     "postcss": {
       "version": "8.4.18",
@@ -22803,9 +22835,12 @@
       }
     },
     "readable-web-to-node-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-2.0.0.tgz",
-      "integrity": "sha512-+oZJurc4hXpaaqsN68GoZGQAQIA3qr09Or4fqEsargABnbe5Aau8hFn6ISVleT3cpY/0n/8drn7huyyEvTbghA=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "requires": {
+        "readable-stream": "^3.6.0"
+      }
     },
     "readdirp": {
       "version": "3.6.0",
@@ -23751,19 +23786,12 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
     "token-types": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-2.1.1.tgz",
-      "integrity": "sha512-wnQcqlreS6VjthyHO3Y/kpK/emflxDBNhlNUPfh7wE39KnuDdOituXomIbyI79vBtF0Ninpkh72mcuRHo+RG3Q==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
       "requires": {
-        "@tokenizer/token": "^0.1.1",
+        "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
-      },
-      "dependencies": {
-        "@tokenizer/token": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.1.tgz",
-          "integrity": "sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w=="
-        }
       }
     },
     "tough-cookie": {
@@ -23928,6 +23956,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "optional": true,
       "requires": {
         "is-typedarray": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "graphql-upload": "^12.0.0",
     "helmet": "^4.6.0",
     "i18n": "^0.13.4",
-    "image-hash": "^4.0.1",
+    "image-hash": "^5.3.1",
     "jsonwebtoken": "^9.0.0",
     "jwt-decode": "^3.1.2",
     "lodash": "^4.17.21",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

**Issue Number:**

Fixes #830 

**Did you add tests for your changes?**

No

**Snapshots/Videos:**

Not needed

**If relevant, did you update the documentation?**

Not relevant

**Summary**

- `file-type` package was vulnerable to an infinite loop
- The `file-type` package was used by the `image-hash` package
- I've updated the `image-hash` package from `v4.0.1` to `v5.3.1` 
- Which has bumped up the `file-type` package to `v16.5.4` and fixed the bug

**Does this PR introduce a breaking change?**

No, it passes all the tests

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes