### PR TITLE
Add dynamic base url support for images to work in production environments [Fixes #1131]

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -212,8 +212,6 @@ export const EMAIL_ALREADY_EXISTS_CODE = "email.alreadyExists";
 export const EMAIL_ALREADY_EXISTS_MESSAGE = "email.alreadyExists";
 export const EMAIL_ALREADY_EXISTS_PARAM = "email";
 
-export const BASE_URL = `http://localhost:${process.env.port || 4000}/`;
-
 export const ACCESS_TOKEN_SECRET = process.env.ACCESS_TOKEN_SECRET;
 
 export const REFRESH_TOKEN_SECRET = process.env.REFRESH_TOKEN_SECRET;

--- a/src/libraries/requestUrl.ts
+++ b/src/libraries/requestUrl.ts
@@ -1,0 +1,7 @@
+// Returns current server's domain on passing the context object.
+
+export function requestUrl(context: any) {
+  const { req } = context;
+  const fullUrl: string = req.protocol + "://" + req.get("host") + "/";
+  return fullUrl;
+}

--- a/src/libraries/requestUrl.ts
+++ b/src/libraries/requestUrl.ts
@@ -1,7 +1,0 @@
-// Returns current server's domain on passing the context object.
-
-export function requestUrl(context: any) {
-  const { req } = context;
-  const fullUrl: string = req.protocol + "://" + req.get("host") + "/";
-  return fullUrl;
-}

--- a/src/resolvers/Organization/image.ts
+++ b/src/resolvers/Organization/image.ts
@@ -1,5 +1,4 @@
-// requestUrl() is a function which returns current server's domain on passing the context object.
-import { requestUrl } from "../../libraries/requestUrl";
+// Context object contains an apiRootUrl for mapping DNS request of server to its domain, for example: http:abcd.com/
 import { OrganizationResolvers } from "../../types/generatedGraphQLTypes";
 
 export const image: OrganizationResolvers["image"] = async (
@@ -8,7 +7,7 @@ export const image: OrganizationResolvers["image"] = async (
   context
 ) => {
   if (parent!.image) {
-    return `${requestUrl(context)}${parent!.image}`;
+    return `${context.apiRootUrl}${parent!.image}`;
   }
   return null;
 };

--- a/src/resolvers/Organization/image.ts
+++ b/src/resolvers/Organization/image.ts
@@ -1,10 +1,14 @@
-// BASE_URL is the url on which the server is running, it converts the relative path to absolute path
-import { BASE_URL } from "../../constants";
+// requestUrl() is a function which returns current server's domain on passing the context object.
+import { requestUrl } from "../../libraries/requestUrl";
 import { OrganizationResolvers } from "../../types/generatedGraphQLTypes";
 
-export const image: OrganizationResolvers["image"] = async (parent) => {
+export const image: OrganizationResolvers["image"] = async (
+  parent,
+  _args,
+  context
+) => {
   if (parent!.image) {
-    return `${BASE_URL}${parent!.image}`;
+    return `${requestUrl(context)}${parent!.image}`;
   }
   return null;
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -102,6 +102,15 @@ const apolloServer = new ApolloServer({
     role: RoleAuthorizationDirective,
   },
   context: ({ req, res, connection }) => {
+    /**
+     * The apiRootUrl for serving static files.
+     * This is constructed by extracting the protocol and host information from the `req` object.
+     * It is passed to the context object and can be accessed by all the resolver functions.
+     * Resolver functions can use this to construct absolute URLs for serving static files.
+     * For example, http://testDomain.com/ is apiRootUrl for a server with testDomain.com as Domain Name
+     * with no SSL certificate (http://)
+     * In local environment, apiRootUrl will be http://localhost:{port}/
+     */
     const apiRootUrl = `${req.protocol}://${req.get("host")}/`;
     if (connection) {
       return {

--- a/src/server.ts
+++ b/src/server.ts
@@ -102,12 +102,14 @@ const apolloServer = new ApolloServer({
     role: RoleAuthorizationDirective,
   },
   context: ({ req, res, connection }) => {
+    const apiRootUrl = `${req.protocol}://${req.get("host")}/`;
     if (connection) {
       return {
         ...connection,
         pubsub,
         res,
         req,
+        apiRootUrl,
       };
     } else {
       return {
@@ -115,6 +117,7 @@ const apolloServer = new ApolloServer({
         pubsub,
         res,
         req,
+        apiRootUrl,
       };
     }
   },

--- a/tests/resolvers/Organization/image.spec.ts
+++ b/tests/resolvers/Organization/image.spec.ts
@@ -9,7 +9,6 @@ import {
   it,
   vi,
 } from "vitest";
-import { BASE_URL } from "../../../src/constants";
 import { Organization } from "../../../src/models";
 import { connect, disconnect } from "../../helpers/db";
 import {
@@ -59,13 +58,21 @@ describe("resolvers -> Organization -> image", () => {
     const { image: imageResolver } = await import(
       "../../../src/resolvers/Organization/image"
     );
-    const creatorPayload = await imageResolver?.(parent, {}, {});
+    const context = {
+      req: {
+        protocol: "http",
+        get: (_param: string) => {
+          return "testdomain.com";
+        },
+      },
+    };
+    const creatorPayload = await imageResolver?.(parent, {}, context);
 
     const org = await Organization.findOne({
       _id: parent._id,
     });
 
-    expect(creatorPayload).toEqual(BASE_URL + org?.image);
+    expect(creatorPayload).toEqual("http://testdomain.com/" + org?.image);
   });
   it(`returns null if the image is null in the organization`, async () => {
     testOrganization = await Organization.findOneAndUpdate(

--- a/tests/resolvers/Organization/image.spec.ts
+++ b/tests/resolvers/Organization/image.spec.ts
@@ -59,12 +59,7 @@ describe("resolvers -> Organization -> image", () => {
       "../../../src/resolvers/Organization/image"
     );
     const context = {
-      req: {
-        protocol: "http",
-        get: (_param: string) => {
-          return "testdomain.com";
-        },
-      },
+      apiRootUrl: "http://testdomain.com",
     };
     const creatorPayload = await imageResolver?.(parent, {}, context);
 
@@ -72,7 +67,7 @@ describe("resolvers -> Organization -> image", () => {
       _id: parent._id,
     });
 
-    expect(creatorPayload).toEqual("http://testdomain.com/" + org?.image);
+    expect(creatorPayload).toEqual("http://testdomain.com" + org?.image);
   });
   it(`returns null if the image is null in the organization`, async () => {
     testOrganization = await Organization.findOneAndUpdate(


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
This PR adds the dynamic apiRootUrl into context of all requests which returns a url based on the current server's hostname and protocol.
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #1131 

**Did you add tests for your changes?**
Yes
<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**
Not Relevant
<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
Not Required
<!--Add link to Talawa-Docs.-->

**Summary**
This PR adds the dynamic apiRootUrl into context of all requests which returns a url based on the current server's hostname and protocol.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
This makes the current Talawa-API images logic to work in remote production or development servers.
<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->
