### PR TITLE
Increases code coverage for Mutation/removeUserImage

### DIFF
--- a/__tests__/resolvers/Mutation/removeUserImage.spec.ts
+++ b/__tests__/resolvers/Mutation/removeUserImage.spec.ts
@@ -2,12 +2,20 @@ import "dotenv/config";
 import { Document, Types } from "mongoose";
 import { Interface_User, User } from "../../../src/lib/models";
 import { connect, disconnect } from "../../../src/db";
-import { removeUserImage as removeUserImageResolver } from "../../../src/lib/resolvers/Mutation/removeUserImage";
-import { USER_NOT_FOUND } from "../../../src/constants";
+import { USER_NOT_FOUND, USER_NOT_FOUND_MESSAGE } from "../../../src/constants";
 import { nanoid } from "nanoid";
-import { beforeAll, afterAll, describe, it, expect } from "vitest";
+import {
+  beforeAll,
+  afterAll,
+  describe,
+  it,
+  expect,
+  afterEach,
+  vi,
+} from "vitest";
 
 let testUser: Interface_User & Document<any, any, Interface_User>;
+let testImage: string = "testImage";
 
 beforeAll(async () => {
   await connect();
@@ -26,11 +34,30 @@ afterAll(async () => {
 });
 
 describe("resolvers -> Mutation -> removeUserImage", () => {
-  it(`throws NotFoundError if no user exists with _id === context.userId`, async () => {
+  afterEach(() => {
+    vi.doUnmock("../../../src/constants");
+    vi.resetModules();
+  });
+
+  it(`throws NotFoundError if no user exists with _id === context.userId and IN_PRODUCTION === false`, async () => {
     try {
       const context = {
         userId: Types.ObjectId().toString(),
       };
+
+      vi.doMock("../../../src/constants", async () => {
+        const actualConstants: object = await vi.importActual(
+          "../../../src/constants"
+        );
+        return {
+          ...actualConstants,
+          IN_PRODUCTION: false,
+        };
+      });
+
+      const { removeUserImage: removeUserImageResolver } = await import(
+        "../../../src/lib/resolvers/Mutation/removeUserImage"
+      );
 
       await removeUserImageResolver?.({}, {}, context);
     } catch (error: any) {
@@ -38,12 +65,58 @@ describe("resolvers -> Mutation -> removeUserImage", () => {
     }
   });
 
+  it(`throws NotFoundError if no user exists with _id === context.userId and IN_PRODUCTION === true`, async () => {
+    const { requestContext } = await import("../../../src/lib/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementationOnce((message) => `Translated ${message}`);
+
+    try {
+      const context = {
+        userId: Types.ObjectId().toString(),
+      };
+
+      vi.doMock("../../../src/constants", async () => {
+        const actualConstants: object = await vi.importActual(
+          "../../../src/constants"
+        );
+        return {
+          ...actualConstants,
+          IN_PRODUCTION: true,
+        };
+      });
+
+      const { removeUserImage: removeUserImageResolver } = await import(
+        "../../../src/lib/resolvers/Mutation/removeUserImage"
+      );
+
+      await removeUserImageResolver?.({}, {}, context);
+    } catch (error: any) {
+      expect(spy).toBeCalledWith(USER_NOT_FOUND_MESSAGE);
+      expect(error.message).toEqual(`Translated ${USER_NOT_FOUND_MESSAGE}`);
+    }
+  });
+
   it(`throws NotFoundError if no user.image exists for currentUser
-  with _id === context.userId`, async () => {
+  with _id === context.userId and IN_PRODUCTION === false`, async () => {
     try {
       const context = {
         userId: testUser.id,
       };
+
+      vi.doMock("../../../src/constants", async () => {
+        const actualConstants: object = await vi.importActual(
+          "../../../src/constants"
+        );
+        return {
+          ...actualConstants,
+          IN_PRODUCTION: false,
+        };
+      });
+
+      const { removeUserImage: removeUserImageResolver } = await import(
+        "../../../src/lib/resolvers/Mutation/removeUserImage"
+      );
 
       await removeUserImageResolver?.({}, {}, context);
     } catch (error: any) {
@@ -51,35 +124,80 @@ describe("resolvers -> Mutation -> removeUserImage", () => {
     }
   });
 
-  // it(`sets image field to null for organization with _id === args.organizationId
-  // and returns the updated organization`, async () => {
-  //   await User.updateOne(
-  //     {
-  //       _id: testUser._id,
-  //     },
-  //     {
-  //       $set: {
-  //         image: 'image',
-  //       },
-  //     }
-  //   );
+  it(`throws NotFoundError if no user.image exists for currentUser
+  with _id === context.userId and IN_PRODUCTION === true`, async () => {
+    const { requestContext } = await import("../../../src/lib/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementationOnce((message) => `Translated ${message}`);
 
-  //   const context = {
-  //     userId: testUser._id,
-  //   };
+    try {
+      const context = {
+        userId: testUser.id,
+      };
 
-  //   const removeUserImagePayload = await removeUserImageResolver?.(
-  //     {},
-  //     {},
-  //     context
-  //   );
+      vi.doMock("../../../src/constants", async () => {
+        const actualConstants: object = await vi.importActual(
+          "../../../src/constants"
+        );
+        return {
+          ...actualConstants,
+          IN_PRODUCTION: true,
+        };
+      });
 
-  //   const updatedTestUser = await User.findOne({
-  //     _id: testUser._id,
-  //   }).lean();
+      const { removeUserImage: removeUserImageResolver } = await import(
+        "../../../src/lib/resolvers/Mutation/removeUserImage"
+      );
 
-  //   expect(removeUserImagePayload).toEqual(updatedTestUser);
+      await removeUserImageResolver?.({}, {}, context);
+    } catch (error: any) {
+      expect(spy).toBeCalledWith("user.profileImage.notFound");
+      expect(error.message).toEqual(`Translated user.profileImage.notFound`);
+    }
+  });
 
-  //   expect(removeUserImagePayload?.image).toEqual(null);
-  // });
+  it(`sets image field to null for organization with _id === args.organizationId
+  and returns the updated user`, async () => {
+    const utilities = await import("../../../src/lib/utilities");
+
+    const deleteImageSpy = vi
+      .spyOn(utilities, "deleteImage")
+      .mockImplementation((_imageToBeDeleted: string) => {
+        return Promise.resolve();
+      });
+
+    await User.updateOne(
+      {
+        _id: testUser._id,
+      },
+      {
+        $set: {
+          image: testImage,
+        },
+      }
+    );
+
+    const context = {
+      userId: testUser._id,
+    };
+
+    const { removeUserImage: removeUserImageResolver } = await import(
+      "../../../src/lib/resolvers/Mutation/removeUserImage"
+    );
+
+    const removeUserImagePayload = await removeUserImageResolver?.(
+      {},
+      {},
+      context
+    );
+
+    const updatedTestUser = await User.findOne({
+      _id: testUser._id,
+    }).lean();
+
+    expect(removeUserImagePayload).toEqual(updatedTestUser);
+    expect(deleteImageSpy).toBeCalledWith(testImage);
+    expect(removeUserImagePayload?.image).toEqual(null);
+  });
 });


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Increases code coverage for `resolvers/Mutation/removeUserImage.ts` to 100%.

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #561 

**Did you add tests for your changes?**

<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->
