### PR TITLE
Fixes #993 : Remove the conditional check process.env !== "PRODUCTION" for requestContext.translate() in code files.

### DIFF
--- a/src/utilities/adminCheck.ts
+++ b/src/utilities/adminCheck.ts
@@ -1,8 +1,6 @@
 import { Types } from "mongoose";
 import { errors, requestContext } from "../libraries";
 import {
-  IN_PRODUCTION,
-  USER_NOT_AUTHORIZED,
   USER_NOT_AUTHORIZED_MESSAGE,
   USER_NOT_AUTHORIZED_CODE,
   USER_NOT_AUTHORIZED_PARAM,
@@ -19,9 +17,7 @@ export const adminCheck = (
 
   if (userIsOrganizationAdmin === false) {
     throw new errors.UnauthorizedError(
-      IN_PRODUCTION !== true
-        ? USER_NOT_AUTHORIZED
-        : requestContext.translate(USER_NOT_AUTHORIZED_MESSAGE),
+      requestContext.translate(USER_NOT_AUTHORIZED_MESSAGE),
       USER_NOT_AUTHORIZED_CODE,
       USER_NOT_AUTHORIZED_PARAM
     );

--- a/src/utilities/creatorCheck.ts
+++ b/src/utilities/creatorCheck.ts
@@ -1,10 +1,12 @@
-import { Types } from "mongoose";
 import { errors, requestContext } from "../libraries";
 import {
+  USER_NOT_AUTHORIZED,
   USER_NOT_AUTHORIZED_MESSAGE,
   USER_NOT_AUTHORIZED_CODE,
   USER_NOT_AUTHORIZED_PARAM,
+  IN_PRODUCTION,
 } from "../constants";
+import { Types } from "mongoose";
 import { Interface_Organization } from "../models";
 
 export const creatorCheck = (
@@ -15,9 +17,12 @@ export const creatorCheck = (
 
   if (userIsCreator === false) {
     throw new errors.UnauthorizedError(
-      requestContext.translate(USER_NOT_AUTHORIZED_MESSAGE),
+      IN_PRODUCTION !== true
+        ? USER_NOT_AUTHORIZED
+        : requestContext.translate(USER_NOT_AUTHORIZED_MESSAGE),
       USER_NOT_AUTHORIZED_CODE,
       USER_NOT_AUTHORIZED_PARAM
     );
   }
 };
+

--- a/src/utilities/creatorCheck.ts
+++ b/src/utilities/creatorCheck.ts
@@ -1,12 +1,10 @@
+import { Types } from "mongoose";
 import { errors, requestContext } from "../libraries";
 import {
-  USER_NOT_AUTHORIZED,
   USER_NOT_AUTHORIZED_MESSAGE,
   USER_NOT_AUTHORIZED_CODE,
   USER_NOT_AUTHORIZED_PARAM,
-  IN_PRODUCTION,
 } from "../constants";
-import { Types } from "mongoose";
 import { Interface_Organization } from "../models";
 
 export const creatorCheck = (
@@ -17,9 +15,7 @@ export const creatorCheck = (
 
   if (userIsCreator === false) {
     throw new errors.UnauthorizedError(
-      IN_PRODUCTION !== true
-        ? USER_NOT_AUTHORIZED
-        : requestContext.translate(USER_NOT_AUTHORIZED_MESSAGE),
+      requestContext.translate(USER_NOT_AUTHORIZED_MESSAGE),
       USER_NOT_AUTHORIZED_CODE,
       USER_NOT_AUTHORIZED_PARAM
     );

--- a/tests/utilities/adminCheck.spec.ts
+++ b/tests/utilities/adminCheck.spec.ts
@@ -9,15 +9,8 @@ import {
   vi,
 } from "vitest";
 import { connect, disconnect } from "../../src/db";
-import {
-  USER_NOT_AUTHORIZED,
-  USER_NOT_AUTHORIZED_MESSAGE,
-} from "../../src/constants";
-import {
-  createTestUserAndOrganization,
-  testOrganizationType,
-  testUserType,
-} from "../helpers/userAndOrg";
+import { USER_NOT_AUTHORIZED_MESSAGE } from "../../src/constants";
+import {createTestUserAndOrganization ,testOrganizationType ,testUserType} from "../helpers/userAndOrg";
 
 let testUser: testUserType;
 let testOrganization: testOrganizationType;
@@ -37,25 +30,6 @@ describe("utilities -> adminCheck", () => {
   afterEach(() => {
     vi.doUnmock("../../src/constants");
     vi.resetModules();
-  });
-
-  it("throws error if userIsOrganizationAdmin === false and IN_PRODUCTION === false", async () => {
-    vi.doMock("../../src/constants", async () => {
-      const actualConstants: object = await vi.importActual(
-        "../../src/constants"
-      );
-      return {
-        ...actualConstants,
-        IN_PRODUCTION: false,
-      };
-    });
-
-    try {
-      const { adminCheck } = await import("../../src/utilities");
-      adminCheck(testUser!._id, testOrganization!);
-    } catch (error: any) {
-      expect(error.message).toEqual(USER_NOT_AUTHORIZED);
-    }
   });
 
   it("throws error if userIsOrganizationAdmin === false and IN_PRODUCTION === true", async () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Removes the conditional check process.env !== "PRODUCTION" for requestContext.translate() in utilities files.

**Issue Number:**
#993 : Original Issue
#1004 : Child Issue

**Did you add tests for your changes?**
Yes

**Snapshots/Videos:**
![tests#1004](https://user-images.githubusercontent.com/121368112/216816248-3c1afe3d-b52e-4cf4-8cca-40e7d38dca12.jpg)


**If relevant, did you update the documentation?**
No need to update the documentation


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes
