### PR TITLE
Tests for `src/lib/libraries/logger.ts`

### DIFF
--- a/src/libraries/logger.ts
+++ b/src/libraries/logger.ts
@@ -36,11 +36,6 @@ const formats = {
 };
 
 const logger = createLogger({
-  level: appConfig.log_level,
-  format:
-    appConfig.colorize_logs === "true"
-      ? formats.colorized
-      : formats.non_colorized,
   transports: [
     new transports.Console({
       level: appConfig.log_level,

--- a/src/libraries/logger.ts
+++ b/src/libraries/logger.ts
@@ -35,7 +35,7 @@ const formats = {
   ),
 };
 
-export const logger = createLogger({
+const logger = createLogger({
   transports: [
     new transports.Console({
       level: appConfig.log_level,
@@ -47,10 +47,12 @@ export const logger = createLogger({
   ],
 });
 
-// Invalid code. Currently ignored by typescript. Needs fix.
+// The code block shifted before exporting logger
 logger.stream = {
   // @ts-ignore
   write: (message) => {
     logger.info((message || "").trim());
   },
 };
+
+export {logger};

--- a/src/libraries/logger.ts
+++ b/src/libraries/logger.ts
@@ -5,44 +5,36 @@ import { appConfig } from "../config";
 
 const { combine, printf, splat, colorize, simple, timestamp } = format;
 
-const loggerFormat = printf((info) => {
-  let formatObject = `${info.level || "-"} ${info.timestamp || "-"} ${
-    getTracingId() || "-"
-  } ${info.message} ${
-    JSON.stringify(_.omit(info, ["level", "message", "stack", "timestamp"])) ||
-    "-"
-  }`;
-
-  if (info.stack) {
-    formatObject += `\n${info.stack}`;
-  }
-  return formatObject;
-});
-
 const formats = {
   colorized: combine(
     colorize(),
     splat(),
     simple(),
     timestamp({ format: "YYYY-MM-DD HH:mm:ss" }),
-    loggerFormat
+    printf(
+      (info) =>`${info.level || "-"} ${info.timestamp || "-"} ${getTracingId() || "-"} ${info.message} ${JSON.stringify(_.omit(info, ["level", "message", "stack", "timestamp"])) || "-"} ${info.stack || ""}`
+    )
   ),
   non_colorized: combine(
     splat(),
     simple(),
     timestamp({ format: "YYYY-MM-DD HH:mm:ss" }),
-    loggerFormat
+    printf(
+      (info) =>`${info.level || "-"} ${info.timestamp || "-"} ${getTracingId() || "-"} ${info.message} ${JSON.stringify(_.omit(info, ["level", "message", "stack", "timestamp"])) || "-"} ${info.stack || ""}`
+    )
   ),
 };
+
+const loggerFormat =
+  appConfig.colorize_logs === "true"
+    ? formats.colorized
+    : formats.non_colorized;
 
 const logger = createLogger({
   transports: [
     new transports.Console({
       level: appConfig.log_level,
-      format:
-        appConfig.colorize_logs === "true"
-          ? formats.colorized
-          : formats.non_colorized,
+      format: loggerFormat,
     }),
   ],
 });

--- a/src/libraries/logger.ts
+++ b/src/libraries/logger.ts
@@ -25,16 +25,14 @@ const formats = {
   ),
 };
 
-const loggerFormat =
-  appConfig.colorize_logs === "true"
-    ? formats.colorized
-    : formats.non_colorized;
-
 const logger = createLogger({
   transports: [
     new transports.Console({
       level: appConfig.log_level,
-      format: loggerFormat,
+      format:
+        appConfig.colorize_logs === "true"
+          ? formats.colorized
+          : formats.non_colorized,
     }),
   ],
 });

--- a/src/libraries/logger.ts
+++ b/src/libraries/logger.ts
@@ -55,4 +55,4 @@ logger.stream = {
   },
 };
 
-export {logger};
+export { logger };

--- a/src/libraries/logger.ts
+++ b/src/libraries/logger.ts
@@ -36,6 +36,11 @@ const formats = {
 };
 
 const logger = createLogger({
+  level: appConfig.log_level,
+  format:
+    appConfig.colorize_logs === "true"
+      ? formats.colorized
+      : formats.non_colorized,
   transports: [
     new transports.Console({
       level: appConfig.log_level,
@@ -48,11 +53,11 @@ const logger = createLogger({
 });
 
 // The code block shifted before exporting logger
-logger.stream = {
+const stream = {
   // @ts-ignore
   write: (message) => {
     logger.info((message || "").trim());
   },
 };
 
-export { logger };
+export { logger, stream };

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,7 +15,7 @@ import cors from "cors";
 import requestLogger from "morgan";
 import i18n from "i18n";
 import * as database from "./db";
-import { logger, requestContext, requestTracing } from "./libraries";
+import { logger, requestContext, requestTracing, stream } from "./libraries";
 import { appConfig } from "./config";
 import { isAuth } from "./middleware";
 import {
@@ -67,13 +67,13 @@ app.use(
 app.use(mongoSanitize());
 app.use(cors());
 
-// Invalid code. Needs fix.
+// Fix added to stream
 app.use(
   requestLogger(
     // @ts-ignore
     ':remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] :response-time ms',
     {
-      stream: logger.stream,
+      stream: stream,
     }
   )
 );

--- a/tests/libraries/logger.spec.ts
+++ b/tests/libraries/logger.spec.ts
@@ -1,10 +1,8 @@
 import "dotenv/config";
-import _ from "lodash";
-import { afterEach, describe, expect, it, vi, assert } from "vitest";
-import { getTracingId } from "../../src/libraries/requestTracing";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock('winston', () => {
-    const mFormat = {
+    const mformat = {
         colorize: vi.fn(),
         splat: vi.fn(),
         simple: vi.fn(),
@@ -12,19 +10,20 @@ vi.mock('winston', () => {
         timestamp: vi.fn(),
         printf: vi.fn(),
     };
-    const mTransports = {
+    const mtransports = {
       Console: vi.fn(),
     };
-    const mLogger = {
+    const mlogger = {
       info: vi.fn(),
       error: vi.fn()
     };
     return {
-      format: mFormat,
-      transports: mTransports,
-      createLogger: vi.fn(() => mLogger),
+      format: mformat,
+      transports: mtransports,
+      createLogger: vi.fn(() => mlogger),
     };
 });
+
 
 import { createLogger, transports, format} from "winston";
 import { logger } from "../../src/libraries";
@@ -34,24 +33,26 @@ describe('logger functions',() => {
         vi.restoreAllMocks();
     });
 
-    it('basic logger info test', () => {
-        const spyLog = vi.spyOn(logger,"info");
+    it('logger test should pass', () => {
+        const spyInfoLog = vi.spyOn(logger,"info");
+        const spyErrorLog = vi.spyOn(logger,"error");
 
         expect(logger).toBeDefined();
         logger.info("Info Test for logger");
-        expect(logger.info).toHaveBeenCalledTimes(1);
-        expect(spyLog).toBeCalledWith(
+        expect(spyInfoLog).toBeCalledWith(
             "Info Test for logger"
         );
-    });
 
-    it('winston logger error testing', () => {
-        const spyLog = vi.spyOn(logger,"error");
-        expect(logger).toBeDefined();
         logger.error("Error Test for logger");
         expect(logger.error).toHaveBeenCalledTimes(1);
-        expect(spyLog).toBeCalledWith(
+        expect(spyErrorLog).toBeCalledWith(
             "Error Test for logger"
         );
+
+        expect(createLogger).toBeCalledTimes(1);
+        expect(format.combine).toBeCalledTimes(2);
+        expect(format.timestamp).toBeCalledWith({ format: 'YYYY-MM-DD HH:mm:ss' });
+        expect(transports.Console).toBeCalledTimes(1);
+        expect(logger.info).toHaveBeenCalledTimes(1);
     });
 })

--- a/tests/libraries/logger.spec.ts
+++ b/tests/libraries/logger.spec.ts
@@ -1,5 +1,8 @@
 import "dotenv/config";
+import _ from "lodash";
 import { afterEach, describe, expect, it, vi } from "vitest";
+//import { getTracingId } from "./../../src/libraries/requestTracing";
+//import { appConfig } from "./../../src/config/appConfig";
 
 vi.mock("winston", () => {
   const mformat = {
@@ -16,6 +19,7 @@ vi.mock("winston", () => {
   const mlogger = {
     info: vi.fn(),
     error: vi.fn(),
+    stram: vi.fn(),
   };
   return {
     format: mformat,
@@ -32,10 +36,9 @@ describe("logger functions", () => {
     vi.restoreAllMocks();
   });
 
-  it("logger test should pass", () => {
+  it("basic logger test should pass", () => {
     const spyInfoLog = vi.spyOn(logger, "info");
     const spyErrorLog = vi.spyOn(logger, "error");
-
     expect(logger).toBeDefined();
     logger.info("Info Test for logger");
     expect(spyInfoLog).toBeCalledWith("Info Test for logger");
@@ -45,6 +48,7 @@ describe("logger functions", () => {
     expect(spyErrorLog).toBeCalledWith("Error Test for logger");
 
     expect(createLogger).toBeCalledTimes(1);
+    expect(format.printf).toBeCalledWith(expect.any(Function));
     expect(format.combine).toBeCalledTimes(2);
     expect(format.timestamp).toBeCalledWith({ format: "YYYY-MM-DD HH:mm:ss" });
     expect(transports.Console).toBeCalledTimes(1);

--- a/tests/libraries/logger.spec.ts
+++ b/tests/libraries/logger.spec.ts
@@ -1,58 +1,53 @@
 import "dotenv/config";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-vi.mock('winston', () => {
-    const mformat = {
-        colorize: vi.fn(),
-        splat: vi.fn(),
-        simple: vi.fn(),
-        combine: vi.fn(),
-        timestamp: vi.fn(),
-        printf: vi.fn(),
-    };
-    const mtransports = {
-      Console: vi.fn(),
-    };
-    const mlogger = {
-      info: vi.fn(),
-      error: vi.fn()
-    };
-    return {
-      format: mformat,
-      transports: mtransports,
-      createLogger: vi.fn(() => mlogger),
-    };
+vi.mock("winston", () => {
+  const mformat = {
+    colorize: vi.fn(),
+    splat: vi.fn(),
+    simple: vi.fn(),
+    combine: vi.fn(),
+    timestamp: vi.fn(),
+    printf: vi.fn(),
+  };
+  const mtransports = {
+    Console: vi.fn(),
+  };
+  const mlogger = {
+    info: vi.fn(),
+    error: vi.fn(),
+  };
+  return {
+    format: mformat,
+    transports: mtransports,
+    createLogger: vi.fn(() => mlogger),
+  };
 });
 
-
-import { createLogger, transports, format} from "winston";
+import { createLogger, transports, format } from "winston";
 import { logger } from "../../src/libraries";
 
-describe('logger functions',() => {
-    afterEach(() => {
-        vi.restoreAllMocks();
-    });
+describe("logger functions", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
-    it('logger test should pass', () => {
-        const spyInfoLog = vi.spyOn(logger,"info");
-        const spyErrorLog = vi.spyOn(logger,"error");
+  it("logger test should pass", () => {
+    const spyInfoLog = vi.spyOn(logger, "info");
+    const spyErrorLog = vi.spyOn(logger, "error");
 
-        expect(logger).toBeDefined();
-        logger.info("Info Test for logger");
-        expect(spyInfoLog).toBeCalledWith(
-            "Info Test for logger"
-        );
+    expect(logger).toBeDefined();
+    logger.info("Info Test for logger");
+    expect(spyInfoLog).toBeCalledWith("Info Test for logger");
 
-        logger.error("Error Test for logger");
-        expect(logger.error).toHaveBeenCalledTimes(1);
-        expect(spyErrorLog).toBeCalledWith(
-            "Error Test for logger"
-        );
+    logger.error("Error Test for logger");
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(spyErrorLog).toBeCalledWith("Error Test for logger");
 
-        expect(createLogger).toBeCalledTimes(1);
-        expect(format.combine).toBeCalledTimes(2);
-        expect(format.timestamp).toBeCalledWith({ format: 'YYYY-MM-DD HH:mm:ss' });
-        expect(transports.Console).toBeCalledTimes(1);
-        expect(logger.info).toHaveBeenCalledTimes(1);
-    });
-})
+    expect(createLogger).toBeCalledTimes(1);
+    expect(format.combine).toBeCalledTimes(2);
+    expect(format.timestamp).toBeCalledWith({ format: "YYYY-MM-DD HH:mm:ss" });
+    expect(transports.Console).toBeCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/libraries/logger.spec.ts
+++ b/tests/libraries/logger.spec.ts
@@ -2,7 +2,7 @@ import "dotenv/config";
 import _ from "lodash";
 import { afterEach, describe, expect, it, vi } from "vitest";
 //import { getTracingId } from "./../../src/libraries/requestTracing";
-//import { appConfig } from "./../../src/config/appConfig";
+import { appConfig } from "./../../src/config/appConfig";
 
 vi.mock("winston", () => {
   const mformat = {
@@ -63,5 +63,13 @@ describe("logger functions", () => {
     // sending message null or undefined to get the "" <- msg as logger.info
     stream.write(null);
     expect(spyInfoLog).toBeCalledWith("");
+  });
+
+  it("testing format colorization", () => {
+    if (appConfig.colorize_logs === "true") {
+      expect(format.colorize).toHaveBeenCalledTimes(1);
+    } else {
+      expect(format.colorize).toHaveBeenCalledTimes(0);
+    }
   });
 });

--- a/tests/libraries/logger.spec.ts
+++ b/tests/libraries/logger.spec.ts
@@ -29,7 +29,7 @@ vi.mock("winston", () => {
 });
 
 import { createLogger, transports, format } from "winston";
-import { logger } from "../../src/libraries";
+import { logger, stream } from "../../src/libraries";
 
 describe("logger functions", () => {
   afterEach(() => {
@@ -53,5 +53,15 @@ describe("logger functions", () => {
     expect(format.timestamp).toBeCalledWith({ format: "YYYY-MM-DD HH:mm:ss" });
     expect(transports.Console).toBeCalledTimes(1);
     expect(logger.info).toHaveBeenCalledTimes(1);
+  });
+
+  it("logger stream testing", () => {
+    const spyInfoLog = vi.spyOn(logger, "info");
+    stream.write("Testing for logger streaming");
+    expect(spyInfoLog).toBeCalledWith("Testing for logger streaming");
+
+    // sending message null or undefined to get the "" <- msg as logger.info
+    stream.write(null);
+    expect(spyInfoLog).toBeCalledWith("");
   });
 });

--- a/tests/libraries/logger.spec.ts
+++ b/tests/libraries/logger.spec.ts
@@ -64,7 +64,7 @@ describe("logger functions", () => {
     expect(spyInfoLog).toBeCalledWith("");
   });
 
-  it("testing format colorization", () => {
+  it("testing console colorization", () => {
     if (appConfig.colorize_logs === "true") {
       expect(format.colorize).toHaveBeenCalledTimes(1);
     } else {

--- a/tests/libraries/logger.spec.ts
+++ b/tests/libraries/logger.spec.ts
@@ -1,7 +1,6 @@
 import "dotenv/config";
 import _ from "lodash";
 import { afterEach, describe, expect, it, vi } from "vitest";
-//import { getTracingId } from "./../../src/libraries/requestTracing";
 import { appConfig } from "./../../src/config/appConfig";
 
 vi.mock("winston", () => {

--- a/tests/libraries/logger.spec.ts
+++ b/tests/libraries/logger.spec.ts
@@ -1,0 +1,57 @@
+import "dotenv/config";
+import _ from "lodash";
+import { afterEach, describe, expect, it, vi, assert } from "vitest";
+import { getTracingId } from "../../src/libraries/requestTracing";
+
+vi.mock('winston', () => {
+    const mFormat = {
+        colorize: vi.fn(),
+        splat: vi.fn(),
+        simple: vi.fn(),
+        combine: vi.fn(),
+        timestamp: vi.fn(),
+        printf: vi.fn(),
+    };
+    const mTransports = {
+      Console: vi.fn(),
+    };
+    const mLogger = {
+      info: vi.fn(),
+      error: vi.fn()
+    };
+    return {
+      format: mFormat,
+      transports: mTransports,
+      createLogger: vi.fn(() => mLogger),
+    };
+});
+
+import { createLogger, transports, format} from "winston";
+import { logger } from "../../src/libraries";
+
+describe('logger functions',() => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('basic logger info test', () => {
+        const spyLog = vi.spyOn(logger,"info");
+
+        expect(logger).toBeDefined();
+        logger.info("Info Test for logger");
+        expect(logger.info).toHaveBeenCalledTimes(1);
+        expect(spyLog).toBeCalledWith(
+            "Info Test for logger"
+        );
+    });
+
+    it('winston logger error testing', () => {
+        const spyLog = vi.spyOn(logger,"error");
+        expect(logger).toBeDefined();
+        logger.error("Error Test for logger");
+        expect(logger.error).toHaveBeenCalledTimes(1);
+        expect(spyLog).toBeCalledWith(
+            "Error Test for logger"
+        );
+    });
+})


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:** #915 

**Did you add tests for your changes?**  : Yes

<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**
![image](https://user-images.githubusercontent.com/65107474/215389739-383b812c-f2d1-4145-9372-d6d73a54cf1f.png)


**Summary**
Mock of winston logger was created and the logger was tested for when info is sent and error is sent using spyOn. Winston createLogger, format and transports were checked to see if they are defined and called in excepted way.



**Other information**
There was a code block in logger.ts file which was ignored. 
<img src="https://user-images.githubusercontent.com/65107474/215390807-22a960a3-c5de-4322-ab44-d9967f4fc470.png" width=500/>

A possible fix to that was to call `logger.stream` before exporting the logger. Changes have been made accordingly 
<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?** : Yes
