### PR TITLE
Remove the conditional check `process.env !== "PRODUCTION"` for `requestContext.translate()`

### DIFF
--- a/src/resolvers/Query/users.ts
+++ b/src/resolvers/Query/users.ts
@@ -7,8 +7,6 @@ import {
 import { User } from "../../models";
 import { errors, requestContext } from "../../libraries";
 import {
-  IN_PRODUCTION,
-  USER_NOT_FOUND,
   USER_NOT_FOUND_CODE,
   USER_NOT_FOUND_MESSAGE,
   USER_NOT_FOUND_PARAM,
@@ -31,9 +29,7 @@ export const users: QueryResolvers["users"] = async (_parent, args) => {
 
   if (!users[0]) {
     throw new errors.NotFoundError(
-      IN_PRODUCTION !== true
-        ? USER_NOT_FOUND
-        : requestContext.translate(USER_NOT_FOUND_MESSAGE),
+      requestContext.translate(USER_NOT_FOUND_MESSAGE),
       USER_NOT_FOUND_CODE,
       USER_NOT_FOUND_PARAM
     );

--- a/tests/resolvers/Query/users.spec.ts
+++ b/tests/resolvers/Query/users.spec.ts
@@ -23,7 +23,18 @@ describe("resolvers -> Query -> users", () => {
   it("throws NotFoundError if no user exists", async () => {
     const testObjectId = new mongoose.Types.ObjectId();
 
+    vi.doMock("../../../src/constants", async () => {
+      const actualConstants: object = await vi.importActual(
+        "../../../src/constants"
+      );
+      return {
+        ...actualConstants,
+        IN_PRODUCTION: true,
+      };
+    });
+
     const { requestContext } = await import("../../../src/libraries");
+
     const spy = vi
       .spyOn(requestContext, "translate")
       .mockImplementationOnce((message) => `Translated ${message}`);

--- a/tests/resolvers/Query/users.spec.ts
+++ b/tests/resolvers/Query/users.spec.ts
@@ -5,7 +5,7 @@ import { connect, disconnect } from "../../../src/db";
 import { QueryUsersArgs } from "../../../src/types/generatedGraphQLTypes";
 import { Document } from "mongoose";
 import { nanoid } from "nanoid";
-import { USER_NOT_FOUND, USER_NOT_FOUND_MESSAGE } from "../../../src/constants";
+import { USER_NOT_FOUND_MESSAGE } from "../../../src/constants";
 import { beforeAll, afterAll, describe, it, expect, vi } from "vitest";
 import * as mongoose from "mongoose";
 
@@ -20,54 +20,10 @@ afterAll(async () => {
 });
 
 describe("resolvers -> Query -> users", () => {
-  it("throws NotFoundError if no user exists and IN_PRODUCTION === false", async () => {
+  it("throws NotFoundError if no user exists", async () => {
     const testObjectId = new mongoose.Types.ObjectId();
-
-    vi.doMock("../../../src/constants", async () => {
-      const actualConstants: object = await vi.importActual(
-        "../../../src/constants"
-      );
-      return {
-        ...actualConstants,
-        IN_PRODUCTION: false,
-      };
-    });
-
-    try {
-      const args: QueryUsersArgs = {
-        orderBy: null,
-        where: {
-          id: testObjectId as unknown as string,
-        },
-      };
-
-      const { users: mockedInProductionUserResolver } = await import(
-        "../../../src/resolvers/Query/users"
-      );
-      await mockedInProductionUserResolver?.({}, args, {});
-    } catch (error: any) {
-      expect(error.message).toEqual(USER_NOT_FOUND);
-    }
-
-    vi.doUnmock("../../../src/constants");
-    vi.resetModules();
-  });
-
-  it("throws NotFoundError if no user exists and IN_PRODUCTION === true", async () => {
-    const testObjectId = new mongoose.Types.ObjectId();
-
-    vi.doMock("../../../src/constants", async () => {
-      const actualConstants: object = await vi.importActual(
-        "../../../src/constants"
-      );
-      return {
-        ...actualConstants,
-        IN_PRODUCTION: true,
-      };
-    });
 
     const { requestContext } = await import("../../../src/libraries");
-
     const spy = vi
       .spyOn(requestContext, "translate")
       .mockImplementationOnce((message) => `Translated ${message}`);


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Removes the conditional check for environment variable being equal to `PRODUCTION` for tests in `/tests/resolvers/Query`


**Issue Number:**
Fixes #1005 

**Did you add tests for your changes?**
Yes

**Snapshots/Videos:**
NA
<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
NA
<!--Add link to Talawa-Docs.-->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
NA
<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->
