### PR TITLE
feature: add graphql connection object factory function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,6 @@
         "concurrently": "^7.5.0",
         "eslint": "^8.26.0",
         "eslint-config-prettier": "^8.5.0",
-        "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-tsdoc": "^0.2.17",
         "husky": "^8.0.3",
         "prettier": "^2.7.1",
@@ -7014,27 +7013,6 @@
         "eslint": ">=7.0.0"
       }
     },
-    "node_modules/eslint-plugin-prettier": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
-      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
-      "dev": true,
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.28.0",
-        "prettier": ">=2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint-config-prettier": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/eslint-plugin-tsdoc": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.2.17.tgz",
@@ -7379,12 +7357,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
-    "node_modules/fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
-      "dev": true
     },
     "node_modules/fast-glob": {
       "version": "3.2.12",
@@ -11384,18 +11356,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "dev": true,
-      "dependencies": {
-        "fast-diff": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -19234,15 +19194,6 @@
       "dev": true,
       "requires": {}
     },
-    "eslint-plugin-prettier": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
-      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
-      "dev": true,
-      "requires": {
-        "prettier-linter-helpers": "^1.0.0"
-      }
-    },
     "eslint-plugin-tsdoc": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.2.17.tgz",
@@ -19461,12 +19412,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
-    "fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
-      "dev": true
     },
     "fast-glob": {
       "version": "3.2.12",
@@ -22466,15 +22411,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
       "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
       "dev": true
-    },
-    "prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "dev": true,
-      "requires": {
-        "fast-diff": "^1.1.2"
-      }
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/src/utilities/graphqlConnectionFactory.ts
+++ b/src/utilities/graphqlConnectionFactory.ts
@@ -1,0 +1,38 @@
+import { ConnectionPageInfo } from "../types/generatedGraphQLTypes";
+
+interface ConnectionEdge<T> {
+  cursor: string;
+  node: T;
+}
+
+interface Connection<T> {
+  edges?: Array<ConnectionEdge<T> | null | undefined>;
+  pageInfo: ConnectionPageInfo;
+}
+
+/*
+This is a factory function to quickly create a graphql
+connection object. The function accepts a generic type
+'T' which is used to reference the type of node that this
+connection and it's edges will reference. A node is
+a business object which can be uniquely identified in graphql.
+For example `User`, `Organization`, `Event`, `Post` etc.
+All of these objects are viable candiates for a node and
+can be paginated using graphql connections. The default object
+returned by this function represents a connection which has no
+data at all, i.e., the table/collection for that node(along with
+other constraints like filters if any) is completely empty in database.
+This object will need to be transformed according to different
+logic inside resolvers.
+*/
+export function graphqlConnectionFactory<T>(): Connection<T> {
+  return {
+    edges: [],
+    pageInfo: {
+      endCursor: null,
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: null,
+    },
+  };
+}

--- a/tests/utilities/graphqlConnectionFactory.spec.ts
+++ b/tests/utilities/graphqlConnectionFactory.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { graphqlConnectionFactory } from "../../src/utilities/graphqlConnectionFactory";
+
+describe("utilities -> graphqlConnectionFactory", () => {
+  it(`Returns a connection object with default/pre-defined fields which
+represents a connection that has no data at all and cannot be paginated.`, async () => {
+    const connection = graphqlConnectionFactory<unknown>();
+
+    expect(connection).toEqual({
+      edges: [],
+      pageInfo: {
+        endCursor: null,
+        hasNextPage: false,
+        hasPreviousPage: false,
+        startCursor: null,
+      },
+    });
+  });
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

feature: add graphql connection object factory function to easily create connection objects

**Issue Number:**

Fixes #

**Did you add tests for your changes?**

 Yes

**Snapshots/Videos:**

 -

**If relevant, did you update the documentation?**

 -

**Summary**

Creating graphql connection objects from scratch for each resolver which should return a connection object is redundant. This function lets us create a connection object with sensible default fields which can be changed according to different logic within the resolver.

**Does this PR introduce a breaking change?**

 -

**Other information**

 -

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
 
 Yes
