### PR TITLE
Prevent `SUPERADMIN` from downgrading their own roles [Fixes #1207]

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -263,6 +263,12 @@ export const USER_NOT_FOUND_ERROR = {
   MESSAGE: "user.notFound",
   PARAM: "user",
 };
+export const SUPERADMIN_CANT_CHANGE_OWN_ROLE = {
+  MESSAGE:
+    "Superadmin's are not allowed to change their own roles. This is done as SUPERADMIN is the highest level of access to the system, and downgrading their own role may result in them being locked out of the system.",
+  CODE: "superadmin.NotChangeSelf",
+  PARAM: "superadmin.NotChangeSelf",
+};
 export const TRANSLATION_ALREADY_PRESENT_ERROR = {
   DESC: "Translation Already Present",
   CODE: "translation.alreadyPresent",

--- a/src/resolvers/Mutation/updateUserType.ts
+++ b/src/resolvers/Mutation/updateUserType.ts
@@ -1,6 +1,9 @@
 import { MutationResolvers } from "../../types/generatedGraphQLTypes";
 import { User } from "../../models";
-import { USER_NOT_FOUND_ERROR } from "../../constants";
+import {
+  USER_NOT_FOUND_ERROR,
+  SUPERADMIN_CANT_CHANGE_OWN_ROLE,
+} from "../../constants";
 import { errors, requestContext } from "../../libraries";
 import { superAdminCheck } from "../../utilities";
 /**
@@ -32,6 +35,14 @@ export const updateUserType: MutationResolvers["updateUserType"] = async (
   }
 
   superAdminCheck(currentUser);
+
+  if (args.data.id === currentUser._id.toString()) {
+    throw new errors.InputValidationError(
+      requestContext.translate(SUPERADMIN_CANT_CHANGE_OWN_ROLE.MESSAGE),
+      SUPERADMIN_CANT_CHANGE_OWN_ROLE.CODE,
+      SUPERADMIN_CANT_CHANGE_OWN_ROLE.PARAM
+    );
+  }
 
   const userExists = await User.exists({
     _id: args.data.id!,

--- a/tests/resolvers/Mutation/updateUserType.spec.ts
+++ b/tests/resolvers/Mutation/updateUserType.spec.ts
@@ -7,6 +7,7 @@ import mongoose from "mongoose";
 import {
   USER_NOT_AUTHORIZED_SUPERADMIN,
   USER_NOT_FOUND_ERROR,
+  SUPERADMIN_CANT_CHANGE_OWN_ROLE,
 } from "../../../src/constants";
 import {
   beforeAll,
@@ -141,7 +142,54 @@ describe("resolvers -> Mutation -> updateUserType", () => {
     }
   });
 
+  it(`throws SUPERADMIN_CANT_CHANGE_OWN_ROLE_ERROR if the user is a superadmin and tries to downgrade their own role`, async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementation((message) => `Translated ${message}`);
+
+    try {
+      const args: MutationUpdateUserTypeArgs = {
+        data: {
+          id: testUsers[0]!._id,
+        },
+      };
+
+      const context = {
+        userId: testUsers[0]!._id,
+      };
+
+      const { updateUserType: updateUserTypeResolver } = await import(
+        "../../../src/resolvers/Mutation/updateUserType"
+      );
+
+      await updateUserTypeResolver?.({}, args, context);
+    } catch (error: any) {
+      expect(spy).toHaveBeenCalledWith(SUPERADMIN_CANT_CHANGE_OWN_ROLE.MESSAGE);
+      expect(error.message).toEqual(
+        `Translated ${SUPERADMIN_CANT_CHANGE_OWN_ROLE.MESSAGE}`
+      );
+    }
+  });
+
   it(`updates user.userType of user with _id === args.data.id to args.data.userType`, async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    vi.spyOn(requestContext, "translate").mockImplementation(
+      (message) => `Translated ${message}`
+    );
+
+    await User.updateOne(
+      {
+        _id: testUsers[0]!._id,
+      },
+      {
+        userType: "SUPERADMIN",
+      },
+      {
+        new: true,
+      }
+    );
+
     const args: MutationUpdateUserTypeArgs = {
       data: {
         id: testUsers[1]!._id,


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Bugfix
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
Fixes #1207
 
**Did you add tests for your changes?**
Yes
<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**
NA
<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
NA
<!--Add link to Talawa-Docs.-->

**Summary**
Prevent a superadmin from downgrading their own role to prevent them from being locked out of the system.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
NA
<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->
