### PR TITLE
Adds tests for utilities/imageAlreadyInDbCheck

### DIFF
--- a/__tests__/utilities/imageAlreadyInDbCheck.spec.ts
+++ b/__tests__/utilities/imageAlreadyInDbCheck.spec.ts
@@ -1,0 +1,197 @@
+import "dotenv/config";
+import { ImageHash } from "../../src/lib/models";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { connect, disconnect } from "../../src/db";
+import { nanoid } from "nanoid";
+
+let testNewImagePath: string = `${nanoid()}-testNewImagePath`;
+let testOldImagePath: string = `${nanoid()}-testOldImagePath`;
+let testHash: string = `${nanoid()}-testHash`;
+let testDifferentHash: string = `${nanoid()}-testDifferentHash`;
+let testMessage: string = "invalid.fileType";
+
+let testErrors = [
+  {
+    message: "invalid.fileType",
+    code: "invalid.fileType",
+    param: "fileType",
+  },
+];
+
+beforeAll(async () => {
+  await connect();
+});
+
+afterAll(async () => {
+  await disconnect();
+});
+
+describe("utilities -> imageAlreadyInDbCheck", () => {
+  afterEach(async () => {
+    vi.doUnmock("image-hash");
+    vi.resetModules();
+    vi.restoreAllMocks();
+
+    await ImageHash.deleteOne({
+      hashValue: testHash,
+    });
+  });
+
+  it("creates ImageHash instance and returns fileName as undefined if existingImageHash === null", async () => {
+    vi.doMock("image-hash", () => {
+      return {
+        imageHash: (...args: any) => {
+          const callBack = args[3];
+
+          return callBack(null, testHash);
+        },
+      };
+    });
+
+    const { imageAlreadyInDbCheck } = await import(
+      "../../src/lib/utilities/imageAlreadyInDbCheck"
+    );
+
+    const fileName = await imageAlreadyInDbCheck(null, testNewImagePath);
+
+    const imageHashCreated = await ImageHash.findOne({
+      hashValue: testHash,
+    });
+
+    expect(fileName).toBeUndefined();
+    expect(imageHashCreated?.numberOfUses).toEqual(1);
+    expect(imageHashCreated?.fileName).toEqual(testNewImagePath);
+    expect(imageHashCreated?.hashValue).toEqual(testHash);
+  });
+
+  it("calls deleteDuplicatedImage and returns fileName as existingImageHash.fileName if existingImageHash !== null and imageHash(oldImagePath) === imageHash(newImagePath)", async () => {
+    vi.doMock("image-hash", () => {
+      return {
+        imageHash: (...args: any) => {
+          const callBack = args[3];
+
+          return callBack(null, testHash);
+        },
+      };
+    });
+
+    await ImageHash.create({
+      hashValue: testHash,
+      fileName: testOldImagePath,
+      numberOfUses: 1,
+    });
+
+    const deleteDuplicatedImage = await import(
+      "../../src/lib/utilities/deleteDuplicatedImage"
+    );
+
+    const mockedDeleteDuplicateImage = vi
+      .spyOn(deleteDuplicatedImage, "deleteDuplicatedImage")
+      .mockImplementation((_imagePath: any) => {});
+
+    const { imageAlreadyInDbCheck } = await import(
+      "../../src/lib/utilities/imageAlreadyInDbCheck"
+    );
+
+    const fileName = await imageAlreadyInDbCheck(
+      testOldImagePath,
+      testNewImagePath
+    );
+
+    expect(fileName).toEqual(testOldImagePath);
+    expect(mockedDeleteDuplicateImage).toBeCalledWith(testNewImagePath);
+  });
+
+  it("calls deleteDuplicatedImage and returns fileName as existingImageHash.fileName if existingImageHash !== null and imageHash(oldImagePath) !== imageHash(newImagePath)", async () => {
+    vi.doMock("image-hash", () => {
+      return {
+        imageHash: (...args: any) => {
+          let callBack = args[3];
+          let imagePath: string = args[0];
+
+          if (imagePath.indexOf("./") !== -1) {
+            imagePath = imagePath.slice(2);
+          }
+
+          if (imagePath === testNewImagePath) {
+            return callBack(null, testHash);
+          }
+
+          return callBack(null, testDifferentHash);
+        },
+      };
+    });
+
+    await ImageHash.create({
+      hashValue: testHash,
+      fileName: testOldImagePath,
+      numberOfUses: 1,
+    });
+
+    const deleteDuplicatedImage = await import(
+      "../../src/lib/utilities/deleteDuplicatedImage"
+    );
+
+    const mockedDeleteDuplicateImage = vi
+      .spyOn(deleteDuplicatedImage, "deleteDuplicatedImage")
+      .mockImplementation((_imagePath: any) => {});
+
+    const { imageAlreadyInDbCheck } = await import(
+      "../../src/lib/utilities/imageAlreadyInDbCheck"
+    );
+
+    const fileName = await imageAlreadyInDbCheck(
+      testOldImagePath,
+      testNewImagePath
+    );
+
+    const existingImageHash = await ImageHash.findOne({
+      hashValue: testHash,
+    }).lean();
+
+    expect(fileName).toEqual(testOldImagePath);
+    expect(mockedDeleteDuplicateImage).toBeCalledWith(testNewImagePath);
+    expect(existingImageHash?.numberOfUses).toEqual(2);
+  });
+
+  it("throws ValidationError if imageHash callbacks with error !== null", async () => {
+    vi.doMock("image-hash", () => {
+      return {
+        imageHash: (...args: any) => {
+          const callBack = args[3];
+
+          return callBack("testError", null);
+        },
+      };
+    });
+
+    const { requestContext } = await import("../../src/lib/libraries");
+
+    const mockedRequestTranslate = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementation((message) => {
+        return message;
+      });
+
+    const { imageAlreadyInDbCheck } = await import(
+      "../../src/lib/utilities/imageAlreadyInDbCheck"
+    );
+
+    try {
+      await imageAlreadyInDbCheck(null, testNewImagePath);
+    } catch (error: any) {
+      expect(error.message).toEqual(testMessage);
+      expect(error.errors).toEqual(testErrors);
+    }
+
+    expect(mockedRequestTranslate).toBeCalledWith("invalid.fileType");
+  });
+});


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Adds tests for `utilities/imageAlreadyInDbCheck.ts`
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #798 

**Did you add tests for your changes?**

<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->
