### PR TITLE
Populating organizationsBlockedBy when query called by Admin/Superadmin

### DIFF
--- a/src/resolvers/Query/users.ts
+++ b/src/resolvers/Query/users.ts
@@ -29,7 +29,7 @@ export const users: QueryResolvers["users"] = async (
 
   if (!queryUser) {
     throw new errors.UnauthenticatedError(
-      UNAUTHENTICATED_ERROR.MESSAGE,
+      requestContext.translate(UNAUTHENTICATED_ERROR.MESSAGE),
       UNAUTHENTICATED_ERROR.CODE,
       UNAUTHENTICATED_ERROR.PARAM
     );

--- a/src/resolvers/Query/users.ts
+++ b/src/resolvers/Query/users.ts
@@ -23,6 +23,10 @@ export const users: QueryResolvers["users"] = async (
   const inputArg = getInputArg(args.where);
   const sort = getSort(args.orderBy);
 
+  const queryUser = await User.findOne({
+    _id: context.userId,
+  });
+
   const users = await User.find(inputArg)
     .sort(sort)
     .select(["-password"])
@@ -32,6 +36,7 @@ export const users: QueryResolvers["users"] = async (
     .populate("registeredEvents")
     .populate("eventAdmin")
     .populate("adminFor")
+    .populate("organizationsBlockedBy")
     .lean();
 
   if (!users[0]) {
@@ -45,7 +50,11 @@ export const users: QueryResolvers["users"] = async (
       return {
         ...user,
         image: user.image ? `${context.apiRootUrl}${user.image}` : null,
-        organizationsBlockedBy: [],
+        organizationsBlockedBy:
+          queryUser?.userType === "ADMIN" ||
+          queryUser?.userType === "SUPERADMIN"
+            ? user.organizationsBlockedBy
+            : [],
       };
     });
 };

--- a/tests/resolvers/Query/users.spec.ts
+++ b/tests/resolvers/Query/users.spec.ts
@@ -255,6 +255,7 @@ describe("resolvers -> Query -> users", () => {
       users = users.map((user) => ({
         ...user,
         organizationsBlockedBy: [],
+        image: null,
       }));
 
       expect(usersPayload).toEqual(users);
@@ -275,7 +276,7 @@ describe("resolvers -> Query -> users", () => {
         userId: testUsers[3]._id,
       });
 
-      const users = await User.find({
+      let users = await User.find({
         _id: testUsers[1].id,
       })
         .sort(sort)
@@ -288,6 +289,11 @@ describe("resolvers -> Query -> users", () => {
         .populate("adminFor")
         .populate("organizationsBlockedBy")
         .lean();
+
+      users = users.map((user) => ({
+        ...user,
+        image: null,
+      }));
 
       expect(usersPayload).toEqual(users);
     });
@@ -307,7 +313,7 @@ describe("resolvers -> Query -> users", () => {
         userId: testUsers[4]._id,
       });
 
-      const users = await User.find({
+      let users = await User.find({
         _id: testUsers[1].id,
       })
         .sort(sort)
@@ -320,6 +326,11 @@ describe("resolvers -> Query -> users", () => {
         .populate("adminFor")
         .populate("organizationsBlockedBy")
         .lean();
+
+      users = users.map((user) => ({
+        ...user,
+        image: null,
+      }));
 
       expect(usersPayload).toEqual(users);
     });

--- a/tests/resolvers/Query/users.spec.ts
+++ b/tests/resolvers/Query/users.spec.ts
@@ -882,6 +882,7 @@ describe("resolvers -> Query -> users", () => {
 
     const context = {
       apiRootUrl: BASE_URL,
+      userId: testUsers[0]._id,
     };
 
     const usersPayload = await usersResolver?.({}, args, context);


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Issue Number:**

Fixes #1186

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

NA

**If relevant, did you update the documentation?**

Not Relevant

**Summary**

The problem -

- The User and Users queries have organizationsBlockedBy set to an empty array
- This is done on purpose so that users are not able to see which organizations they've been blocked by
- This breaks the Block/Unblock functionality in Talawa Admin

Solution -

- Now, the user needs to be authenticated to call `USERS` query
- If the user role is `ADMIN` or `SUPERADMIN`, then we are populating the `organizationsBlockedBy` field
- Otherwise returning `[]`
- We are also checking if the user is querying on themselves, and returning `[]` in that case

**Does this PR introduce a breaking change?**

No

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes