### PR TITLE
Mutations: Refactored file 61 to 70, removing conditional check for PRODUCTION

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ serviceAccountKey.json
 
 # Added FNM configuration files
 .node-version
+
+# MacOS
+
+.DS_STORE

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -75,6 +75,11 @@ export const UNAUTHENTICATED_ERROR = {
   param: "userAuthentication",
 };
 
+export const TASK_NOT_FOUND = "Task not found";
+export const TASK_NOT_FOUND_CODE = "task.notFound";
+export const TASK_NOT_FOUND_MESSAGE = "task.notFound";
+export const TASK_NOT_FOUND_PARAM = "task";
+
 export const STATUS_ACTIVE = "ACTIVE";
 
 export const URL =

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -109,6 +109,11 @@ export const USER_NOT_FOUND_CODE = "user.notFound";
 export const USER_NOT_FOUND_MESSAGE = "user.notFound";
 export const USER_NOT_FOUND_PARAM = "user";
 
+export const EMAIL_ALREADY_EXISTS = "Email already exists";
+export const EMAIL_ALREADY_EXISTS_CODE = "email.alreadyExists";
+export const EMAIL_ALREADY_EXISTS_MESSAGE = "email.alreadyExists";
+export const EMAIL_ALREADY_EXISTS_PARAM = "email";
+
 export const ACCESS_TOKEN_SECRET = process.env.ACCESS_TOKEN_SECRET;
 
 export const REFRESH_TOKEN_SECRET = process.env.REFRESH_TOKEN_SECRET;

--- a/src/resolvers/Mutation/unregisterForEventByUser.ts
+++ b/src/resolvers/Mutation/unregisterForEventByUser.ts
@@ -2,16 +2,12 @@ import { MutationResolvers } from "../../types/generatedGraphQLTypes";
 import { errors, requestContext } from "../../libraries";
 import { User, Event } from "../../models";
 import {
-  IN_PRODUCTION,
-  USER_NOT_FOUND,
   USER_NOT_FOUND_MESSAGE,
   USER_NOT_FOUND_CODE,
   USER_NOT_FOUND_PARAM,
-  EVENT_NOT_FOUND,
   EVENT_NOT_FOUND_PARAM,
   EVENT_NOT_FOUND_CODE,
   EVENT_NOT_FOUND_MESSAGE,
-  USER_ALREADY_UNREGISTERED,
   USER_ALREADY_UNREGISTERED_MESSAGE,
   USER_ALREADY_UNREGISTERED_CODE,
   USER_ALREADY_UNREGISTERED_PARAM,
@@ -26,9 +22,7 @@ export const unregisterForEventByUser: MutationResolvers["unregisterForEventByUs
     // checks if current user exists
     if (currentUserExists === false) {
       throw new errors.NotFoundError(
-        IN_PRODUCTION !== true
-          ? USER_NOT_FOUND
-          : requestContext.translate(USER_NOT_FOUND_MESSAGE),
+        requestContext.translate(USER_NOT_FOUND_MESSAGE),
         USER_NOT_FOUND_CODE,
         USER_NOT_FOUND_PARAM
       );
@@ -41,9 +35,7 @@ export const unregisterForEventByUser: MutationResolvers["unregisterForEventByUs
     // checks if there exists an event with _id === args.id
     if (!event) {
       throw new errors.NotFoundError(
-        IN_PRODUCTION !== true
-          ? EVENT_NOT_FOUND
-          : requestContext.translate(EVENT_NOT_FOUND_MESSAGE),
+        requestContext.translate(EVENT_NOT_FOUND_MESSAGE),
         EVENT_NOT_FOUND_CODE,
         EVENT_NOT_FOUND_PARAM
       );
@@ -57,9 +49,7 @@ export const unregisterForEventByUser: MutationResolvers["unregisterForEventByUs
     // checks if current user is a registrant of event
     if (index === -1) {
       throw new errors.NotFoundError(
-        IN_PRODUCTION !== true
-          ? USER_NOT_FOUND
-          : requestContext.translate(USER_NOT_FOUND_MESSAGE),
+        requestContext.translate(USER_NOT_FOUND_MESSAGE),
         USER_NOT_FOUND_CODE,
         USER_NOT_FOUND_PARAM
       );
@@ -91,9 +81,7 @@ export const unregisterForEventByUser: MutationResolvers["unregisterForEventByUs
       ).lean();
     } else {
       throw new errors.NotFoundError(
-        IN_PRODUCTION !== true
-          ? USER_ALREADY_UNREGISTERED
-          : requestContext.translate(USER_ALREADY_UNREGISTERED_MESSAGE),
+        requestContext.translate(USER_ALREADY_UNREGISTERED_MESSAGE),
         USER_ALREADY_UNREGISTERED_CODE,
         USER_ALREADY_UNREGISTERED_PARAM
       );

--- a/src/resolvers/Mutation/updateEvent.ts
+++ b/src/resolvers/Mutation/updateEvent.ts
@@ -2,16 +2,12 @@ import { MutationResolvers } from "../../types/generatedGraphQLTypes";
 import { errors, requestContext } from "../../libraries";
 import { User, Event } from "../../models";
 import {
-  IN_PRODUCTION,
-  USER_NOT_FOUND,
   USER_NOT_FOUND_MESSAGE,
   USER_NOT_FOUND_CODE,
   USER_NOT_FOUND_PARAM,
-  EVENT_NOT_FOUND,
   EVENT_NOT_FOUND_MESSAGE,
   EVENT_NOT_FOUND_CODE,
   EVENT_NOT_FOUND_PARAM,
-  USER_NOT_AUTHORIZED,
   USER_NOT_AUTHORIZED_MESSAGE,
   USER_NOT_AUTHORIZED_CODE,
   USER_NOT_AUTHORIZED_PARAM,
@@ -29,9 +25,7 @@ export const updateEvent: MutationResolvers["updateEvent"] = async (
   // checks if current user exists
   if (currentUserExists === false) {
     throw new errors.NotFoundError(
-      IN_PRODUCTION !== true
-        ? USER_NOT_FOUND
-        : requestContext.translate(USER_NOT_FOUND_MESSAGE),
+      requestContext.translate(USER_NOT_FOUND_MESSAGE),
       USER_NOT_FOUND_CODE,
       USER_NOT_FOUND_PARAM
     );
@@ -44,9 +38,7 @@ export const updateEvent: MutationResolvers["updateEvent"] = async (
   // checks if there exists an event with _id === args.id
   if (!event) {
     throw new errors.NotFoundError(
-      IN_PRODUCTION !== true
-        ? EVENT_NOT_FOUND
-        : requestContext.translate(EVENT_NOT_FOUND_MESSAGE),
+      requestContext.translate(EVENT_NOT_FOUND_MESSAGE),
       EVENT_NOT_FOUND_CODE,
       EVENT_NOT_FOUND_PARAM
     );
@@ -59,9 +51,7 @@ export const updateEvent: MutationResolvers["updateEvent"] = async (
   // checks if current user is an admin of the event with _id === args.id
   if (currentUserIsEventAdmin === false) {
     throw new errors.UnauthorizedError(
-      IN_PRODUCTION !== true
-        ? USER_NOT_AUTHORIZED
-        : requestContext.translate(USER_NOT_AUTHORIZED_MESSAGE),
+      requestContext.translate(USER_NOT_AUTHORIZED_MESSAGE),
       USER_NOT_AUTHORIZED_CODE,
       USER_NOT_AUTHORIZED_PARAM
     );

--- a/src/resolvers/Mutation/updateEventProject.ts
+++ b/src/resolvers/Mutation/updateEventProject.ts
@@ -2,15 +2,11 @@ import { User, EventProject } from "../../models";
 import { errors, requestContext } from "../../libraries";
 import {
   EVENT_NOT_FOUND_CODE,
-  EVENT_PROJECT_NOT_FOUND,
   EVENT_PROJECT_NOT_FOUND_MESSAGE,
   EVENT_PROJECT_NOT_FOUND_PARAM,
-  IN_PRODUCTION,
-  USER_NOT_AUTHORIZED,
   USER_NOT_AUTHORIZED_CODE,
   USER_NOT_AUTHORIZED_MESSAGE,
   USER_NOT_AUTHORIZED_PARAM,
-  USER_NOT_FOUND,
   USER_NOT_FOUND_CODE,
   USER_NOT_FOUND_MESSAGE,
   USER_NOT_FOUND_PARAM,
@@ -27,9 +23,7 @@ export const updateEventProject = async (
 
   if (currentUserExists === false) {
     throw new errors.NotFoundError(
-      IN_PRODUCTION !== true
-        ? USER_NOT_FOUND
-        : requestContext.translate(USER_NOT_FOUND_MESSAGE),
+      requestContext.translate(USER_NOT_FOUND_MESSAGE),
       USER_NOT_FOUND_CODE,
       USER_NOT_FOUND_PARAM
     );
@@ -41,9 +35,7 @@ export const updateEventProject = async (
 
   if (!eventProject) {
     throw new errors.NotFoundError(
-      IN_PRODUCTION !== true
-        ? EVENT_PROJECT_NOT_FOUND
-        : requestContext.translate(EVENT_PROJECT_NOT_FOUND_MESSAGE),
+      requestContext.translate(EVENT_PROJECT_NOT_FOUND_MESSAGE),
       EVENT_NOT_FOUND_CODE,
       EVENT_PROJECT_NOT_FOUND_PARAM
     );
@@ -52,9 +44,7 @@ export const updateEventProject = async (
   // toString() method converts mongodb's objectId to a javascript string for comparision
   if (eventProject.creator.toString() !== context.userId.toString()) {
     throw new errors.UnauthorizedError(
-      IN_PRODUCTION !== true
-        ? USER_NOT_AUTHORIZED
-        : requestContext.translate(USER_NOT_AUTHORIZED_MESSAGE),
+      requestContext.translate(USER_NOT_AUTHORIZED_MESSAGE),
       USER_NOT_AUTHORIZED_CODE,
       USER_NOT_AUTHORIZED_PARAM
     );

--- a/src/resolvers/Mutation/updateLanguage.ts
+++ b/src/resolvers/Mutation/updateLanguage.ts
@@ -1,6 +1,4 @@
 import {
-  IN_PRODUCTION,
-  USER_NOT_FOUND,
   USER_NOT_FOUND_CODE,
   USER_NOT_FOUND_MESSAGE,
   USER_NOT_FOUND_PARAM,
@@ -21,9 +19,7 @@ export const updateLanguage: MutationResolvers["updateLanguage"] = async (
   // checks if current user exists
   if (currentUserExists === false) {
     throw new errors.NotFoundError(
-      IN_PRODUCTION !== true
-        ? USER_NOT_FOUND
-        : requestContext.translate(USER_NOT_FOUND_MESSAGE),
+      requestContext.translate(USER_NOT_FOUND_MESSAGE),
       USER_NOT_FOUND_CODE,
       USER_NOT_FOUND_PARAM
     );

--- a/src/resolvers/Mutation/updateOrganization.ts
+++ b/src/resolvers/Mutation/updateOrganization.ts
@@ -2,8 +2,6 @@ import { MutationResolvers } from "../../types/generatedGraphQLTypes";
 import { errors, requestContext } from "../../libraries";
 import { Organization } from "../../models";
 import {
-  IN_PRODUCTION,
-  ORGANIZATION_NOT_FOUND,
   ORGANIZATION_NOT_FOUND_MESSAGE,
   ORGANIZATION_NOT_FOUND_CODE,
   ORGANIZATION_NOT_FOUND_PARAM,
@@ -19,9 +17,7 @@ export const updateOrganization: MutationResolvers["updateOrganization"] =
     // Checks if organization with _id === args.id exists.
     if (!organization) {
       throw new errors.NotFoundError(
-        IN_PRODUCTION !== true
-          ? ORGANIZATION_NOT_FOUND
-          : requestContext.translate(ORGANIZATION_NOT_FOUND_MESSAGE),
+        requestContext.translate(ORGANIZATION_NOT_FOUND_MESSAGE),
         ORGANIZATION_NOT_FOUND_CODE,
         ORGANIZATION_NOT_FOUND_PARAM
       );

--- a/src/resolvers/Mutation/updateTask.ts
+++ b/src/resolvers/Mutation/updateTask.ts
@@ -1,4 +1,7 @@
 import {
+  TASK_NOT_FOUND_CODE,
+  TASK_NOT_FOUND_MESSAGE,
+  TASK_NOT_FOUND_PARAM,
   USER_NOT_AUTHORIZED_CODE,
   USER_NOT_AUTHORIZED_MESSAGE,
   USER_NOT_AUTHORIZED_PARAM,
@@ -33,9 +36,9 @@ export const updateTask: MutationResolvers["updateTask"] = async (
 
   if (!task) {
     throw new errors.NotFoundError(
-      requestContext.translate("task.notFound"),
-      "task.notFound",
-      "task"
+      requestContext.translate(TASK_NOT_FOUND_MESSAGE),
+      TASK_NOT_FOUND_CODE,
+      TASK_NOT_FOUND_PARAM
     );
   }
 

--- a/src/resolvers/Mutation/updateUserProfile.ts
+++ b/src/resolvers/Mutation/updateUserProfile.ts
@@ -1,4 +1,7 @@
 import {
+  EMAIL_ALREADY_EXISTS,
+  EMAIL_ALREADY_EXISTS_MESSAGE,
+  EMAIL_ALREADY_EXISTS_PARAM,
   IN_PRODUCTION,
   USER_NOT_FOUND,
   USER_NOT_FOUND_CODE,
@@ -37,10 +40,10 @@ export const updateUserProfile: MutationResolvers["updateUserProfile"] = async (
     if (userWithEmailExists === true) {
       throw new errors.ConflictError(
         IN_PRODUCTION !== true
-          ? "Email already exists"
-          : requestContext.translate("email.alreadyExists"),
-        "email.alreadyExists",
-        "email"
+          ? EMAIL_ALREADY_EXISTS
+          : requestContext.translate(EMAIL_ALREADY_EXISTS_MESSAGE),
+        EMAIL_ALREADY_EXISTS_MESSAGE,
+        EMAIL_ALREADY_EXISTS_PARAM
       );
     }
   } // Upload file

--- a/src/resolvers/Mutation/updateUserProfile.ts
+++ b/src/resolvers/Mutation/updateUserProfile.ts
@@ -1,9 +1,6 @@
 import {
-  EMAIL_ALREADY_EXISTS,
   EMAIL_ALREADY_EXISTS_MESSAGE,
   EMAIL_ALREADY_EXISTS_PARAM,
-  IN_PRODUCTION,
-  USER_NOT_FOUND,
   USER_NOT_FOUND_CODE,
   USER_NOT_FOUND_MESSAGE,
   USER_NOT_FOUND_PARAM,
@@ -24,9 +21,7 @@ export const updateUserProfile: MutationResolvers["updateUserProfile"] = async (
 
   if (currentUserExists === false) {
     throw new errors.NotFoundError(
-      IN_PRODUCTION !== true
-        ? USER_NOT_FOUND
-        : requestContext.translate(USER_NOT_FOUND_MESSAGE),
+      requestContext.translate(USER_NOT_FOUND_MESSAGE),
       USER_NOT_FOUND_CODE,
       USER_NOT_FOUND_PARAM
     );
@@ -39,9 +34,7 @@ export const updateUserProfile: MutationResolvers["updateUserProfile"] = async (
 
     if (userWithEmailExists === true) {
       throw new errors.ConflictError(
-        IN_PRODUCTION !== true
-          ? EMAIL_ALREADY_EXISTS
-          : requestContext.translate(EMAIL_ALREADY_EXISTS_MESSAGE),
+        requestContext.translate(EMAIL_ALREADY_EXISTS_MESSAGE),
         EMAIL_ALREADY_EXISTS_MESSAGE,
         EMAIL_ALREADY_EXISTS_PARAM
       );

--- a/src/resolvers/Mutation/updateUserType.ts
+++ b/src/resolvers/Mutation/updateUserType.ts
@@ -2,8 +2,6 @@ import { MutationResolvers } from "../../types/generatedGraphQLTypes";
 import { User } from "../../models";
 import {
   USER_NOT_AUTHORIZED,
-  IN_PRODUCTION,
-  USER_NOT_FOUND,
   USER_NOT_FOUND_MESSAGE,
   USER_NOT_FOUND_CODE,
   USER_NOT_FOUND_PARAM,
@@ -31,9 +29,7 @@ export const updateUserType: MutationResolvers["updateUserType"] = async (
 
   if (userExists === false) {
     throw new errors.NotFoundError(
-      IN_PRODUCTION !== true
-        ? USER_NOT_FOUND
-        : requestContext.translate(USER_NOT_FOUND_MESSAGE),
+      requestContext.translate(USER_NOT_FOUND_MESSAGE),
       USER_NOT_FOUND_CODE,
       USER_NOT_FOUND_PARAM
     );

--- a/tests/resolvers/Mutation/unregisterForEventByUser.spec.ts
+++ b/tests/resolvers/Mutation/unregisterForEventByUser.spec.ts
@@ -3,13 +3,20 @@ import { Types } from "mongoose";
 import { User, Event } from "../../../src/models";
 import { MutationUnregisterForEventByUserArgs } from "../../../src/types/generatedGraphQLTypes";
 import { connect, disconnect } from "../../../src/db";
-import { unregisterForEventByUser as unregisterForEventByUserResolver } from "../../../src/resolvers/Mutation/unregisterForEventByUser";
 import {
-  EVENT_NOT_FOUND,
-  USER_ALREADY_UNREGISTERED,
-  USER_NOT_FOUND,
+  EVENT_NOT_FOUND_MESSAGE,
+  USER_ALREADY_UNREGISTERED_MESSAGE,
+  USER_NOT_FOUND_MESSAGE,
 } from "../../../src/constants";
-import { beforeAll, afterAll, describe, it, expect } from "vitest";
+import {
+  beforeAll,
+  afterAll,
+  describe,
+  it,
+  expect,
+  vi,
+  afterEach,
+} from "vitest";
 import { testUserType } from "../../helpers/userAndOrg";
 import { createTestEvent, testEventType } from "../../helpers/events";
 
@@ -27,8 +34,18 @@ afterAll(async () => {
   await disconnect();
 });
 
+afterEach(() => {
+  vi.doUnmock("../../../src/constants");
+  vi.resetModules();
+});
+
 describe("resolvers -> Mutation -> unregisterForEventByUser", () => {
   it(`throws NotFoundError if no user exists with _id === context.userId`, async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementation((message) => `Translated ${message}`);
+
     try {
       const args: MutationUnregisterForEventByUserArgs = {
         id: "",
@@ -38,13 +55,24 @@ describe("resolvers -> Mutation -> unregisterForEventByUser", () => {
         userId: Types.ObjectId().toString(),
       };
 
+      const { unregisterForEventByUser: unregisterForEventByUserResolver } =
+        await import(
+          "../../../src/resolvers/Mutation/unregisterForEventByUser"
+        );
+
       await unregisterForEventByUserResolver?.({}, args, context);
     } catch (error: any) {
-      expect(error.message).toEqual(USER_NOT_FOUND);
+      expect(spy).toHaveBeenCalledWith(USER_NOT_FOUND_MESSAGE);
+      expect(error.message).toEqual(`Translated ${USER_NOT_FOUND_MESSAGE}`);
     }
   });
 
   it(`throws NotFoundError if no event exists with _id === args.id`, async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementation((message) => `Translated ${message}`);
+
     try {
       const args: MutationUnregisterForEventByUserArgs = {
         id: Types.ObjectId().toString(),
@@ -54,14 +82,25 @@ describe("resolvers -> Mutation -> unregisterForEventByUser", () => {
         userId: testUser!._id,
       };
 
+      const { unregisterForEventByUser: unregisterForEventByUserResolver } =
+        await import(
+          "../../../src/resolvers/Mutation/unregisterForEventByUser"
+        );
+
       await unregisterForEventByUserResolver?.({}, args, context);
     } catch (error: any) {
-      expect(error.message).toEqual(EVENT_NOT_FOUND);
+      expect(spy).toHaveBeenCalledWith(EVENT_NOT_FOUND_MESSAGE);
+      expect(error.message).toEqual(`Translated ${EVENT_NOT_FOUND_MESSAGE}`);
     }
   });
 
   it(`throws NotFoundError if current user with _id === context.userId is
   not a registrant of event with _id === args.id`, async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementation((message) => `Translated ${message}`);
+
     try {
       const args: MutationUnregisterForEventByUserArgs = {
         id: testEvent!._id,
@@ -71,9 +110,15 @@ describe("resolvers -> Mutation -> unregisterForEventByUser", () => {
         userId: testUser!._id,
       };
 
+      const { unregisterForEventByUser: unregisterForEventByUserResolver } =
+        await import(
+          "../../../src/resolvers/Mutation/unregisterForEventByUser"
+        );
+
       await unregisterForEventByUserResolver?.({}, args, context);
     } catch (error: any) {
-      expect(error.message).toEqual(USER_NOT_FOUND);
+      expect(spy).toHaveBeenCalledWith(USER_NOT_FOUND_MESSAGE);
+      expect(error.message).toEqual(`Translated ${USER_NOT_FOUND_MESSAGE}`);
     }
   });
 
@@ -113,6 +158,9 @@ describe("resolvers -> Mutation -> unregisterForEventByUser", () => {
       userId: testUser!._id,
     };
 
+    const { unregisterForEventByUser: unregisterForEventByUserResolver } =
+      await import("../../../src/resolvers/Mutation/unregisterForEventByUser");
+
     const unregisterForEventByUserPayload =
       await unregisterForEventByUserResolver?.({}, args, context);
 
@@ -127,6 +175,11 @@ describe("resolvers -> Mutation -> unregisterForEventByUser", () => {
 
   it(`throws NotFoundError if current user with _id === context.userId has
   already unregistered from the event with _id === args.id`, async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementation((message) => `Translated ${message}`);
+
     try {
       const args: MutationUnregisterForEventByUserArgs = {
         id: testEvent!._id,
@@ -136,9 +189,17 @@ describe("resolvers -> Mutation -> unregisterForEventByUser", () => {
         userId: testUser!._id,
       };
 
+      const { unregisterForEventByUser: unregisterForEventByUserResolver } =
+        await import(
+          "../../../src/resolvers/Mutation/unregisterForEventByUser"
+        );
+
       await unregisterForEventByUserResolver?.({}, args, context);
     } catch (error: any) {
-      expect(error.message).toEqual(USER_ALREADY_UNREGISTERED);
+      expect(spy).toHaveBeenCalledWith(USER_ALREADY_UNREGISTERED_MESSAGE);
+      expect(error.message).toEqual(
+        `Translated ${USER_ALREADY_UNREGISTERED_MESSAGE}`
+      );
     }
   });
 });

--- a/tests/resolvers/Mutation/updateEvent.spec.ts
+++ b/tests/resolvers/Mutation/updateEvent.spec.ts
@@ -3,13 +3,20 @@ import { Types } from "mongoose";
 import { User, Event } from "../../../src/models";
 import { MutationUpdateEventArgs } from "../../../src/types/generatedGraphQLTypes";
 import { connect, disconnect } from "../../../src/db";
-import { updateEvent as updateEventResolver } from "../../../src/resolvers/Mutation/updateEvent";
 import {
-  EVENT_NOT_FOUND,
-  USER_NOT_AUTHORIZED,
-  USER_NOT_FOUND,
+  EVENT_NOT_FOUND_MESSAGE,
+  USER_NOT_AUTHORIZED_MESSAGE,
+  USER_NOT_FOUND_MESSAGE,
 } from "../../../src/constants";
-import { beforeAll, afterAll, describe, it, expect } from "vitest";
+import {
+  beforeAll,
+  afterAll,
+  describe,
+  it,
+  expect,
+  vi,
+  afterEach,
+} from "vitest";
 import {
   createTestUserAndOrganization,
   testUserType,
@@ -53,8 +60,18 @@ afterAll(async () => {
   await disconnect();
 });
 
+afterEach(() => {
+  vi.doUnmock("../../../src/constants");
+  vi.resetModules();
+});
+
 describe("resolvers -> Mutation -> updateEvent", () => {
   it(`throws NotFoundError if no user exists with _id === context.userId`, async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementation((message) => `Translated ${message}`);
+
     try {
       const args: MutationUpdateEventArgs = {
         id: "",
@@ -64,13 +81,23 @@ describe("resolvers -> Mutation -> updateEvent", () => {
         userId: Types.ObjectId().toString(),
       };
 
+      const { updateEvent: updateEventResolver } = await import(
+        "../../../src/resolvers/Mutation/updateEvent"
+      );
+
       await updateEventResolver?.({}, args, context);
     } catch (error: any) {
-      expect(error.message).toEqual(USER_NOT_FOUND);
+      expect(spy).toHaveBeenCalledWith(USER_NOT_FOUND_MESSAGE);
+      expect(error.message).toEqual(`Translated ${USER_NOT_FOUND_MESSAGE}`);
     }
   });
 
   it(`throws NotFoundError if no event exists with _id === args.id`, async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementation((message) => `Translated ${message}`);
+
     try {
       const args: MutationUpdateEventArgs = {
         id: Types.ObjectId().toString(),
@@ -80,14 +107,24 @@ describe("resolvers -> Mutation -> updateEvent", () => {
         userId: testUser!._id,
       };
 
+      const { updateEvent: updateEventResolver } = await import(
+        "../../../src/resolvers/Mutation/updateEvent"
+      );
+
       await updateEventResolver?.({}, args, context);
     } catch (error: any) {
-      expect(error.message).toEqual(EVENT_NOT_FOUND);
+      expect(spy).toHaveBeenCalledWith(EVENT_NOT_FOUND_MESSAGE);
+      expect(error.message).toEqual(`Translated ${EVENT_NOT_FOUND_MESSAGE}`);
     }
   });
 
   it(`throws UnauthorizedError if current user with _id === context.userId is
   not an admin of event with _id === args.id`, async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementation((message) => `Translated ${message}`);
+
     try {
       const args: MutationUpdateEventArgs = {
         id: testEvent!._id,
@@ -97,9 +134,16 @@ describe("resolvers -> Mutation -> updateEvent", () => {
         userId: testUser!._id,
       };
 
+      const { updateEvent: updateEventResolver } = await import(
+        "../../../src/resolvers/Mutation/updateEvent"
+      );
+
       await updateEventResolver?.({}, args, context);
     } catch (error: any) {
-      expect(error.message).toEqual(USER_NOT_AUTHORIZED);
+      expect(spy).toHaveBeenCalledWith(USER_NOT_AUTHORIZED_MESSAGE);
+      expect(error.message).toEqual(
+        `Translated ${USER_NOT_AUTHORIZED_MESSAGE}`
+      );
     }
   });
 
@@ -149,6 +193,10 @@ describe("resolvers -> Mutation -> updateEvent", () => {
     const context = {
       userId: testUser!._id,
     };
+
+    const { updateEvent: updateEventResolver } = await import(
+      "../../../src/resolvers/Mutation/updateEvent"
+    );
 
     const updateEventPayload = await updateEventResolver?.({}, args, context);
 

--- a/tests/resolvers/Mutation/updateEventProject.spec.ts
+++ b/tests/resolvers/Mutation/updateEventProject.spec.ts
@@ -58,7 +58,7 @@ afterEach(() => {
 });
 
 describe("resolvers -> Mutation -> createEventProject", () => {
-  it("Should throw an error if the user is not found /IN_PRODUCTION=false ", async () => {
+  it("Should throw an error if the user is not found", async () => {
     const { requestContext } = await import("../../../src/libraries");
 
     const spy = vi
@@ -76,17 +76,6 @@ describe("resolvers -> Mutation -> createEventProject", () => {
         userId: Types.ObjectId().toString(),
       };
 
-      vi.doMock("../../../src/constants", async () => {
-        const actualConstants: object = await vi.importActual(
-          "../../../src/constants"
-        );
-
-        return {
-          ...actualConstants,
-          IN_PRODUCTION: false,
-        };
-      });
-
       const { updateEventProject: updateEventProjectResolver } = await import(
         "../../../src/resolvers/Mutation/updateEventProject"
       );
@@ -98,47 +87,7 @@ describe("resolvers -> Mutation -> createEventProject", () => {
     }
   });
 
-  it("Should throw an error if the user is not found /IN_PRODUCTION=true ", async () => {
-    const { requestContext } = await import("../../../src/libraries");
-
-    const spy = vi
-      .spyOn(requestContext, "translate")
-      .mockImplementationOnce((message) => `Translated ${message}`);
-
-    try {
-      const args = {
-        data: {
-          eventId: null,
-        },
-      };
-
-      const context = {
-        userId: Types.ObjectId().toString(),
-      };
-
-      vi.doMock("../../../src/constants", async () => {
-        const actualConstants: object = await vi.importActual(
-          "../../../src/constants"
-        );
-
-        return {
-          ...actualConstants,
-          IN_PRODUCTION: true,
-        };
-      });
-
-      const { updateEventProject: updateEventProjectResolver } = await import(
-        "../../../src/resolvers/Mutation/updateEventProject"
-      );
-
-      await updateEventProjectResolver?.({}, args, context);
-    } catch (error: any) {
-      expect(spy).toHaveBeenLastCalledWith(USER_NOT_FOUND_MESSAGE);
-      expect(error.message).toEqual(`Translated ${USER_NOT_FOUND_MESSAGE}`);
-    }
-  });
-
-  it("should throw an error when event is not found / IN_PRODUCTION= false", async () => {
+  it("should throw an error when event is not found", async () => {
     const { requestContext } = await import("../../../src/libraries");
 
     const spy = vi
@@ -154,17 +103,6 @@ describe("resolvers -> Mutation -> createEventProject", () => {
         userId: testUser!.id,
       };
 
-      vi.doMock("../../../src/constants", async () => {
-        const actualConstants: object = await vi.importActual(
-          "../../../src/constants"
-        );
-
-        return {
-          ...actualConstants,
-          IN_PRODUCTION: false,
-        };
-      });
-
       const { updateEventProject: updateEventProjectResolver } = await import(
         "../../../src/resolvers/Mutation/updateEventProject"
       );
@@ -178,47 +116,7 @@ describe("resolvers -> Mutation -> createEventProject", () => {
     }
   });
 
-  it("should throw an error when event is not found / IN_PRODUCTION=true", async () => {
-    const { requestContext } = await import("../../../src/libraries");
-
-    const spy = vi
-      .spyOn(requestContext, "translate")
-      .mockImplementationOnce((message) => `Translated ${message}`);
-
-    try {
-      const args = {
-        id: Types.ObjectId().toString(),
-      };
-
-      const context = {
-        userId: testUser!.id,
-      };
-
-      vi.doMock("../../../src/constants", async () => {
-        const actualConstants: object = await vi.importActual(
-          "../../../src/constants"
-        );
-
-        return {
-          ...actualConstants,
-          IN_PRODUCTION: true,
-        };
-      });
-
-      const { updateEventProject: updateEventProjectResolver } = await import(
-        "../../../src/resolvers/Mutation/updateEventProject"
-      );
-
-      await updateEventProjectResolver?.({}, args, context);
-    } catch (error: any) {
-      expect(spy).toHaveBeenLastCalledWith(EVENT_PROJECT_NOT_FOUND_MESSAGE);
-      expect(error.message).toEqual(
-        `Translated ${EVENT_PROJECT_NOT_FOUND_MESSAGE}`
-      );
-    }
-  });
-
-  it("should throw an error if user is not admin of the event // IN_PRODUCTION=false", async () => {
+  it("should throw an error if user is not admin of the event", async () => {
     const { requestContext } = await import("../../../src/libraries");
 
     const spy = vi
@@ -233,57 +131,6 @@ describe("resolvers -> Mutation -> createEventProject", () => {
       const context = {
         userId: testUser!._id,
       };
-
-      vi.doMock("../../../src/constants", async () => {
-        const actualConstants: object = await vi.importActual(
-          "../../../src/constants"
-        );
-
-        return {
-          ...actualConstants,
-          IN_PRODUCTION: false,
-        };
-      });
-
-      const { updateEventProject: updateEventProjectResolver } = await import(
-        "../../../src/resolvers/Mutation/updateEventProject"
-      );
-
-      await updateEventProjectResolver?.({}, args, context);
-    } catch (error: any) {
-      expect(spy).toHaveBeenLastCalledWith(USER_NOT_AUTHORIZED_MESSAGE);
-      expect(error.message).toEqual(
-        `Translated ${USER_NOT_AUTHORIZED_MESSAGE}`
-      );
-    }
-  });
-
-  it("should throw an error if user is not admin of the event // IN_PRODUCTION=true", async () => {
-    const { requestContext } = await import("../../../src/libraries");
-
-    const spy = vi
-      .spyOn(requestContext, "translate")
-      .mockImplementationOnce((message) => `Translated ${message}`);
-
-    try {
-      const args = {
-        id: testEventProject.id.toString(),
-      };
-
-      const context = {
-        userId: testUser!._id,
-      };
-
-      vi.doMock("../../../src/constants", async () => {
-        const actualConstants: object = await vi.importActual(
-          "../../../src/constants"
-        );
-
-        return {
-          ...actualConstants,
-          IN_PRODUCTION: true,
-        };
-      });
 
       const { updateEventProject: updateEventProjectResolver } = await import(
         "../../../src/resolvers/Mutation/updateEventProject"

--- a/tests/resolvers/Mutation/updateEventProject.spec.ts
+++ b/tests/resolvers/Mutation/updateEventProject.spec.ts
@@ -18,14 +18,10 @@ import {
   afterEach,
 } from "vitest";
 import {
-  USER_NOT_FOUND,
-  USER_NOT_AUTHORIZED,
-  EVENT_PROJECT_NOT_FOUND,
   EVENT_PROJECT_NOT_FOUND_MESSAGE,
   USER_NOT_FOUND_MESSAGE,
   USER_NOT_AUTHORIZED_MESSAGE,
 } from "../../../src/constants";
-import { updateEventProject } from "../../../src/resolvers/Mutation/updateEventProject";
 import { createTestUserFunc, testUserType } from "../../helpers/user";
 import { createTestEvent, testEventType } from "../../helpers/events";
 let testUser: testUserType;
@@ -56,6 +52,11 @@ afterAll(async () => {
   await disconnect();
 });
 
+afterEach(() => {
+  vi.doUnmock("../../../src/constants");
+  vi.resetModules();
+});
+
 describe("resolvers -> Mutation -> createEventProject", () => {
   afterEach(() => {
     vi.doUnmock("../../../src/constants");
@@ -63,6 +64,12 @@ describe("resolvers -> Mutation -> createEventProject", () => {
   });
 
   it("Should throw an error if the user is not found /IN_PRODUCTION=false ", async () => {
+    const { requestContext } = await import("../../../src/libraries");
+
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementationOnce((message) => `Translated ${message}`);
+
     try {
       const args = {
         data: {
@@ -73,19 +80,26 @@ describe("resolvers -> Mutation -> createEventProject", () => {
       const context = {
         userId: Types.ObjectId().toString(),
       };
+
       vi.doMock("../../../src/constants", async () => {
         const actualConstants: object = await vi.importActual(
           "../../../src/constants"
         );
+
         return {
           ...actualConstants,
           IN_PRODUCTION: false,
         };
       });
 
-      await updateEventProject?.({}, args, context);
+      const { updateEventProject: updateEventProjectResolver } = await import(
+        "../../../src/resolvers/Mutation/updateEventProject"
+      );
+
+      await updateEventProjectResolver?.({}, args, context);
     } catch (error: any) {
-      expect(error.message).toBe(USER_NOT_FOUND);
+      expect(spy).toHaveBeenLastCalledWith(USER_NOT_FOUND_MESSAGE);
+      expect(error.message).toEqual(`Translated ${USER_NOT_FOUND_MESSAGE}`);
     }
   });
 
@@ -106,18 +120,22 @@ describe("resolvers -> Mutation -> createEventProject", () => {
       const context = {
         userId: Types.ObjectId().toString(),
       };
+
       vi.doMock("../../../src/constants", async () => {
         const actualConstants: object = await vi.importActual(
           "../../../src/constants"
         );
+
         return {
           ...actualConstants,
           IN_PRODUCTION: true,
         };
       });
+
       const { updateEventProject: updateEventProjectResolver } = await import(
         "../../../src/resolvers/Mutation/updateEventProject"
       );
+
       await updateEventProjectResolver?.({}, args, context);
     } catch (error: any) {
       expect(spy).toHaveBeenLastCalledWith(USER_NOT_FOUND_MESSAGE);
@@ -126,6 +144,12 @@ describe("resolvers -> Mutation -> createEventProject", () => {
   });
 
   it("should throw an error when event is not found / IN_PRODUCTION= false", async () => {
+    const { requestContext } = await import("../../../src/libraries");
+
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementationOnce((message) => `Translated ${message}`);
+
     try {
       const args = {
         id: Types.ObjectId().toString(),
@@ -134,19 +158,28 @@ describe("resolvers -> Mutation -> createEventProject", () => {
       const context = {
         userId: testUser!.id,
       };
+
       vi.doMock("../../../src/constants", async () => {
         const actualConstants: object = await vi.importActual(
           "../../../src/constants"
         );
+
         return {
           ...actualConstants,
           IN_PRODUCTION: false,
         };
       });
 
-      await updateEventProject?.({}, args, context);
+      const { updateEventProject: updateEventProjectResolver } = await import(
+        "../../../src/resolvers/Mutation/updateEventProject"
+      );
+
+      await updateEventProjectResolver?.({}, args, context);
     } catch (error: any) {
-      expect(error.message).toBe(EVENT_PROJECT_NOT_FOUND);
+      expect(spy).toHaveBeenLastCalledWith(EVENT_PROJECT_NOT_FOUND_MESSAGE);
+      expect(error.message).toEqual(
+        `Translated ${EVENT_PROJECT_NOT_FOUND_MESSAGE}`
+      );
     }
   });
 
@@ -170,14 +203,17 @@ describe("resolvers -> Mutation -> createEventProject", () => {
         const actualConstants: object = await vi.importActual(
           "../../../src/constants"
         );
+
         return {
           ...actualConstants,
           IN_PRODUCTION: true,
         };
       });
+
       const { updateEventProject: updateEventProjectResolver } = await import(
         "../../../src/resolvers/Mutation/updateEventProject"
       );
+
       await updateEventProjectResolver?.({}, args, context);
     } catch (error: any) {
       expect(spy).toHaveBeenLastCalledWith(EVENT_PROJECT_NOT_FOUND_MESSAGE);
@@ -188,17 +224,42 @@ describe("resolvers -> Mutation -> createEventProject", () => {
   });
 
   it("should throw an error if user is not admin of the event // IN_PRODUCTION=false", async () => {
+    const { requestContext } = await import("../../../src/libraries");
+
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementationOnce((message) => `Translated ${message}`);
+
     try {
       const args = {
         id: testEventProject.id.toString(),
       };
+
       const context = {
         userId: testUser!._id,
       };
 
-      await updateEventProject?.({}, args, context);
+      vi.doMock("../../../src/constants", async () => {
+        const actualConstants: object = await vi.importActual(
+          "../../../src/constants"
+        );
+
+        return {
+          ...actualConstants,
+          IN_PRODUCTION: false,
+        };
+      });
+
+      const { updateEventProject: updateEventProjectResolver } = await import(
+        "../../../src/resolvers/Mutation/updateEventProject"
+      );
+
+      await updateEventProjectResolver?.({}, args, context);
     } catch (error: any) {
-      expect(error.message).toBe(USER_NOT_AUTHORIZED);
+      expect(spy).toHaveBeenLastCalledWith(USER_NOT_AUTHORIZED_MESSAGE);
+      expect(error.message).toEqual(
+        `Translated ${USER_NOT_AUTHORIZED_MESSAGE}`
+      );
     }
   });
 
@@ -213,21 +274,26 @@ describe("resolvers -> Mutation -> createEventProject", () => {
       const args = {
         id: testEventProject.id.toString(),
       };
+
       const context = {
         userId: testUser!._id,
       };
+
       vi.doMock("../../../src/constants", async () => {
         const actualConstants: object = await vi.importActual(
           "../../../src/constants"
         );
+
         return {
           ...actualConstants,
           IN_PRODUCTION: true,
         };
       });
+
       const { updateEventProject: updateEventProjectResolver } = await import(
         "../../../src/resolvers/Mutation/updateEventProject"
       );
+
       await updateEventProjectResolver?.({}, args, context);
     } catch (error: any) {
       expect(spy).toHaveBeenLastCalledWith(USER_NOT_AUTHORIZED_MESSAGE);
@@ -245,11 +311,16 @@ describe("resolvers -> Mutation -> createEventProject", () => {
       },
       id: testEventProject.id.toString(),
     };
+
     const context = {
       userId: testAdminUser!._id,
     };
 
-    const updatedEventProjectObj = await updateEventProject?.(
+    const { updateEventProject: updateEventProjectResolver } = await import(
+      "../../../src/resolvers/Mutation/updateEventProject"
+    );
+
+    const updatedEventProjectObj = await updateEventProjectResolver?.(
       {},
       args,
       context

--- a/tests/resolvers/Mutation/updateEventProject.spec.ts
+++ b/tests/resolvers/Mutation/updateEventProject.spec.ts
@@ -58,11 +58,6 @@ afterEach(() => {
 });
 
 describe("resolvers -> Mutation -> createEventProject", () => {
-  afterEach(() => {
-    vi.doUnmock("../../../src/constants");
-    vi.resetModules();
-  });
-
   it("Should throw an error if the user is not found /IN_PRODUCTION=false ", async () => {
     const { requestContext } = await import("../../../src/libraries");
 

--- a/tests/resolvers/Mutation/updateTask.spec.ts
+++ b/tests/resolvers/Mutation/updateTask.spec.ts
@@ -5,6 +5,7 @@ import { MutationUpdateTaskArgs } from "../../../src/types/generatedGraphQLTypes
 import { connect, disconnect } from "../../../src/db";
 import { updateTask as updateTaskResolver } from "../../../src/resolvers/Mutation/updateTask";
 import {
+  TASK_NOT_FOUND_MESSAGE,
   USER_NOT_AUTHORIZED_MESSAGE,
   USER_NOT_FOUND_MESSAGE,
 } from "../../../src/constants";
@@ -63,6 +64,7 @@ describe("resolvers -> Mutation -> updateTask", () => {
         id: testUser?.id,
         data: {},
       };
+
       const context = { userId: Types.ObjectId().toString() };
 
       const { updateTask: updateTaskResolverNotFoundError } = await import(
@@ -88,6 +90,7 @@ describe("resolvers -> Mutation -> updateTask", () => {
         id: Types.ObjectId().toString(),
         data: {},
       };
+
       const context = {
         userId: testUser?.id,
       };
@@ -98,8 +101,8 @@ describe("resolvers -> Mutation -> updateTask", () => {
 
       await updateTaskResolverNotFoundError?.({}, args, context);
     } catch (error: any) {
-      expect(error.message).toEqual(`Translated task.notFound`);
-      expect(spy).toHaveBeenLastCalledWith("task.notFound");
+      expect(spy).toHaveBeenLastCalledWith(TASK_NOT_FOUND_MESSAGE);
+      expect(error.message).toEqual(`Translated ${TASK_NOT_FOUND_MESSAGE}`);
     }
   });
 

--- a/tests/resolvers/Mutation/updateUserProfile.spec.ts
+++ b/tests/resolvers/Mutation/updateUserProfile.spec.ts
@@ -71,7 +71,7 @@ describe("resolvers -> Mutation -> updateUserProfile", () => {
     }
   });
 
-  it(`throws NotFoundError if no user exists with _id === context.userId // IN_PRODUCTION=true`, async () => {
+  it(`throws NotFoundError if no user exists with _id === context.userId`, async () => {
     const { requestContext } = await import("../../../src/libraries");
 
     const spy = vi
@@ -87,17 +87,6 @@ describe("resolvers -> Mutation -> updateUserProfile", () => {
         userId: Types.ObjectId().toString(),
       };
 
-      vi.doMock("../../../src/constants", async () => {
-        const actualConstants: object = await vi.importActual(
-          "../../../src/constants"
-        );
-
-        return {
-          ...actualConstants,
-          IN_PRODUCTION: true,
-        };
-      });
-
       const { updateUserProfile: updateUserProfileResolverUserError } =
         await import("../../../src/resolvers/Mutation/updateUserProfile");
 
@@ -108,7 +97,7 @@ describe("resolvers -> Mutation -> updateUserProfile", () => {
     }
   });
 
-  it(`throws ConflictError if args.data.email is already registered for another user'`, async () => {
+  it(`throws ConflictError if args.data.email is already registered for another user`, async () => {
     const { requestContext } = await import("../../../src/libraries");
 
     const spy = vi
@@ -139,7 +128,7 @@ describe("resolvers -> Mutation -> updateUserProfile", () => {
     }
   });
 
-  it(`throws ConflictError if args.data.email is already registered for another user'// IN_PRODUCTION=true `, async () => {
+  it(`throws ConflictError if args.data.email is already registered for another user`, async () => {
     const { requestContext } = await import("../../../src/libraries");
 
     const spy = vi
@@ -156,17 +145,6 @@ describe("resolvers -> Mutation -> updateUserProfile", () => {
       const context = {
         userId: testUser._id,
       };
-
-      vi.doMock("../../../src/constants", async () => {
-        const actualConstants: object = await vi.importActual(
-          "../../../src/constants"
-        );
-
-        return {
-          ...actualConstants,
-          IN_PRODUCTION: true,
-        };
-      });
 
       const { updateUserProfile: updateUserProfileResolverEmailError } =
         await import("../../../src/resolvers/Mutation/updateUserProfile");

--- a/tests/resolvers/Mutation/updateUserProfile.spec.ts
+++ b/tests/resolvers/Mutation/updateUserProfile.spec.ts
@@ -4,7 +4,11 @@ import { Interface_User, User } from "../../../src/models";
 import { MutationUpdateUserProfileArgs } from "../../../src/types/generatedGraphQLTypes";
 import { connect, disconnect } from "../../../src/db";
 import { updateUserProfile as updateUserProfileResolver } from "../../../src/resolvers/Mutation/updateUserProfile";
-import { USER_NOT_FOUND, USER_NOT_FOUND_MESSAGE } from "../../../src/constants";
+import {
+  EMAIL_ALREADY_EXISTS_MESSAGE,
+  USER_NOT_FOUND,
+  USER_NOT_FOUND_MESSAGE,
+} from "../../../src/constants";
 import { nanoid } from "nanoid";
 import {
   beforeAll,
@@ -140,8 +144,10 @@ describe("resolvers -> Mutation -> updateUserProfile", () => {
         await import("../../../src/resolvers/Mutation/updateUserProfile");
       await updateUserProfileResolverEmailError?.({}, args, context);
     } catch (error: any) {
-      expect(spy).toHaveBeenLastCalledWith("email.alreadyExists");
-      expect(error.message).toEqual(`Translated ${"email.alreadyExists"}`);
+      expect(spy).toHaveBeenLastCalledWith(EMAIL_ALREADY_EXISTS_MESSAGE);
+      expect(error.message).toEqual(
+        `Translated ${EMAIL_ALREADY_EXISTS_MESSAGE}`
+      );
     }
   });
 

--- a/tests/resolvers/Mutation/updateUserType.spec.ts
+++ b/tests/resolvers/Mutation/updateUserType.spec.ts
@@ -38,11 +38,6 @@ afterEach(() => {
 
 describe("resolvers -> Mutation -> updateUserType", () => {
   it(`throws UnauthorizedError if user with _id === context.userId is not a SUPERADMIN`, async () => {
-    const { requestContext } = await import("../../../src/libraries");
-    const spy = vi
-      .spyOn(requestContext, "translate")
-      .mockImplementation((message) => `Translated ${message}`);
-
     try {
       const args: MutationUpdateUserTypeArgs = {
         data: {},

--- a/tests/resolvers/Mutation/updateUserType.spec.ts
+++ b/tests/resolvers/Mutation/updateUserType.spec.ts
@@ -3,9 +3,19 @@ import { Types } from "mongoose";
 import { User } from "../../../src/models";
 import { MutationUpdateUserTypeArgs } from "../../../src/types/generatedGraphQLTypes";
 import { connect, disconnect } from "../../../src/db";
-import { updateUserType as updateUserTypeResolver } from "../../../src/resolvers/Mutation/updateUserType";
-import { USER_NOT_AUTHORIZED, USER_NOT_FOUND } from "../../../src/constants";
-import { beforeAll, afterAll, describe, it, expect } from "vitest";
+import {
+  USER_NOT_AUTHORIZED,
+  USER_NOT_FOUND_MESSAGE,
+} from "../../../src/constants";
+import {
+  beforeAll,
+  afterAll,
+  afterEach,
+  describe,
+  it,
+  vi,
+  expect,
+} from "vitest";
 import { createTestUserFunc, testUserType } from "../../helpers/user";
 
 let testUsers: testUserType[];
@@ -21,8 +31,18 @@ afterAll(async () => {
   await disconnect();
 });
 
+afterEach(() => {
+  vi.doUnmock("../../../src/constants");
+  vi.resetModules();
+});
+
 describe("resolvers -> Mutation -> updateUserType", () => {
   it(`throws UnauthorizedError if user with _id === context.userId is not a SUPERADMIN`, async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementation((message) => `Translated ${message}`);
+
     try {
       const args: MutationUpdateUserTypeArgs = {
         data: {},
@@ -32,6 +52,10 @@ describe("resolvers -> Mutation -> updateUserType", () => {
         userId: testUsers[0]!._id,
       };
 
+      const { updateUserType: updateUserTypeResolver } = await import(
+        "../../../src/resolvers/Mutation/updateUserType"
+      );
+
       await updateUserTypeResolver?.({}, args, context);
     } catch (error: any) {
       expect(error.message).toEqual(USER_NOT_AUTHORIZED);
@@ -39,6 +63,11 @@ describe("resolvers -> Mutation -> updateUserType", () => {
   });
 
   it(`throws NotFoundError if no user exists with _id === args.data.id`, async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementation((message) => `Translated ${message}`);
+
     try {
       await User.updateOne(
         {
@@ -55,11 +84,17 @@ describe("resolvers -> Mutation -> updateUserType", () => {
       const args: MutationUpdateUserTypeArgs = {
         data: { id: Types.ObjectId().toString() },
       };
+
       const context = { userId: testUsers[0]!._id };
+
+      const { updateUserType: updateUserTypeResolver } = await import(
+        "../../../src/resolvers/Mutation/updateUserType"
+      );
 
       await updateUserTypeResolver?.({}, args, context);
     } catch (error: any) {
-      expect(error.message).toEqual(USER_NOT_FOUND);
+      expect(spy).toHaveBeenCalledWith(USER_NOT_FOUND_MESSAGE);
+      expect(error.message).toEqual(`Translated ${USER_NOT_FOUND_MESSAGE}`);
     }
   });
 
@@ -68,6 +103,10 @@ describe("resolvers -> Mutation -> updateUserType", () => {
       data: { id: testUsers[1]!._id, userType: "BLOCKED" },
     };
     const context = { userId: testUsers[0]!._id };
+
+    const { updateUserType: updateUserTypeResolver } = await import(
+      "../../../src/resolvers/Mutation/updateUserType"
+    );
 
     const updateUserTypePayload = await updateUserTypeResolver?.(
       {},


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Refactoring

**Issue Number:** 

Fixes #1003 

**Did you add tests for your changes?**

Not Applicable 

**Snapshots/Videos:**

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

Not Relevant 

**Summary**

- This PR refactors file 61 to 70
- Removing the conditional check `process.env !== "PRODUCTION"` for `requestContext.translate()`
- Also added new constants where needed

**Does this PR introduce a breaking change?**

No

**Other information**

All tests cases are passing as shown below -

<img width="653" alt="Screenshot 2023-02-10 at 7 55 56 PM" src="https://user-images.githubusercontent.com/28570857/218115867-1213f5d4-1d1a-4b0e-9f75-ef1bea7b7931.png">


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes