### PR TITLE
Update workflow to club Code Quality jobs into a singular job [Fixes #1241]

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,44 +19,28 @@ env:
     CODECOV_UNIQUE_NAME: CODECOV_UNIQUE_NAME-${{ github.run_id }}-${{ github.run_number }}
           
 jobs:
-  Linter:
-    name: Check for linting errors
+  Code-Quality-Checks:
+    name: Check for linting, formatting and typpe errors
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Install Dependencies
         run: npm ci
+
       - name: Run ESLint to check for linting errors
         run: npm run lint:check
 
-  Code-Formatter:
-    name: Check for formatting errors
-    runs-on: ubuntu-latest
-    needs: Linter
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Install Dependencies
-        run: npm ci
       - name: Check for fomatting errors
         run: npm run format:check 
 
-  Type-Checker:
-    name: Check for type errors
-    runs-on: ubuntu-latest     
-    needs: [Linter, Code-Formatter]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Install Dependencies
-        run: npm ci
       - name: Run Typescript Type-Checker
         run: npm run typecheck 
   
   Test-Application:
     name: Testing Application
     runs-on: ubuntu-latest
-    needs: [Linter, Code-Formatter, Type-Checker]
+    needs: [Code-Quality-Checks]
     strategy:
       matrix:
         node-version: [14.x]

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,7 +23,8 @@ jobs:
     name: Check for linting, formatting and typpe errors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository content
+        uses: actions/checkout@v3
 
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Feature
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #1241 

**Did you add tests for your changes?**
No
<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**
NA
<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
NA
<!--Add link to Talawa-Docs.-->

**Summary**
Uodated the Pull Request action to run Linter, Formatter and Typechecker in the same job with multiple steps. This would cause the `npm ci` command to run only once, instead of three times, thus reducing the Workflow run time.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
NA
<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->
