### PR TITLE
Added tests for `src/lib/resolvers/Mutation/removeOrganizationImage.ts`

### DIFF
--- a/src/utilities/adminCheck.ts
+++ b/src/utilities/adminCheck.ts
@@ -13,8 +13,8 @@ export const adminCheck = (
   userId: string | Types.ObjectId,
   organization: Interface_Organization
 ) => {
-  const userIsOrganizationAdmin = organization.admins.some(
-    (admin) => admin.toString() === userId.toString()
+  const userIsOrganizationAdmin = organization.admins.some((admin) =>
+    admin.equals(userId.toString())
   );
 
   if (userIsOrganizationAdmin === false) {

--- a/tests/resolvers/Mutation/removeOrganizationImage.spec.ts
+++ b/tests/resolvers/Mutation/removeOrganizationImage.spec.ts
@@ -11,13 +11,25 @@ import { connect, disconnect } from "../../../src/db";
 import { removeOrganizationImage as removeOrganizationImageResolver } from "../../../src/resolvers/Mutation/removeOrganizationImage";
 import {
   ORGANIZATION_NOT_FOUND,
+  ORGANIZATION_NOT_FOUND_MESSAGE,
   USER_NOT_AUTHORIZED,
+  USER_NOT_AUTHORIZED_MESSAGE,
   USER_NOT_FOUND,
+  USER_NOT_FOUND_MESSAGE,
 } from "../../../src/constants";
 import { nanoid } from "nanoid";
-import { beforeAll, afterAll, describe, it, expect } from "vitest";
+import {
+  beforeAll,
+  afterAll,
+  describe,
+  it,
+  expect,
+  vi,
+  afterEach,
+} from "vitest";
 
 let testUser: Interface_User & Document<any, any, Interface_User>;
+let testAdminUser: Interface_User & Document<any, any, Interface_User>;
 let testOrganization: Interface_Organization &
   Document<any, any, Interface_Organization>;
 
@@ -32,11 +44,20 @@ beforeAll(async () => {
     appLanguageCode: "en",
   });
 
+  testAdminUser = await User.create({
+    email: `email${nanoid().toLowerCase()}@gmail.com`,
+    password: "password",
+    firstName: "firstName",
+    lastName: "lastName",
+    appLanguageCode: "en",
+  });
+
   testOrganization = await Organization.create({
     name: "name",
     description: "description",
     isPublic: true,
-    creator: testUser._id,
+    admins: [testAdminUser._id],
+    creator: testAdminUser._id,
     members: [testUser._id],
     blockedUsers: [testUser._id],
   });
@@ -56,10 +77,17 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  await User.deleteMany({});
+  await Organization.deleteMany({});
   await disconnect();
 });
 
 describe("resolvers -> Mutation -> removeOrganizationImage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.doUnmock("../../../src/constants");
+    vi.resetModules();
+  });
   it(`throws NotFoundError if no user exists with _id === context.userId`, async () => {
     try {
       const args: MutationRemoveOrganizationImageArgs = {
@@ -76,6 +104,40 @@ describe("resolvers -> Mutation -> removeOrganizationImage", () => {
     }
   });
 
+  it(`throws NotFoundError if no user exists with _id === context.userId // IN_PRODUCTION =true`, async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementationOnce((message) => `Translated ${message}`);
+
+    try {
+      const args: MutationRemoveOrganizationImageArgs = {
+        organizationId: "",
+      };
+
+      const context = {
+        userId: Types.ObjectId().toString(),
+      };
+
+      vi.doMock("../../../src/constants", async () => {
+        const actualConstants: object = await vi.importActual(
+          "../../../src/constants"
+        );
+        return {
+          ...actualConstants,
+          IN_PRODUCTION: true,
+        };
+      });
+      const { removeOrganizationImage: removeOrganizationImageResolver } =
+        await import("../../../src/resolvers/Mutation/removeOrganizationImage");
+
+      await removeOrganizationImageResolver?.({}, args, context);
+    } catch (error: any) {
+      expect(spy).toHaveBeenLastCalledWith(USER_NOT_FOUND_MESSAGE);
+      expect(error.message).toEqual(`Translated ${USER_NOT_FOUND_MESSAGE}`);
+    }
+  });
+
   it(`throws NotFoundError if no organization exists with _id === args.organizationId`, async () => {
     try {
       const args: MutationRemoveOrganizationImageArgs = {
@@ -89,6 +151,40 @@ describe("resolvers -> Mutation -> removeOrganizationImage", () => {
       await removeOrganizationImageResolver?.({}, args, context);
     } catch (error: any) {
       expect(error.message).toEqual(ORGANIZATION_NOT_FOUND);
+    }
+  });
+  it(`throws NotFoundError if no organization exists with _id === args.organizationId //IN_PRODUCTION = true`, async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementationOnce((message) => `Translated ${message}`);
+
+    try {
+      const args: MutationRemoveOrganizationImageArgs = {
+        organizationId: Types.ObjectId().toString(),
+      };
+
+      const context = {
+        userId: testUser.id,
+      };
+      vi.doMock("../../../src/constants", async () => {
+        const actualConstants: object = await vi.importActual(
+          "../../../src/constants"
+        );
+        return {
+          ...actualConstants,
+          IN_PRODUCTION: true,
+        };
+      });
+      const { removeOrganizationImage: removeOrganizationImageResolver } =
+        await import("../../../src/resolvers/Mutation/removeOrganizationImage");
+
+      await removeOrganizationImageResolver?.({}, args, context);
+    } catch (error: any) {
+      expect(spy).toHaveBeenLastCalledWith(ORGANIZATION_NOT_FOUND_MESSAGE);
+      expect(error.message).toEqual(
+        `Translated ${ORGANIZATION_NOT_FOUND_MESSAGE}`
+      );
     }
   });
 
@@ -108,21 +204,14 @@ describe("resolvers -> Mutation -> removeOrganizationImage", () => {
       expect(error.message).toEqual(USER_NOT_AUTHORIZED);
     }
   });
+  it(`throws UnauthorizedError if current user with _id === context.userId
+  is not an admin of organization with _id === args.organizationId //IN_PRODUCTION = true`, async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementationOnce((message) => `Translated ${message}`);
 
-  it(`throws NotFoundError if no organization.image exists for organization
-  with _id === args.organizationId`, async () => {
     try {
-      await Organization.updateOne(
-        {
-          _id: testOrganization._id,
-        },
-        {
-          $push: {
-            admins: testUser._id,
-          },
-        }
-      );
-
       const args: MutationRemoveOrganizationImageArgs = {
         organizationId: testOrganization.id,
       };
@@ -131,42 +220,123 @@ describe("resolvers -> Mutation -> removeOrganizationImage", () => {
         userId: testUser.id,
       };
 
+      vi.doMock("../../../src/constants", async () => {
+        const actualConstants: object = await vi.importActual(
+          "../../../src/constants"
+        );
+        return {
+          ...actualConstants,
+          IN_PRODUCTION: true,
+        };
+      });
+      const { removeOrganizationImage: removeOrganizationImageResolver } =
+        await import("../../../src/resolvers/Mutation/removeOrganizationImage");
+
+      await removeOrganizationImageResolver?.({}, args, context);
+    } catch (error: any) {
+      expect(spy).toHaveBeenLastCalledWith(USER_NOT_AUTHORIZED_MESSAGE);
+      expect(error.message).toEqual(
+        `Translated ${USER_NOT_AUTHORIZED_MESSAGE}`
+      );
+    }
+  });
+
+  it(`throws NotFoundError if no organization.image exists for organization
+  with _id === args.organizationId`, async () => {
+    try {
+      const args: MutationRemoveOrganizationImageArgs = {
+        organizationId: testOrganization.id,
+      };
+
+      const context = {
+        userId: testAdminUser.id,
+      };
+
       await removeOrganizationImageResolver?.({}, args, context);
     } catch (error: any) {
       expect(error.message).toEqual("Organization image not found");
     }
   });
 
-  // it(`sets image field to null for organization with _id === args.organizationId
-  // and returns the updated organization`, async () => {
-  //   await Organization.updateOne(
-  //     {
-  //       _id: testOrganization._id,
-  //     },
-  //     {
-  //       $set: {
-  //         image: 'image',
-  //       },
-  //     }
-  //   );
+  it(`throws NotFoundError if no organization.image exists for organization
+  with _id === args.organizationId // IN_PRODUCTION = true`, async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementationOnce((message) => `Translated ${message}`);
 
-  //   const args: MutationRemoveOrganizationImageArgs = {
-  //     organizationId: testOrganization.id,
-  //   };
+    try {
+      const args: MutationRemoveOrganizationImageArgs = {
+        organizationId: testOrganization.id,
+      };
 
-  //   const context = {
-  //     userId: testUser._id,
-  //   };
+      const context = {
+        userId: testAdminUser.id,
+      };
+      vi.doMock("../../../src/constants", async () => {
+        const actualConstants: object = await vi.importActual(
+          "../../../src/constants"
+        );
+        return {
+          ...actualConstants,
+          IN_PRODUCTION: true,
+        };
+      });
 
-  //   const removeOrganizationImagePayload =
-  //     await removeOrganizationImageResolver?.({}, args, context);
+      const { removeOrganizationImage: removeOrganizationImageResolver } =
+        await import("../../../src/resolvers/Mutation/removeOrganizationImage");
 
-  //   const updatedTestOrganization = await Organization.findOne({
-  //     _id: testOrganization._id,
-  //   }).lean();
+      await removeOrganizationImageResolver?.({}, args, context);
+    } catch (error: any) {
+      expect(spy).toHaveBeenLastCalledWith("organization.profile.notFound");
+      expect(error.message).toEqual(
+        `Translated ${"organization.profile.notFound"}`
+      );
+    }
+  });
 
-  //   expect(removeOrganizationImagePayload).toEqual(updatedTestOrganization);
+  it("should delete the Organizatin Image and return the updated Organization object", async () => {
+    const utilities = await import("../../../src/utilities");
 
-  //   expect(removeOrganizationImagePayload?.image).toEqual(null);
-  // });
+    const deleteImageSpy = vi
+      .spyOn(utilities, "deleteImage")
+      .mockImplementation((_imageToBeDeleted: string) => {
+        return Promise.resolve();
+      });
+
+    const args: MutationRemoveOrganizationImageArgs = {
+      organizationId: testOrganization._id,
+    };
+
+    const testImage: string = "testImage";
+
+    await Organization.updateOne(
+      {
+        _id: testOrganization._id,
+      },
+      {
+        $set: {
+          image: testImage,
+        },
+      }
+    );
+
+    const context = {
+      userId: testAdminUser._id,
+    };
+
+    const { removeOrganizationImage: removeOrganizationImageResolver } =
+      await import("../../../src/resolvers/Mutation/removeOrganizationImage");
+
+    const removeOrganizationImagePayload =
+      await removeOrganizationImageResolver?.({}, args, context);
+
+    const updatedTestOrg = await Organization.findOne({
+      _id: testOrganization._id,
+    }).lean();
+
+    expect(removeOrganizationImagePayload).toEqual(updatedTestOrg);
+    expect(deleteImageSpy).toBeCalledWith(testImage);
+    expect(removeOrganizationImagePayload?.image).toEqual(null);
+  });
 });

--- a/tests/resolvers/Mutation/updateUserProfile.spec.ts
+++ b/tests/resolvers/Mutation/updateUserProfile.spec.ts
@@ -87,9 +87,7 @@ describe("resolvers -> Mutation -> updateUserProfile", () => {
       await updateUserProfileResolverUserError?.({}, args, context);
     } catch (error: any) {
       expect(spy).toHaveBeenLastCalledWith(USER_NOT_FOUND_MESSAGE);
-      // expect(error.message).toEqual(
-      //   `Translated ${USER_NOT_FOUND_MESSAGE}`
-      // );
+      expect(error.message).toEqual(`Translated ${USER_NOT_FOUND_MESSAGE}`);
     }
   });
 


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #900 

**Did you add tests for your changes?**
YES
<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
I also changed `adminCheck` because it had a buggy equality check for `mongoose`'s `objectId`
Added one more expect statement for `updateUserProfile` for which I wrote tests previosly.
<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->
Yes