### PR TITLE
Test: Written for internalServerError.ts file

### DIFF
--- a/tests/libraries/errors/internalServerError.spec.ts
+++ b/tests/libraries/errors/internalServerError.spec.ts
@@ -1,0 +1,23 @@
+import "dotenv/config";
+import { describe, it, expect } from "vitest";
+import { errors } from "../../../src/libraries";
+
+describe("libraries -> errors -> internalServerError", () => {
+  it(`throws internalServerError if there is error from the server side `, async () => {
+    try {
+      throw new errors.InternalServerError(
+        "Internal Server Error!",
+        "internalServerError",
+        "internalServerError"
+      );
+    } catch (error: any) {
+      expect(error.errors).toEqual([
+        expect.objectContaining({
+          message: "Internal Server Error!",
+          code: "internalServerError",
+          param: "internalServerError",
+        }),
+      ]);
+    }
+  });
+});

--- a/tests/libraries/errors/unauthenticatedError.spec.ts
+++ b/tests/libraries/errors/unauthenticatedError.spec.ts
@@ -1,0 +1,23 @@
+import "dotenv/config";
+import { describe, it, expect } from "vitest";
+import { errors } from "../../../src/libraries";
+
+describe("libraries -> errors -> unauthenticatedError", () => {
+  it(`throws unauthenticatedError if user not authenticated`, async () => {
+    try {
+      throw new errors.UnauthenticatedError(
+        "UnauthenticatedError",
+        "user.notAuthenticated",
+        "userAuthentication"
+      );
+    } catch (error: any) {
+      expect(error.errors).toEqual([
+        expect.objectContaining({
+          message: "UnauthenticatedError",
+          code: "user.notAuthenticated",
+          param: "userAuthentication",
+        }),
+      ]);
+    }
+  });
+});


### PR DESCRIPTION


**What kind of change does this PR introduce?**

Test
**Issue Number:**

Fixes #917 



**Summary**

https://github.com/PalisadoesFoundation/talawa-api/issues/917

**Other information**
Created a folder structure in tests folder for writing tests for files in libraries/errors. Desired tests are written in internalServerError.spec.ts

Created
**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes