### PR TITLE
Separate testing database [Fixes #964]

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -13,15 +13,15 @@ This document provides instructions on how to set up and start a running instanc
   - [Setting up this repository](#setting-up-this-repository)
   - [Creating .env file](#creating-env-file)
   - [Access/refresh token secrets](#accessrefresh-token-secrets)
-    - [Setting up ACCESS\_TOKEN\_SECRET in .env file](#setting-up-access_token_secret-in-env-file)
-    - [Setting up REFRESH\_TOKEN\_SECRET in .env file](#setting-up-refresh_token_secret-in-env-file)
+    - [Setting up ACCESS_TOKEN_SECRET in .env file](#setting-up-access_token_secret-in-env-file)
+    - [Setting up REFRESH_TOKEN_SECRET in .env file](#setting-up-refresh_token_secret-in-env-file)
   - [MongoDB](#mongodb)
     - [Setting up the mongoDB database](#setting-up-the-mongodb-database)
-    - [Setting up MONGODB\_URL in .env file](#setting-up-mongodb_url-in-env-file)
+    - [Setting up MONGODB_URL in .env file](#setting-up-mongodb_url-in-env-file)
     - [Optional:- Managing mongodb database using VSCode extension](#optional--managing-mongodb-database-using-vscode-extension)
   - [Google/firebase](#googlefirebase)
-    - [Setting up RECAPTCHA\_SECRET\_KEY in .env file](#setting-up-recaptcha_secret_key-in-env-file)
-    - [Setting up MAIL\_USERNAME/MAIL\_PASSWORD in .env file](#setting-up-mail_usernamemail_password-in-env-file)
+    - [Setting up RECAPTCHA_SECRET_KEY in .env file](#setting-up-recaptcha_secret_key-in-env-file)
+    - [Setting up MAIL_USERNAME/MAIL_PASSWORD in .env file](#setting-up-mail_usernamemail_password-in-env-file)
     - [Generate Firebase Keys for the Talawa Notification Service](#generate-firebase-keys-for-the-talawa-notification-service)
     - [Apply the Firebase Keys to the Talawa Mobile App](#apply-the-firebase-keys-to-the-talawa-mobile-app)
   - [Installing required packages](#installing-required-packages)
@@ -46,8 +46,8 @@ Follow the setup guide for `git` on official [git docs](https://git-scm.com/down
 <br/>
 
 ## Setting up this repository
-First you need a local copy of talawa-api. Run the following command in the directory of choice on your local system.
 
+First you need a local copy of talawa-api. Run the following command in the directory of choice on your local system.
 
 1. Navigate to the folder where you want to setup the repository. Here, I will set it up in a folder called `talawa`.
 
@@ -70,7 +70,6 @@ $ git clone https://github.com/{{GITHUB USERNAME}}/talawa-api.git
 This will setup the repository and the code files locally for you. For more detailed instructios on contributing code, and managing the versions of this repository with Git, checkout [CONTRIBUTING.md here](./CONTRIBUTING.md)
 
 `NOTE:- All the commands we're going to execute in the following instructions will assume you are in the root directory of the project. If you fail to do so, the commands will not work.`
-
 
 ## Creating .env file
 
@@ -118,6 +117,14 @@ Run the following command and copy/paste the result to the variable named `REFRE
 ## MongoDB
 
 Talawa-api makes use of `mongoDB` for its database needs. We make use of `mongoose ODM` to interact with the mongoDB database from within the code.
+
+**NOTE :**
+It must be noted that that talawa-api actually uses **2** databases. You only have to setup
+one database and provide it's URL in the .env file. This will be `primary database` and would
+be used to store all your data.
+
+In addition, we would automatically create a new database with the name `TALAWA_TESTING_DB`,
+which would be exclusively used for storing all the test data generated during the testing process so that it does not bloat the main database with unnecessary data.
 
 <br/>
 
@@ -397,6 +404,10 @@ Talawa-api makes use of `vitest` to run tests because it is much faster than `je
 You can run the tests for talawa-api using this command:-
 
         npm run test
+
+**NOTE :** STRICTLY only use the `test` script to run the tests as this script sets the `NODE_ENV` to `testing` and thus connects to the testing database instead of the main database.
+
+Using other ways to run tests (like using `npx vitest`) may result in the bloating of the main database with testing data. Before using such methods, do ensure the `NODE_ENV` is set to `testing` to avoid the aforementioned.
 
 <br/>
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prebuild": "graphql-codegen && rimraf ./build",
     "prod": "cross-env NODE_ENV=production pm2-runtime start ./build/server.js",
     "start": "cross-env pm2-runtime start ./build/server.js --watch",
-    "test": "vitest run --no-threads --coverage",
+    "test": "NODE_ENV=testing vitest run --no-threads --coverage",
     "typecheck": "graphql-codegen && tsc --noEmit --pretty"
   },
   "repository": {

--- a/tests/directives/roleDirective.spec.ts
+++ b/tests/directives/roleDirective.spec.ts
@@ -48,7 +48,7 @@ const resolvers = {
 };
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   testUser = await User.create({
     userId: Types.ObjectId().toString(),
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/DirectChat/creator.spec.ts
+++ b/tests/resolvers/DirectChat/creator.spec.ts
@@ -11,7 +11,7 @@ import {
 let testDirectChat: testDirectChatType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const userOrgChat = await createTestDirectChat();
   testDirectChat = userOrgChat[2];
 });

--- a/tests/resolvers/DirectChat/messages.spec.ts
+++ b/tests/resolvers/DirectChat/messages.spec.ts
@@ -11,7 +11,7 @@ import {
 let testDirectChat: testDirectChatType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const userOrgChat = await createTestDirectChatMessage();
   testDirectChat = userOrgChat[2];
 });

--- a/tests/resolvers/DirectChat/organization.spec.ts
+++ b/tests/resolvers/DirectChat/organization.spec.ts
@@ -11,7 +11,7 @@ import {
 let testDirectChat: testDirectChatType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const userOrgChat = await createTestDirectChat();
   testDirectChat = userOrgChat[2];
 });

--- a/tests/resolvers/DirectChat/users.spec.ts
+++ b/tests/resolvers/DirectChat/users.spec.ts
@@ -11,7 +11,7 @@ import {
 let testDirectChat: testDirectChatType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const userOrgChat = await createTestDirectChatMessage();
   testDirectChat = userOrgChat[2];
 });

--- a/tests/resolvers/DirectChatMessage/directChatMessageBelongsTo.spec.ts
+++ b/tests/resolvers/DirectChatMessage/directChatMessageBelongsTo.spec.ts
@@ -11,7 +11,7 @@ import {
 let testDirectChatMessage: testDirectChatType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestDirectChat();
   testDirectChatMessage = temp[2];
 });

--- a/tests/resolvers/DirectChatMessage/receiver.spec.ts
+++ b/tests/resolvers/DirectChatMessage/receiver.spec.ts
@@ -11,7 +11,7 @@ import {
 let testDirectChatMessage: testDirectChatType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestDirectChat();
   testDirectChatMessage = temp[2];
 });

--- a/tests/resolvers/DirectChatMessage/sender.spec.ts
+++ b/tests/resolvers/DirectChatMessage/sender.spec.ts
@@ -10,7 +10,7 @@ import {
 
 let testDirectChatMessage: testDirectChatType;
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestDirectChat();
   testDirectChatMessage = temp[2];
 });

--- a/tests/resolvers/GroupChat/creator.spec.ts
+++ b/tests/resolvers/GroupChat/creator.spec.ts
@@ -12,7 +12,7 @@ import {
 let testGroupChat: testGroupChatMessageType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const resultArray = await createTestGroupChatMessage();
   testGroupChat = resultArray[3];
 });

--- a/tests/resolvers/GroupChat/messages.spec.ts
+++ b/tests/resolvers/GroupChat/messages.spec.ts
@@ -11,7 +11,7 @@ import {
 let testGroupChat: testGroupChatMessageType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const resultArray = await createTestGroupChatMessage();
   testGroupChat = resultArray[3];
 });

--- a/tests/resolvers/GroupChat/organization.spec.ts
+++ b/tests/resolvers/GroupChat/organization.spec.ts
@@ -11,7 +11,7 @@ import {
 let testGroupChat: testGroupChatMessageType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const resultArray = await createTestGroupChatMessage();
   testGroupChat = resultArray[3];
 });

--- a/tests/resolvers/GroupChat/users.spec.ts
+++ b/tests/resolvers/GroupChat/users.spec.ts
@@ -11,7 +11,7 @@ import {
 let testGroupChat: testGroupChatMessageType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const resultArray = await createTestGroupChatMessage();
   testGroupChat = resultArray[3];
 });

--- a/tests/resolvers/GroupChatMessage/groupChatMessageBelongsTo.spec.ts
+++ b/tests/resolvers/GroupChatMessage/groupChatMessageBelongsTo.spec.ts
@@ -11,7 +11,7 @@ import {
 let testGroupChatMessage: testGroupChatMessageType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const resultArray = await createTestGroupChatMessage();
   testGroupChatMessage = resultArray[3];
 });

--- a/tests/resolvers/GroupChatMessage/sender.spec.ts
+++ b/tests/resolvers/GroupChatMessage/sender.spec.ts
@@ -11,7 +11,7 @@ import {
 let testGroupChatMessage: testGroupChatMessageType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const resultArray = await createTestGroupChatMessage();
   testGroupChatMessage = resultArray[3];
 });

--- a/tests/resolvers/MembershipRequest/organization.spec.ts
+++ b/tests/resolvers/MembershipRequest/organization.spec.ts
@@ -15,7 +15,7 @@ let testMembershipRequest: Interface_MembershipRequest &
   Document<any, any, Interface_MembershipRequest>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/MembershipRequest/user.spec.ts
+++ b/tests/resolvers/MembershipRequest/user.spec.ts
@@ -15,7 +15,7 @@ let testMembershipRequest: Interface_MembershipRequest &
   Document<any, any, Interface_MembershipRequest>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Mutation/acceptAdmin.spec.ts
+++ b/tests/resolvers/Mutation/acceptAdmin.spec.ts
@@ -22,7 +22,7 @@ import { User } from "../../../src/models";
 let testUser: testUserType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   testUser = await createTestUser();
 });
 

--- a/tests/resolvers/Mutation/acceptMembershipRequest.spec.ts
+++ b/tests/resolvers/Mutation/acceptMembershipRequest.spec.ts
@@ -23,7 +23,7 @@ let testOrganization: testOrganizationType;
 let testMembershipRequest: testMembershipRequestType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const resultArray = await createTestMembershipRequest();
   testUser = resultArray[0];
   testOrganization = resultArray[1];

--- a/tests/resolvers/Mutation/addLanguageTranslation.spec.ts
+++ b/tests/resolvers/Mutation/addLanguageTranslation.spec.ts
@@ -33,7 +33,7 @@ const testArgs: MutationAddLanguageTranslationArgs[] = [
 ];
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 });
 
 afterAll(async () => {

--- a/tests/resolvers/Mutation/addOrganizationImage.spec.ts
+++ b/tests/resolvers/Mutation/addOrganizationImage.spec.ts
@@ -34,7 +34,7 @@ vi.mock("../../utilities", () => ({
 }));
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const resultArray = await createTestUserAndOrganization();
   testUser = resultArray[0];
   testOrganization = resultArray[1];

--- a/tests/resolvers/Mutation/addUserImage.spec.ts
+++ b/tests/resolvers/Mutation/addUserImage.spec.ts
@@ -17,7 +17,7 @@ import { testUserType, createTestUser } from "../../helpers/userAndOrg";
 let testUser: testUserType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   testUser = await createTestUser();
 });
 

--- a/tests/resolvers/Mutation/addUserToGroupChat.spec.ts
+++ b/tests/resolvers/Mutation/addUserToGroupChat.spec.ts
@@ -30,7 +30,7 @@ let testOrganization: testOrganizationType;
 let testGroupChat: testGroupChatType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const resultArray = await createTestGroupChat();
   testUser = resultArray[0];
   testOrganization = resultArray[1];

--- a/tests/resolvers/Mutation/adminRemoveEvent.spec.ts
+++ b/tests/resolvers/Mutation/adminRemoveEvent.spec.ts
@@ -19,7 +19,7 @@ let testOrganization: testOrganizationType;
 let testEvent: testEventType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const resultsArray = await createTestEvent();
 
   testUser = resultsArray[0];

--- a/tests/resolvers/Mutation/adminRemoveGroup.spec.ts
+++ b/tests/resolvers/Mutation/adminRemoveGroup.spec.ts
@@ -22,7 +22,7 @@ let testOrganization: testOrganizationType;
 let testGroupChat: testGroupChatType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const resultsArray = await createTestGroupChat();
 
   testUser = resultsArray[0];

--- a/tests/resolvers/Mutation/adminRemovePost.spec.ts
+++ b/tests/resolvers/Mutation/adminRemovePost.spec.ts
@@ -19,7 +19,7 @@ let testOrganization: testOrganizationType;
 let testPost: testPostType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const resultsArray = await createTestPost();
 
   testUser = resultsArray[0];

--- a/tests/resolvers/Mutation/blockPluginCreationBySuperadmin.spec.ts
+++ b/tests/resolvers/Mutation/blockPluginCreationBySuperadmin.spec.ts
@@ -14,7 +14,7 @@ import { testUserType, createTestUser } from "../../helpers/userAndOrg";
 let testUser: testUserType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   testUser = await createTestUser();
   const { requestContext } = await import("../../../src/libraries");
   vi.spyOn(requestContext, "translate").mockImplementation(

--- a/tests/resolvers/Mutation/blockUser.spec.ts
+++ b/tests/resolvers/Mutation/blockUser.spec.ts
@@ -22,7 +22,7 @@ let testUser: testUserType;
 let testOrganization: testOrganizationType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testUser = await createTestUser();
 

--- a/tests/resolvers/Mutation/cancelMembershipRequest.spec.ts
+++ b/tests/resolvers/Mutation/cancelMembershipRequest.spec.ts
@@ -22,7 +22,7 @@ let testOrganization: testOrganizationType;
 let testMembershipRequest: testMembershipRequestType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const resultsArray = await createTestMembershipRequestAsNew();
 
   testUser = resultsArray[0];

--- a/tests/resolvers/Mutation/createAdmin.spec.ts
+++ b/tests/resolvers/Mutation/createAdmin.spec.ts
@@ -22,7 +22,7 @@ let testUser: testUserType;
 let testOrganization: testOrganizationType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const resultsArray = await createTestUserAndOrganization(false);
 
   testUser = resultsArray[0];

--- a/tests/resolvers/Mutation/createComment.spec.ts
+++ b/tests/resolvers/Mutation/createComment.spec.ts
@@ -13,7 +13,7 @@ let testUser: testUserType;
 let testPost: testPostType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const resultsArray = await createTestPost();
   testUser = resultsArray[0];
   testPost = resultsArray[2];

--- a/tests/resolvers/Mutation/createDirectChat.spec.ts
+++ b/tests/resolvers/Mutation/createDirectChat.spec.ts
@@ -25,7 +25,7 @@ let testUser: testUserType;
 let testOrganization: testOrganizationType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const resultsArray = await createTestUserAndOrganization();
 
   testUser = resultsArray[0];

--- a/tests/resolvers/Mutation/createDonation.spec.ts
+++ b/tests/resolvers/Mutation/createDonation.spec.ts
@@ -13,7 +13,7 @@ let testUser: testUserType;
 let testOrganization: testOrganizationType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const resultsArray = await createTestUserAndOrganization();
 
   testUser = resultsArray[0];

--- a/tests/resolvers/Mutation/createEvent.spec.ts
+++ b/tests/resolvers/Mutation/createEvent.spec.ts
@@ -20,7 +20,7 @@ let testUser: testUserType;
 let testOrganization: testOrganizationType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testUser = await createTestUser();
   testOrganization = await Organization.create({

--- a/tests/resolvers/Mutation/createEventProject.spec.ts
+++ b/tests/resolvers/Mutation/createEventProject.spec.ts
@@ -28,7 +28,7 @@ let testOrganization: testOrganizationType;
 let testEvent: testEventType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testUser = await createTestUser();
   testAdminUser = await createTestUser();

--- a/tests/resolvers/Mutation/createGroupChat.spec.ts
+++ b/tests/resolvers/Mutation/createGroupChat.spec.ts
@@ -18,7 +18,7 @@ let testUser: testUserType;
 let testOrganization: testOrganizationType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const resultsArray = await createTestUserAndOrganization();
 
   testUser = resultsArray[0];

--- a/tests/resolvers/Mutation/createMessageChat.spec.ts
+++ b/tests/resolvers/Mutation/createMessageChat.spec.ts
@@ -22,7 +22,7 @@ import {
 let testUsers: (Interface_User & Document<any, any, Interface_User>)[];
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testUsers = await User.insertMany([
     {

--- a/tests/resolvers/Mutation/createOrganization.spec.ts
+++ b/tests/resolvers/Mutation/createOrganization.spec.ts
@@ -26,7 +26,7 @@ vi.mock("../../utilities", () => ({
 }));
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   testUser = await createTestUserFunc();
 });
 

--- a/tests/resolvers/Mutation/createPlugin.spec.ts
+++ b/tests/resolvers/Mutation/createPlugin.spec.ts
@@ -8,7 +8,7 @@ import { createTestUserFunc, testUserType } from "../../helpers/user";
 let testUser: testUserType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   testUser = await createTestUserFunc();
 });
 

--- a/tests/resolvers/Mutation/createPost.spec.ts
+++ b/tests/resolvers/Mutation/createPost.spec.ts
@@ -27,7 +27,7 @@ let testUser: testUserType;
 let testOrganization: testOrganizationType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestUserAndOrganization();
   testUser = temp[0];
   testOrganization = temp[1];

--- a/tests/resolvers/Mutation/createTask.spec.ts
+++ b/tests/resolvers/Mutation/createTask.spec.ts
@@ -17,7 +17,7 @@ let testUser: testUserType;
 let testEvent: testEventType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const { requestContext } = await import("../../../src/libraries");
   vi.spyOn(requestContext, "translate").mockImplementation(
     (message) => message

--- a/tests/resolvers/Mutation/deleteDonationById.spec.ts
+++ b/tests/resolvers/Mutation/deleteDonationById.spec.ts
@@ -10,7 +10,7 @@ import { createTestUserAndOrganization } from "../../helpers/userAndOrg";
 let testDonation: Interface_Donation & Document<any, any, Interface_Donation>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestUserAndOrganization();
   const testUser = temp[0];
 

--- a/tests/resolvers/Mutation/forgotPassword.spec.ts
+++ b/tests/resolvers/Mutation/forgotPassword.spec.ts
@@ -13,7 +13,7 @@ import { User } from "../../../src/models";
 let testUser: testUserType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   testUser = await createTestUserFunc();
 });
 

--- a/tests/resolvers/Mutation/joinPublicOrganization.spec.ts
+++ b/tests/resolvers/Mutation/joinPublicOrganization.spec.ts
@@ -32,7 +32,7 @@ let testUser: testUserType;
 let testOrganization: testOrganizationType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestUserAndOrganization(true, true, false);
   testUser = temp[0];
   testOrganization = temp[1];

--- a/tests/resolvers/Mutation/leaveOrganization.spec.ts
+++ b/tests/resolvers/Mutation/leaveOrganization.spec.ts
@@ -21,7 +21,7 @@ let testUser: testUserType;
 let testOrganization: testOrganizationType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestUserAndOrganization();
   testUser = temp[0];
   testOrganization = temp[1];

--- a/tests/resolvers/Mutation/likeComment.spec.ts
+++ b/tests/resolvers/Mutation/likeComment.spec.ts
@@ -13,7 +13,7 @@ let testUser: testUserType;
 let testComment: Interface_Comment & Document<any, any, Interface_Comment>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestPost();
   testUser = temp[0];
 

--- a/tests/resolvers/Mutation/likePost.spec.ts
+++ b/tests/resolvers/Mutation/likePost.spec.ts
@@ -12,7 +12,7 @@ let testUser: testUserType;
 let testPost: testPostType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestPost();
   testUser = temp[0];
   testPost = temp[2];

--- a/tests/resolvers/Mutation/login.spec.ts
+++ b/tests/resolvers/Mutation/login.spec.ts
@@ -17,7 +17,7 @@ import { createTestEventWithRegistrants } from "../../helpers/eventsWithRegistra
 let testUser: testUserType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestEventWithRegistrants();
   const hashedTestPassword = await bcrypt.hash("password", 12);
   testUser = temp[0];

--- a/tests/resolvers/Mutation/logout.spec.ts
+++ b/tests/resolvers/Mutation/logout.spec.ts
@@ -13,7 +13,7 @@ import {
 let testUser: testUserType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestUserAndOrganization();
   testUser = temp[0];
 });

--- a/tests/resolvers/Mutation/otp.spec.ts
+++ b/tests/resolvers/Mutation/otp.spec.ts
@@ -11,7 +11,7 @@ import { beforeAll, afterAll, describe, it, expect } from "vitest";
 // let testUser: Interface_User & Document<any, any, Interface_User>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   // testUser = await User.create({
   //   email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Mutation/refreshToken.spec.ts
+++ b/tests/resolvers/Mutation/refreshToken.spec.ts
@@ -20,7 +20,7 @@ let testUser: testUserType;
 let refreshToken: string;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   testUser = await createTestUserFunc();
 });
 

--- a/tests/resolvers/Mutation/registerForEvent.spec.ts
+++ b/tests/resolvers/Mutation/registerForEvent.spec.ts
@@ -18,7 +18,7 @@ let testUser: testUserType;
 let testEvent: testEventType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestEventWithRegistrants();
   testUser = temp[0];
   const testOrganization = temp[1];

--- a/tests/resolvers/Mutation/rejectAdmin.spec.ts
+++ b/tests/resolvers/Mutation/rejectAdmin.spec.ts
@@ -11,7 +11,7 @@ import { createTestUserFunc, testUserType } from "../../helpers/user";
 let testUser: testUserType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   testUser = await createTestUserFunc();
 });
 

--- a/tests/resolvers/Mutation/rejectMembershipRequest.spec.ts
+++ b/tests/resolvers/Mutation/rejectMembershipRequest.spec.ts
@@ -22,7 +22,7 @@ let testOrganization: testOrganizationType;
 let testMembershipRequest: testMembershipRequestType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestMembershipRequest();
   testUser = temp[0];
   testOrganization = temp[1];

--- a/tests/resolvers/Mutation/removeAdmin.spec.ts
+++ b/tests/resolvers/Mutation/removeAdmin.spec.ts
@@ -20,7 +20,7 @@ let testUser: testUserType;
 let testOrganization: testOrganizationType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestUserAndOrganization();
   testUser = temp[0];
   testOrganization = temp[1];

--- a/tests/resolvers/Mutation/removeComment.spec.ts
+++ b/tests/resolvers/Mutation/removeComment.spec.ts
@@ -20,7 +20,7 @@ let testComment:
   | null;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestPost();
   testUser = temp[0];
   testPost = temp[2];

--- a/tests/resolvers/Mutation/removeDirectChat.spec.ts
+++ b/tests/resolvers/Mutation/removeDirectChat.spec.ts
@@ -34,7 +34,7 @@ let testOrganization: testOrganizationType;
 let testDirectChat: testDirectChatType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestDirectChat();
   testUser = temp[0];
   testOrganization = temp[1];

--- a/tests/resolvers/Mutation/removeEvent.spec.ts
+++ b/tests/resolvers/Mutation/removeEvent.spec.ts
@@ -18,7 +18,7 @@ let testOrganization: testOrganizationType;
 let testEvent: testEventType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestEvent();
   testUser = temp[0];
   testOrganization = temp[1];

--- a/tests/resolvers/Mutation/removeEventProject.spec.ts
+++ b/tests/resolvers/Mutation/removeEventProject.spec.ts
@@ -36,7 +36,7 @@ let testEventProject: Interface_EventProject &
   Document<any, any, Interface_EventProject>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestEvent();
   testUser = temp[0];
 

--- a/tests/resolvers/Mutation/removeGroupChat.spec.ts
+++ b/tests/resolvers/Mutation/removeGroupChat.spec.ts
@@ -21,7 +21,7 @@ let testOrganization: testOrganizationType;
 let testGroupChat: testGroupChatType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestGroupChatMessage();
   testUser = temp[0];
   testOrganization = temp[1];

--- a/tests/resolvers/Mutation/removeMember.spec.ts
+++ b/tests/resolvers/Mutation/removeMember.spec.ts
@@ -18,7 +18,7 @@ let testUsers: testUserType[];
 let testOrganization: testOrganizationType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const tempUser1 = await createTestUserFunc();
   const tempUser2 = await createTestUserFunc();
   const tempUser3 = await createTestUserFunc();

--- a/tests/resolvers/Mutation/removeOrganization.spec.ts
+++ b/tests/resolvers/Mutation/removeOrganization.spec.ts
@@ -29,7 +29,7 @@ let testPost: Interface_Post & Document<any, any, Interface_Post>;
 let testComment: Interface_Comment & Document<any, any, Interface_Comment>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const tempUser1 = await createTestUserFunc();
   const tempUser2 = await createTestUserFunc();
   testUsers = [tempUser1, tempUser2];

--- a/tests/resolvers/Mutation/removeOrganizationImage.spec.ts
+++ b/tests/resolvers/Mutation/removeOrganizationImage.spec.ts
@@ -29,7 +29,7 @@ let testAdminUser: testUserType;
 let testOrganization: testOrganizationType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testUser = await createTestUserFunc();
 

--- a/tests/resolvers/Mutation/removePost.spec.ts
+++ b/tests/resolvers/Mutation/removePost.spec.ts
@@ -18,7 +18,7 @@ let testUsers: testUserType[];
 let testPost: testPostType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const tempUser1 = await createTestUserFunc();
   const tempUser2 = await createTestUserFunc();
   testUsers = [tempUser1, tempUser2];

--- a/tests/resolvers/Mutation/removeTask.spec.ts
+++ b/tests/resolvers/Mutation/removeTask.spec.ts
@@ -19,7 +19,7 @@ let testUsers: testUserType[];
 let testTask: Interface_Task & Document<any, any, Interface_Task>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const tempUser1 = await createTestUserFunc();
   const tempUser2 = await createTestUserFunc();

--- a/tests/resolvers/Mutation/removeUserFromGroupChat.spec.ts
+++ b/tests/resolvers/Mutation/removeUserFromGroupChat.spec.ts
@@ -21,7 +21,7 @@ let testOrganization: testOrganizationType;
 let testGroupChat: testGroupChatType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestGroupChatMessage();
   testUser = temp[0];
   testOrganization = temp[1];

--- a/tests/resolvers/Mutation/removeUserImage.spec.ts
+++ b/tests/resolvers/Mutation/removeUserImage.spec.ts
@@ -18,7 +18,7 @@ let testUser: testUserType;
 const testImage: string = "testImage";
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   testUser = await createTestUserFunc();
 });
 

--- a/tests/resolvers/Mutation/revokeRefreshTokenForUser.spec.ts
+++ b/tests/resolvers/Mutation/revokeRefreshTokenForUser.spec.ts
@@ -9,7 +9,7 @@ import { createTestUserFunc, testUserType } from "../../helpers/user";
 let testUser: testUserType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   testUser = await createTestUserFunc();
 });
 

--- a/tests/resolvers/Mutation/saveFcmToken.spec.ts
+++ b/tests/resolvers/Mutation/saveFcmToken.spec.ts
@@ -11,7 +11,7 @@ import { createTestUserFunc, testUserType } from "../../helpers/user";
 let testUser: testUserType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   testUser = await createTestUserFunc();
 });
 

--- a/tests/resolvers/Mutation/sendMembershipRequest.spec.ts
+++ b/tests/resolvers/Mutation/sendMembershipRequest.spec.ts
@@ -17,7 +17,7 @@ let testOrganization: testOrganizationType;
 let testMembershipRequest: testMembershipRequestType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestMembershipRequest();
   testUser = temp[0];
   testOrganization = temp[1];

--- a/tests/resolvers/Mutation/sendMessageToDirectChat.spec.ts
+++ b/tests/resolvers/Mutation/sendMessageToDirectChat.spec.ts
@@ -20,7 +20,7 @@ let testDirectChat: Interface_DirectChat &
   Document<any, any, Interface_DirectChat>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const tempUser1 = await createTestUserFunc();
   const tempUser2 = await createTestUserFunc();
   testUsers = [tempUser1, tempUser2];

--- a/tests/resolvers/Mutation/sendMessageToGroupChat.spec.ts
+++ b/tests/resolvers/Mutation/sendMessageToGroupChat.spec.ts
@@ -23,7 +23,7 @@ import {
 } from "../../helpers/userAndOrg";
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestUserAndOrganization();
   testUser = temp[0];
 

--- a/tests/resolvers/Mutation/signUp.spec.ts
+++ b/tests/resolvers/Mutation/signUp.spec.ts
@@ -31,7 +31,7 @@ let testUser: testUserType;
 let testOrganization: testOrganizationType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestUserAndOrganization();
   testUser = temp[0];
   testOrganization = temp[1];

--- a/tests/resolvers/Mutation/unblockUser.spec.ts
+++ b/tests/resolvers/Mutation/unblockUser.spec.ts
@@ -20,7 +20,7 @@ let testUser: testUserType;
 let testOrganization: testOrganizationType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestUserAndOrganization();
   testUser = temp[0];
   testOrganization = temp[1];

--- a/tests/resolvers/Mutation/unlikeComment.spec.ts
+++ b/tests/resolvers/Mutation/unlikeComment.spec.ts
@@ -13,7 +13,7 @@ let testUser: testUserType;
 let testComment: Interface_Comment & Document<any, any, Interface_Comment>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestPost();
   testUser = temp[0];
   const testPost = temp[2];

--- a/tests/resolvers/Mutation/unlikePost.spec.ts
+++ b/tests/resolvers/Mutation/unlikePost.spec.ts
@@ -16,7 +16,7 @@ let testUser: testUserType;
 let testPost: testPostType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const temp = await createTestUserAndOrganization();
   testUser = temp[0];
   const testOrganization = temp[1];

--- a/tests/resolvers/Mutation/unregisterForEventByUser.spec.ts
+++ b/tests/resolvers/Mutation/unregisterForEventByUser.spec.ts
@@ -22,7 +22,7 @@ let testUser: Interface_User & Document<any, any, Interface_User>;
 let testEvent: Interface_Event & Document<any, any, Interface_Event>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Mutation/updateEvent.spec.ts
+++ b/tests/resolvers/Mutation/updateEvent.spec.ts
@@ -22,7 +22,7 @@ let testUser: Interface_User & Document<any, any, Interface_User>;
 let testEvent: Interface_Event & Document<any, any, Interface_Event>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Mutation/updateEventProject.spec.ts
+++ b/tests/resolvers/Mutation/updateEventProject.spec.ts
@@ -39,7 +39,7 @@ let testEventProject: Interface_EventProject &
   Document<any, any, Interface_EventProject>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,
     password: "password",

--- a/tests/resolvers/Mutation/updateLanguage.spec.ts
+++ b/tests/resolvers/Mutation/updateLanguage.spec.ts
@@ -11,7 +11,7 @@ import { beforeAll, afterAll, describe, it, expect } from "vitest";
 let testUser: Interface_User & Document<any, any, Interface_User>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Mutation/updateOrganization.spec.ts
+++ b/tests/resolvers/Mutation/updateOrganization.spec.ts
@@ -21,7 +21,7 @@ let testOrganization: Interface_Organization &
   Document<any, any, Interface_Organization>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Mutation/updatePluginInstalledOrgs.spec.ts
+++ b/tests/resolvers/Mutation/updatePluginInstalledOrgs.spec.ts
@@ -20,7 +20,7 @@ let testOrganization: Interface_Organization &
   Document<any, any, Interface_Organization>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Mutation/updatePluginStatus.spec.ts
+++ b/tests/resolvers/Mutation/updatePluginStatus.spec.ts
@@ -17,7 +17,7 @@ let testUser: Interface_User & Document<any, any, Interface_User>;
 let testPlugin: Interface_Plugin & Document<any, any, Interface_Plugin>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Mutation/updateTask.spec.ts
+++ b/tests/resolvers/Mutation/updateTask.spec.ts
@@ -19,7 +19,7 @@ let testUser: Interface_User & Document<any, any, Interface_User>;
 let testTasks: (Interface_Task & Document<any, any, Interface_Task>)[];
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Mutation/updateUserProfile.spec.ts
+++ b/tests/resolvers/Mutation/updateUserProfile.spec.ts
@@ -19,7 +19,7 @@ import {
 let testUser: Interface_User & Document<any, any, Interface_User>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Mutation/updateUserType.spec.ts
+++ b/tests/resolvers/Mutation/updateUserType.spec.ts
@@ -11,7 +11,7 @@ import { beforeAll, afterAll, describe, it, expect } from "vitest";
 let testUsers: (Interface_User & Document<any, any, Interface_User>)[];
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testUsers = await User.insertMany([
     {

--- a/tests/resolvers/Organization/admins.spec.ts
+++ b/tests/resolvers/Organization/admins.spec.ts
@@ -11,7 +11,7 @@ import {
 let testOrganization: testOrganizationType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const userAndOrg = await createTestUserAndOrganization();
   testOrganization = userAndOrg[1];
 });

--- a/tests/resolvers/Organization/blockedUsers.spec.ts
+++ b/tests/resolvers/Organization/blockedUsers.spec.ts
@@ -11,7 +11,7 @@ import {
 let testOrganization: testOrganizationType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const userAndOrg = await createTestUserAndOrganization();
   testOrganization = userAndOrg[1];
 });

--- a/tests/resolvers/Organization/creator.spec.ts
+++ b/tests/resolvers/Organization/creator.spec.ts
@@ -22,7 +22,7 @@ let testUser: testUserType;
 let testOrganization: testOrganizationType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const userAndOrg = await createTestUserAndOrganization();
   testUser = userAndOrg[0];
   testOrganization = userAndOrg[1];

--- a/tests/resolvers/Organization/members.spec.ts
+++ b/tests/resolvers/Organization/members.spec.ts
@@ -11,7 +11,7 @@ import {
 let testOrganization: testOrganizationType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const userAndOrg = await createTestUserAndOrganization();
   testOrganization = userAndOrg[1];
 });

--- a/tests/resolvers/Organization/membershipRequests.spec.ts
+++ b/tests/resolvers/Organization/membershipRequests.spec.ts
@@ -13,7 +13,7 @@ let testUser: testUserType;
 let testOrganization: testOrganizationType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const userAndOrg = await createTestUserAndOrganization();
   testUser = userAndOrg[0];
   testOrganization = userAndOrg[1];

--- a/tests/resolvers/Query/checkAuth.spec.ts
+++ b/tests/resolvers/Query/checkAuth.spec.ts
@@ -8,7 +8,7 @@ import { nanoid } from "nanoid";
 import { beforeAll, afterAll, describe, it, expect } from "vitest";
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 });
 
 afterAll(async () => {

--- a/tests/resolvers/Query/comments.spec.ts
+++ b/tests/resolvers/Query/comments.spec.ts
@@ -6,7 +6,7 @@ import { nanoid } from "nanoid";
 import { beforeAll, afterAll, describe, it, expect } from "vitest";
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/commentsByPost.spec.ts
+++ b/tests/resolvers/Query/commentsByPost.spec.ts
@@ -27,7 +27,7 @@ let testOrganization: Interface_Organization &
 let testPost: Interface_Post & Document<any, any, Interface_Post>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/directChatMessages.spec.ts
+++ b/tests/resolvers/Query/directChatMessages.spec.ts
@@ -11,7 +11,7 @@ import { nanoid } from "nanoid";
 import { beforeAll, afterAll, describe, it, expect } from "vitest";
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/directChats.spec.ts
+++ b/tests/resolvers/Query/directChats.spec.ts
@@ -11,7 +11,7 @@ import { nanoid } from "nanoid";
 import { beforeAll, afterAll, describe, it, expect } from "vitest";
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUsers = await User.insertMany([
     {

--- a/tests/resolvers/Query/directChatsByUserID.spec.ts
+++ b/tests/resolvers/Query/directChatsByUserID.spec.ts
@@ -15,7 +15,7 @@ import { beforeAll, afterAll, describe, it, expect } from "vitest";
 let testUser: Interface_User & Document<any, any, Interface_User>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/directChatsMessagesByChatID.spec.ts
+++ b/tests/resolvers/Query/directChatsMessagesByChatID.spec.ts
@@ -18,7 +18,7 @@ let testDirectChats: (Interface_DirectChat &
   Document<any, any, Interface_DirectChat>)[];
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUsers = await User.insertMany([
     {

--- a/tests/resolvers/Query/event.spec.ts
+++ b/tests/resolvers/Query/event.spec.ts
@@ -17,7 +17,7 @@ import { beforeAll, afterAll, describe, it, expect } from "vitest";
 let testEvent: Interface_Event & Document<any, any, Interface_Event>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/events.spec.ts
+++ b/tests/resolvers/Query/events.spec.ts
@@ -7,7 +7,7 @@ import { QueryEventsArgs } from "../../../src/types/generatedGraphQLTypes";
 import { beforeAll, afterAll, describe, it, expect } from "vitest";
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/eventsByOrganization.spec.ts
+++ b/tests/resolvers/Query/eventsByOrganization.spec.ts
@@ -17,7 +17,7 @@ let testOrganization: Interface_Organization &
   Document<any, any, Interface_Organization>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/getDonationById.spec.ts
+++ b/tests/resolvers/Query/getDonationById.spec.ts
@@ -15,7 +15,7 @@ import { Document } from "mongoose";
 let testDonation: Interface_Donation & Document<any, any, Interface_Donation>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/getDonationByOrgId.spec.ts
+++ b/tests/resolvers/Query/getDonationByOrgId.spec.ts
@@ -16,7 +16,7 @@ let testOrganization: Interface_Organization &
   Document<any, any, Interface_Organization>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/getDonations.spec.ts
+++ b/tests/resolvers/Query/getDonations.spec.ts
@@ -6,7 +6,7 @@ import { nanoid } from "nanoid";
 import { beforeAll, afterAll, describe, it, expect } from "vitest";
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/getPlugins.spec.ts
+++ b/tests/resolvers/Query/getPlugins.spec.ts
@@ -6,7 +6,7 @@ import { nanoid } from "nanoid";
 import { beforeAll, afterAll, describe, it, expect } from "vitest";
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/getlanguage.spec.ts
+++ b/tests/resolvers/Query/getlanguage.spec.ts
@@ -15,7 +15,7 @@ const deValue = `de ${nanoid().toLowerCase()}`;
 const frValue = `fr ${nanoid().toLowerCase()}`;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testLanguages = await Language.insertMany([
     {

--- a/tests/resolvers/Query/groupChatMessages.spec.ts
+++ b/tests/resolvers/Query/groupChatMessages.spec.ts
@@ -11,7 +11,7 @@ import { nanoid } from "nanoid";
 import { beforeAll, afterAll, describe, it, expect } from "vitest";
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/groupChats.spec.ts
+++ b/tests/resolvers/Query/groupChats.spec.ts
@@ -6,7 +6,7 @@ import { nanoid } from "nanoid";
 import { beforeAll, afterAll, describe, it, expect } from "vitest";
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/groups.spec.ts
+++ b/tests/resolvers/Query/groups.spec.ts
@@ -6,7 +6,7 @@ import { nanoid } from "nanoid";
 import { beforeAll, afterAll, describe, it, expect } from "vitest";
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/isUserRegister.spec.ts
+++ b/tests/resolvers/Query/isUserRegister.spec.ts
@@ -19,7 +19,7 @@ let testUser: Interface_User & Document<any, any, Interface_User>;
 let testEvent: Interface_Event & Document<any, any, Interface_Event>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/me.spec.ts
+++ b/tests/resolvers/Query/me.spec.ts
@@ -10,7 +10,7 @@ import { beforeAll, afterAll, describe, it, expect } from "vitest";
 let testUser: (Interface_User & Document<any, any, Interface_User>) | null;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/myLanguage.spec.ts
+++ b/tests/resolvers/Query/myLanguage.spec.ts
@@ -8,7 +8,7 @@ import { Types } from "mongoose";
 import { beforeAll, afterAll, describe, it, expect } from "vitest";
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 });
 
 afterAll(async () => {

--- a/tests/resolvers/Query/organizations.spec.ts
+++ b/tests/resolvers/Query/organizations.spec.ts
@@ -16,7 +16,7 @@ let testOrganization1: Interface_Organization &
   Document<any, any, Interface_Organization>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/organizationsConnection.spec.ts
+++ b/tests/resolvers/Query/organizationsConnection.spec.ts
@@ -15,7 +15,7 @@ let testOrganizations: (Interface_Organization &
   Document<any, any, Interface_Organization>)[];
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/organizationsMemberConnection.spec.ts
+++ b/tests/resolvers/Query/organizationsMemberConnection.spec.ts
@@ -17,7 +17,7 @@ let testOrganization: Interface_Organization &
   Document<any, any, Interface_Organization>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testUsers = await User.insertMany([
     {

--- a/tests/resolvers/Query/post.spec.ts
+++ b/tests/resolvers/Query/post.spec.ts
@@ -17,7 +17,7 @@ import { beforeAll, afterAll, describe, it, expect } from "vitest";
 let testPost: Interface_Post & Document<any, any, Interface_Post>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/posts.spec.ts
+++ b/tests/resolvers/Query/posts.spec.ts
@@ -7,7 +7,7 @@ import { QueryPostsArgs } from "../../../src/types/generatedGraphQLTypes";
 import { beforeAll, afterAll, describe, it, expect } from "vitest";
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/postsByOrganization.spec.ts
+++ b/tests/resolvers/Query/postsByOrganization.spec.ts
@@ -17,7 +17,7 @@ let testOrganization: Interface_Organization &
   Document<any, any, Interface_Organization>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/postsByOrganizationConnection.spec.ts
+++ b/tests/resolvers/Query/postsByOrganizationConnection.spec.ts
@@ -17,7 +17,7 @@ let testOrganization: Interface_Organization &
   Document<any, any, Interface_Organization>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/registeredEventsByUser.spec.ts
+++ b/tests/resolvers/Query/registeredEventsByUser.spec.ts
@@ -16,7 +16,7 @@ import { beforeAll, afterAll, describe, it, expect } from "vitest";
 let testUser: Interface_User & Document<any, any, Interface_User>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/registrantsByEvent.spec.ts
+++ b/tests/resolvers/Query/registrantsByEvent.spec.ts
@@ -16,7 +16,7 @@ import { beforeAll, afterAll, describe, it, expect } from "vitest";
 let testEvent: Interface_Event & Document<any, any, Interface_Event>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/tasksByEvent.spec.ts
+++ b/tests/resolvers/Query/tasksByEvent.spec.ts
@@ -16,7 +16,7 @@ import { beforeAll, afterAll, describe, it, expect } from "vitest";
 let testEvent: Interface_Event & Document<any, any, Interface_Event>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   const testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/tasksByUser.spec.ts
+++ b/tests/resolvers/Query/tasksByUser.spec.ts
@@ -16,7 +16,7 @@ import { beforeAll, afterAll, describe, it, expect } from "vitest";
 let testUser: Interface_User & Document<any, any, Interface_User>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/user.spec.ts
+++ b/tests/resolvers/Query/user.spec.ts
@@ -11,7 +11,7 @@ import { beforeAll, afterAll, describe, it, expect } from "vitest";
 let testUser: Interface_User & Document<any, any, Interface_User>;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testUser = await User.create({
     email: `email${nanoid().toLowerCase()}@gmail.com`,

--- a/tests/resolvers/Query/userLanguage.spec.ts
+++ b/tests/resolvers/Query/userLanguage.spec.ts
@@ -9,7 +9,7 @@ import { QueryUserLanguageArgs } from "../../../src/types/generatedGraphQLTypes"
 import { beforeAll, afterAll, describe, it, expect } from "vitest";
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 });
 
 afterAll(async () => {

--- a/tests/resolvers/Query/users.spec.ts
+++ b/tests/resolvers/Query/users.spec.ts
@@ -12,7 +12,7 @@ import * as mongoose from "mongoose";
 let testUsers: (Interface_User & Document<any, any, Interface_User>)[];
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 });
 
 afterAll(async () => {

--- a/tests/resolvers/Query/usersConnection.spec.ts
+++ b/tests/resolvers/Query/usersConnection.spec.ts
@@ -10,7 +10,7 @@ import { beforeAll, afterAll, describe, it, expect } from "vitest";
 let testUsers: (Interface_User & Document<any, any, Interface_User>)[];
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 
   testUsers = await User.insertMany([
     {

--- a/tests/utilities/adminCheck.spec.ts
+++ b/tests/utilities/adminCheck.spec.ts
@@ -23,7 +23,7 @@ let testUser: testUserType;
 let testOrganization: testOrganizationType;
 
 beforeAll(async () => {
-  connect();
+  await connect("TALAWA_TESTING_DB");
   const userAndOrg = await createTestUserAndOrganization(false, false);
   testUser = userAndOrg[0];
   testOrganization = userAndOrg[1];

--- a/tests/utilities/deleteImage.spec.ts
+++ b/tests/utilities/deleteImage.spec.ts
@@ -24,7 +24,7 @@ vi.mock("fs", () => ({
 }));
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   testHash = await ImageHash.create({
     fileName: testImageToBeDeleted,
     hashValue: testHashString,

--- a/tests/utilities/imageAlreadyInDbCheck.spec.ts
+++ b/tests/utilities/imageAlreadyInDbCheck.spec.ts
@@ -27,7 +27,7 @@ const testErrors = [
 ];
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 });
 
 afterAll(async () => {

--- a/tests/utilities/reuploadDuplicateCheck.spec.ts
+++ b/tests/utilities/reuploadDuplicateCheck.spec.ts
@@ -26,7 +26,7 @@ const testErrors = [
 ];
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
 });
 
 afterAll(async () => {

--- a/tests/utilities/uploadImage.spec.ts
+++ b/tests/utilities/uploadImage.spec.ts
@@ -20,7 +20,7 @@ import {
 let testUser: testUserType;
 
 beforeAll(async () => {
-  await connect();
+  await connect("TALAWA_TESTING_DB");
   const testUserObj = await createTestUserAndOrganization();
   testUser = testUserObj[0];
   if (!fs.existsSync(path.join(__dirname, "../../images"))) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Separates the testing database from the primary database.

**Issue Number:**
Fixes #964 

**Did you add tests for your changes?**
Tested the functionality manually.

**Snapshots/Videos:**

### Before Testing
![before](https://user-images.githubusercontent.com/96648934/216449787-59fb32a0-68fc-4c3d-aa73-c968a78d24a4.png)
(Only test-talawa exists, which is my primary database)

### After running `npm run test`
![image](https://user-images.githubusercontent.com/96648934/216450056-e05e5973-4e8a-49ce-9681-ef55d34d1842.png)
(test-talawa_TEST is automatically created and fillled with the testing data)

![image](https://user-images.githubusercontent.com/96648934/216450207-e3da4912-0813-41f9-a9c5-fb1904eb968f.png)
(All tests are still pass)

![image](https://user-images.githubusercontent.com/96648934/216451001-71ca9490-94ab-490b-b290-ebce9ec56e67.png)
(`NODE_ENV` returns back to `undefined` as soon as the testing command is complete)

**If relevant, did you update the documentation?**
Yes.
Updated documentation in the `INSTALLATION.md`

**Does this PR introduce a breaking change?**
No

**Other information**
1. Added caution message about this functionality in the section about `testing` in `INSTALLATION.md`.
2. No changes in GitHub Action needed as it itself uses the `npm run test` script, thus the maintainers with access to the `MONGO_DB` database can indeed verify all the data is only added to a newly created testing database.
3. Added checks to ensure that we can only connect to the custom database if and only if the environment is set to testing. Also updated the README.md about the same and linted files which weren't linted properly in the recent commits.
4. Re implementation of PR #985 due to merge conflicts

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes