### PR TITLE
Added Organization Member Filter to Users Query

### DIFF
--- a/src/resolvers/Query/helperFunctions/getWhere.ts
+++ b/src/resolvers/Query/helperFunctions/getWhere.ts
@@ -636,6 +636,15 @@ export const getWhere = <T = unknown>(
     };
   }
 
+  if (where.member_of) {
+    wherePayload = {
+      ...wherePayload,
+      joinedOrganizations: {
+        _id: where.member_of,
+      },
+    };
+  }
+
   if (where.event_title_contains) {
     wherePayload = {
       ...wherePayload,

--- a/src/resolvers/Query/helperFunctions/getWhere.ts
+++ b/src/resolvers/Query/helperFunctions/getWhere.ts
@@ -636,6 +636,7 @@ export const getWhere = <T = unknown>(
     };
   }
 
+  // Return users who are member of provider organizationId
   if (where.member_of) {
     wherePayload = {
       ...wherePayload,

--- a/src/typeDefs/inputs.ts
+++ b/src/typeDefs/inputs.ts
@@ -336,6 +336,7 @@ export const inputs = gql`
     appLanguageCode_starts_with: String
 
     admin_for: ID
+    member_of: ID
 
     event_title_contains: String
   }

--- a/src/types/generatedGraphQLTypes.ts
+++ b/src/types/generatedGraphQLTypes.ts
@@ -1542,6 +1542,7 @@ export type UserWhereInput = {
   lastName_not?: InputMaybe<Scalars['String']>;
   lastName_not_in?: InputMaybe<Array<Scalars['String']>>;
   lastName_starts_with?: InputMaybe<Scalars['String']>;
+  member_of?: InputMaybe<Scalars['ID']>;
 };
 
 export type UsersConnection = {

--- a/tests/resolvers/Query/users.spec.ts
+++ b/tests/resolvers/Query/users.spec.ts
@@ -833,7 +833,7 @@ describe("resolvers -> Query -> users", () => {
     });
 
     it(`returns list of all existing users filtered by
-    args.where === { member_of: [testOrganization.id] }`, async () => {
+    args.where === { member_of: testOrganization.id }`, async () => {
       const where = {
         joinedOrganizations: {
           _id: testOrganization.id,


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature

**Issue Number:**

Fixes #1297 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

<img width="1792" alt="Screenshot 2023-04-13 at 9 48 11 PM" src="https://user-images.githubusercontent.com/28570857/231822300-327a5b20-1f89-4156-82a9-eb3ba40c95e8.png">

**If relevant, did you update the documentation?**

Not Relevant

**Summary**

- Added `member_of` filter to `Users` query
- This makes it possible to get a list of users belonging to provided `organizationId`

**Does this PR introduce a breaking change?**

No

**Other information**

NA

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes