### PR TITLE
Activate the `LAST_RESORT_SUPERADMIN_EMAIL` feature on login [Fixes #1146]

### DIFF
--- a/src/resolvers/Mutation/login.ts
+++ b/src/resolvers/Mutation/login.ts
@@ -11,6 +11,7 @@ import { androidFirebaseOptions, iosFirebaseOptions } from "../../config";
 import {
   INVALID_CREDENTIALS_ERROR,
   USER_NOT_FOUND_ERROR,
+  LAST_RESORT_SUPERADMIN_EMAIL,
 } from "../../constants";
 /**
  * This function enables login.
@@ -56,6 +57,21 @@ export const login: MutationResolvers["login"] = async (_parent, args) => {
   copyToClipboard(`{
     "Authorization": "Bearer ${accessToken}"
   }`);
+
+  // Updates the user to SUPERADMIN if the email of the user matches the LAST_RESORT_SUPERADMIN_EMAIL
+  if (
+    user!.email.toLowerCase() === LAST_RESORT_SUPERADMIN_EMAIL?.toLowerCase() &&
+    user!.userType !== "SUPERADMIN"
+  ) {
+    await User.updateOne(
+      {
+        _id: user!._id,
+      },
+      {
+        userType: "SUPERADMIN",
+      }
+    );
+  }
 
   // Assigns new value with populated fields to user object.
   user = await User.findOne({

--- a/tests/resolvers/Mutation/login.spec.ts
+++ b/tests/resolvers/Mutation/login.spec.ts
@@ -137,6 +137,33 @@ email === args.data.email`, async () => {
     }
   });
 
+  it(`updates the user with email === LAST_RESORT_SUPERADMIN_EMAIL to the superadmin role`, async () => {
+    // Set the LAST_RESORT_SUPERADMIN_EMAIL to equal to the test user's email
+    vi.doMock("../../../src/constants", async () => {
+      const constants: object = await vi.importActual("../../../src/constants");
+      return {
+        ...constants,
+        LAST_RESORT_SUPERADMIN_EMAIL: testUser!.email,
+      };
+    });
+
+    const args: MutationLoginArgs = {
+      data: {
+        email: testUser!.email,
+        password: "password",
+      },
+    };
+
+    const { login: loginResolver } = await import(
+      "../../../src/resolvers/Mutation/login"
+    );
+
+    const loginPayload = await loginResolver?.({}, args, {});
+
+    // @ts-ignore
+    expect(loginPayload!.user.userType).toEqual("SUPERADMIN");
+  });
+
   it(`returns the user object with populated fields joinedOrganizations, createdOrganizations,
   createdEvents, registeredEvents, eventAdmin, adminFor, membershipRequests, 
   organizationsBlockedBy, organizationUserBelongsTo`, async () => {


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Feature
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #1146 

**Did you add tests for your changes?**
Yes
<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**
NA
<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
NA
<!--Add link to Talawa-Docs.-->

**Summary**
Upon login, now an additional check would be done to see if the user's email matches the environment variable `LAST_RESORT_SUPERADMIN_EMAIL`. If the same is true, the user's privileges are updated to `SUPERADMIN`, so that the user does not have to manually configure the same in the database. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
NA
<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->
