### PR TITLE
Returning Empty Array Instead of Throwing Error

### DIFF
--- a/src/resolvers/Query/users.ts
+++ b/src/resolvers/Query/users.ts
@@ -21,11 +21,11 @@ export const users: QueryResolvers["users"] = async (
   const where = getWhere<Interface_User>(args.where);
   const sort = getSort(args.orderBy);
 
-  const queryUser = await User.findOne({
+  const currentUser = await User.findOne({
     _id: context.userId,
   });
 
-  if (!queryUser) {
+  if (!currentUser) {
     throw new errors.UnauthenticatedError(
       requestContext.translate(UNAUTHENTICATED_ERROR.MESSAGE),
       UNAUTHENTICATED_ERROR.CODE,
@@ -46,14 +46,14 @@ export const users: QueryResolvers["users"] = async (
     .lean();
 
   return users.map((user) => {
-    const { userType } = queryUser;
+    const { userType } = currentUser;
 
     return {
       ...user,
       image: user.image ? `${context.apiRootUrl}${user.image}` : null,
       organizationsBlockedBy:
         (userType === "ADMIN" || userType === "SUPERADMIN") &&
-        queryUser._id !== user._id
+        currentUser._id !== user._id
           ? user.organizationsBlockedBy
           : [],
     };

--- a/src/resolvers/Query/users.ts
+++ b/src/resolvers/Query/users.ts
@@ -45,24 +45,17 @@ export const users: QueryResolvers["users"] = async (
     .populate("organizationsBlockedBy")
     .lean();
 
-  if (!users[0]) {
-    throw new errors.NotFoundError(
-      requestContext.translate(USER_NOT_FOUND_ERROR.MESSAGE),
-      USER_NOT_FOUND_ERROR.CODE,
-      USER_NOT_FOUND_ERROR.PARAM
-    );
-  } else
-    return users.map((user) => {
-      const { userType } = queryUser;
+  return users.map((user) => {
+    const { userType } = queryUser;
 
-      return {
-        ...user,
-        image: user.image ? `${context.apiRootUrl}${user.image}` : null,
-        organizationsBlockedBy:
-          (userType === "ADMIN" || userType === "SUPERADMIN") &&
-          queryUser._id !== user._id
-            ? user.organizationsBlockedBy
-            : [],
-      };
-    });
+    return {
+      ...user,
+      image: user.image ? `${context.apiRootUrl}${user.image}` : null,
+      organizationsBlockedBy:
+        (userType === "ADMIN" || userType === "SUPERADMIN") &&
+        queryUser._id !== user._id
+          ? user.organizationsBlockedBy
+          : [],
+    };
+  });
 };

--- a/src/resolvers/Query/users.ts
+++ b/src/resolvers/Query/users.ts
@@ -1,7 +1,7 @@
 import { QueryResolvers } from "../../types/generatedGraphQLTypes";
 import { Interface_User, User } from "../../models";
 import { errors, requestContext } from "../../libraries";
-import { UNAUTHENTICATED_ERROR, USER_NOT_FOUND_ERROR } from "../../constants";
+import { UNAUTHENTICATED_ERROR } from "../../constants";
 import { getSort } from "./helperFunctions/getSort";
 import { getWhere } from "./helperFunctions/getWhere";
 

--- a/tests/resolvers/Query/users.spec.ts
+++ b/tests/resolvers/Query/users.spec.ts
@@ -26,15 +26,6 @@ describe("resolvers -> Query -> users", () => {
   it("throws UnauthenticatedError if userId is not passed in context", async () => {
     const testObjectId = new mongoose.Types.ObjectId();
 
-    vi.doMock("../../../src/constants", async () => {
-      const actualConstants: object = await vi.importActual(
-        "../../../src/constants"
-      );
-      return {
-        ...actualConstants,
-      };
-    });
-
     const { requestContext } = await import("../../../src/libraries");
 
     const spy = vi
@@ -60,21 +51,11 @@ describe("resolvers -> Query -> users", () => {
       );
     }
 
-    vi.doUnmock("../../../src/constants");
     vi.resetModules();
   });
 
   it("returns empty array if no user exists", async () => {
     const testObjectId = new mongoose.Types.ObjectId();
-
-    vi.doMock("../../../src/constants", async () => {
-      const actualConstants: object = await vi.importActual(
-        "../../../src/constants"
-      );
-      return {
-        ...actualConstants,
-      };
-    });
 
     const testUser = await createTestUser();
 
@@ -95,7 +76,6 @@ describe("resolvers -> Query -> users", () => {
 
     expect(usersPayload).toEqual([]);
 
-    vi.doUnmock("../../../src/constants");
     vi.resetModules();
   });
 

--- a/tests/resolvers/Query/users.spec.ts
+++ b/tests/resolvers/Query/users.spec.ts
@@ -5,11 +5,7 @@ import { connect, disconnect } from "../../helpers/db";
 import { QueryUsersArgs } from "../../../src/types/generatedGraphQLTypes";
 import { Document } from "mongoose";
 import { nanoid } from "nanoid";
-import {
-  BASE_URL,
-  UNAUTHENTICATED_ERROR,
-  USER_NOT_FOUND_ERROR,
-} from "../../../src/constants";
+import { BASE_URL, UNAUTHENTICATED_ERROR } from "../../../src/constants";
 import { beforeAll, afterAll, describe, it, expect, vi } from "vitest";
 import * as mongoose from "mongoose";
 import { createTestUser } from "../../helpers/user";
@@ -68,7 +64,7 @@ describe("resolvers -> Query -> users", () => {
     vi.resetModules();
   });
 
-  it("throws NotFoundError if no user exists", async () => {
+  it("returns empty array if no user exists", async () => {
     const testObjectId = new mongoose.Types.ObjectId();
 
     vi.doMock("../../../src/constants", async () => {
@@ -80,34 +76,24 @@ describe("resolvers -> Query -> users", () => {
       };
     });
 
-    const { requestContext } = await import("../../../src/libraries");
-
-    const spy = vi
-      .spyOn(requestContext, "translate")
-      .mockImplementationOnce((message) => `Translated ${message}`);
-
     const testUser = await createTestUser();
 
-    try {
-      const args: QueryUsersArgs = {
-        orderBy: null,
-        where: {
-          id: testObjectId as unknown as string,
-        },
-      };
+    const args: QueryUsersArgs = {
+      orderBy: null,
+      where: {
+        id: testObjectId as unknown as string,
+      },
+    };
 
-      const { users: mockedInProductionUserResolver } = await import(
-        "../../../src/resolvers/Query/users"
-      );
-      await mockedInProductionUserResolver?.({}, args, {
-        userId: testUser?._id,
-      });
-    } catch (error: any) {
-      expect(spy).toBeCalledWith(USER_NOT_FOUND_ERROR.MESSAGE);
-      expect(error.message).toEqual(
-        `Translated ${USER_NOT_FOUND_ERROR.MESSAGE}`
-      );
-    }
+    const { users: mockedInProductionUserResolver } = await import(
+      "../../../src/resolvers/Query/users"
+    );
+
+    const usersPayload = await mockedInProductionUserResolver?.({}, args, {
+      userId: testUser?._id,
+    });
+
+    expect(usersPayload).toEqual([]);
 
     vi.doUnmock("../../../src/constants");
     vi.resetModules();

--- a/tests/resolvers/Query/users.spec.ts
+++ b/tests/resolvers/Query/users.spec.ts
@@ -45,7 +45,7 @@ describe("resolvers -> Query -> users", () => {
       const args: QueryUsersArgs = {
         orderBy: null,
         where: {
-          id: testObjectId as unknown as string,
+          id: testObjectId.toString(),
         },
       };
 
@@ -81,7 +81,7 @@ describe("resolvers -> Query -> users", () => {
     const args: QueryUsersArgs = {
       orderBy: null,
       where: {
-        id: testObjectId as unknown as string,
+        id: testObjectId.toString(),
       },
     };
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Issue Number:**

Fixes #1260 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

<img width="1769" alt="Screenshot 2023-04-06 at 11 04 42 PM" src="https://user-images.githubusercontent.com/28570857/230453784-95fc3a80-55dc-45e5-80c1-5a3154f49b03.png">

**If relevant, did you update the documentation?**

Not Relevant

**Summary**

- The `Users` Query returned the `UserNotFound` Error when none of the filters matched
- Other queries like the `organizationsConnection` returned an empty array instead
- This created problems in the admin when filtering users in the Organization People page
- And the filters didn't match any user
- I've fixed this issue to return an empty array instead

**Does this PR introduce a breaking change?**

No

**Other information**

This issue will help solving https://github.com/PalisadoesFoundation/talawa-admin/issues/730

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes