### PR TITLE
100% test coverage for `acceptAdmin.ts`

### DIFF
--- a/tests/resolvers/Mutation/acceptAdmin.spec.ts
+++ b/tests/resolvers/Mutation/acceptAdmin.spec.ts
@@ -3,9 +3,21 @@ import { Types } from "mongoose";
 import { MutationAcceptAdminArgs } from "../../../src/types/generatedGraphQLTypes";
 import { connect, disconnect } from "../../../src/db";
 import { acceptAdmin as acceptAdminResolver } from "../../../src/resolvers/Mutation/acceptAdmin";
-import { USER_NOT_AUTHORIZED, USER_NOT_FOUND } from "../../../src/constants";
-import { beforeAll, afterAll, describe, it, expect } from "vitest";
-import { testUserType, createTestUser } from "../../helpers/userAndOrg";
+import {
+  USER_NOT_AUTHORIZED,
+  USER_NOT_FOUND,
+  USER_NOT_FOUND_MESSAGE,
+} from "../../../src/constants";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { createTestUser, testUserType } from "../../helpers/userAndOrg";
 import { User } from "../../../src/models";
 
 let testUser: testUserType;
@@ -99,5 +111,74 @@ describe("resolvers -> Mutation -> acceptAdmin", () => {
       .lean();
 
     expect(updatedTestUser?.adminApproved).toEqual(true);
+  });
+});
+
+describe("resolvers -> Mutation -> acceptAdmin [IN_PRODUCTION]", () => {
+  afterEach(() => {
+    vi.doUnmock("../../../src/constants");
+    vi.resetModules();
+  });
+
+  it(`throws NotFoundError if no user exists with _id === context.userId [IN_PRODUCTION]`, async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementation((message) => `Translated ${message}`);
+
+    try {
+      const args: MutationAcceptAdminArgs = {
+        id: testUser!.id,
+      };
+
+      const context = {
+        userId: Types.ObjectId().toString(),
+      };
+
+      vi.doMock("../../../src/constants", async () => {
+        const actualConstants: object = await vi.importActual(
+          "../../../src/constants"
+        );
+        return {
+          ...actualConstants,
+          IN_PRODUCTION: true,
+        };
+      });
+
+      const { acceptAdmin: acceptAdminResolver } = await import(
+        "../../../src/resolvers/Mutation/acceptAdmin"
+      );
+      await acceptAdminResolver?.({}, args, context);
+    } catch (error: any) {
+      expect(spy).toHaveBeenCalledWith(USER_NOT_FOUND_MESSAGE);
+      expect(error.message).toEqual(`Translated ${USER_NOT_FOUND_MESSAGE}`);
+    }
+  });
+
+  it(`throws NotFoundError if no user exists with _id === args.id`, async () => {
+    try {
+      await User.updateOne(
+        {
+          _id: testUser!._id,
+        },
+        {
+          $set: {
+            userType: "SUPERADMIN",
+          },
+        }
+      );
+
+      const args: MutationAcceptAdminArgs = {
+        id: Types.ObjectId().toString(),
+      };
+
+      const context = {
+        userId: testUser!.id,
+      };
+
+      await acceptAdminResolver?.({}, args, context);
+    } catch (error: any) {
+      expect(error.message).toEqual(USER_NOT_FOUND);
+    }
   });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Increases coverage for `acceptAdmin.ts` to 100%.


**Issue Number:**
Fixes #979 

**Did you add tests for your changes?**
Yes

**Snapshots/Videos:**
![image](https://user-images.githubusercontent.com/96648934/216463213-3f5c0c31-e15b-47a6-81a9-5c734b47c40a.png)


**If relevant, did you update the documentation?**
NA

**Does this PR introduce a breaking change?**
No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes