### PR TITLE
fixed express static files path in server.ts

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -78,7 +78,8 @@ app.use(
     }
   )
 );
-app.use("/images", express.static(path.join(__dirname, "./images")));
+
+app.use("/images", express.static(path.join(__dirname, "./../images")));
 app.use(requestContext.middleware());
 
 app.get("/", (req, res) =>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Issue Number:**

Fixes #1006

**Did you add tests for your changes?**

 -

**Snapshots/Videos:**

 -

**If relevant, did you update the documentation?**

 -

**Summary**

Path address provided to `express.static` function is incorrect. It currently points to `/src/images` inside `src` directory which is incorrect. It should point to `/images` in the root directory. All static files should live outside the `src` directory.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

-

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes
