### PR TITLE
Fix createPost mutation [Fixes #1102]

### DIFF
--- a/src/resolvers/Mutation/createPost.ts
+++ b/src/resolvers/Mutation/createPost.ts
@@ -90,7 +90,7 @@ export const createPost: MutationResolvers["createPost"] = async (
     ...args.data,
     creator: context.userId,
     organization: args.data.organizationId,
-    imageUrl: args.file ? uploadImageObj?.newImagePath : "",
+    imageUrl: args.file ? uploadImageObj?.newImagePath : null,
   });
 
   // Returns createdPost.


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
This PR changes the default value of imageUrl from ```""``` to ```null```. The ```Url``` GraphQL-Scaler was introduced few days back, which does not accept a string argument in place of a Url field.
This error was causing the postsByOrganization query to fail since Url scaler was not able to parse the ```""``` empty string.
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #1102 

**Did you add tests for your changes?**
Not required.
<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**
![image](https://user-images.githubusercontent.com/94157520/222474663-521fcfb6-c3c8-43fb-bf72-f7fb21bfd9f9.png)
.
Page is working fine now after adding a new post.
<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
Not required.
<!--Add link to Talawa-Docs.-->

**Summary**
This PR changes the default value of imageUrl from ```""``` to ```null```. The ```Url``` GraphQL-Scaler was introduced few days back, which does not accept a string argument in place of a Url field.
This error was causing the postsByOrganization query to fail since Url scaler was not able to parse the ```""``` empty string.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
No
<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->
