### PR TITLE
Improve and Standardize Automated Linting Tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -63,8 +63,12 @@
 
     // Typescript rule to enforce PascalCase naming convention for types and interfaces
     "@typescript-eslint/naming-convention": [
-      "error",
+      "off",
       // Interfaces must begin with Interface or TestInterface followed by a PascalCase name
+      {
+        "selector": "default",
+        "format": ["camelCase"]
+      },
       {
         "selector": "interface",
         "format": ["PascalCase"],
@@ -74,7 +78,57 @@
       {
         "selector": "typeAlias",
         "format": ["PascalCase"]
+      },
+      { "selector": "typeLike", "format": ["PascalCase"] },
+      {
+        "selector": "typeParameter",
+        "format": ["PascalCase"],
+        "prefix": ["T"]
+      },
+      {
+        "selector": "enum",
+        "format": ["PascalCase"]
+      },
+      { "selector": "variableLike", "format": ["camelCase"] },
+      { "selector": "variable", "format": ["camelCase", "UPPER_CASE"] },
+      {
+        "selector": "parameter",
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow"
+      },
+      {
+        "selector": "function",
+        "format": ["camelCase"],
+        "custom": {
+          "match": true,
+          "regex": "^[create|retrieve|search|delete]"
+        }
+      },
+      {
+        "selector": "memberLike",
+        "modifiers": ["private"],
+        "format": ["camelCase"],
+        "leadingUnderscore": "require"
+      }
+    ],
+
+    // Typescript additional rules
+    "@typescript-eslint/array-type": "off",
+    "@typescript-eslint/consistent-type-assertions": "off",
+    "@typescript-eslint/consistent-type-imports": "off",
+    "@typescript-eslint/explicit-function-return-type": "off",
+
+    "@typescript-eslint/typedef": [
+      "off",
+      {
+        "arrowParameter": true,
+        "variableDeclaration": true
       }
     ]
+    // "no-return-await": "off",
+    // "@typescript-eslint/return-await": "error",
+    // "@typescript-eslint/consistent-type-exports": "error",
+    // "@typescript-eslint/unbound-method": "error",
+    // "@typescript-eslint/no-floating-promises": "error"
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** - This PR introduces new linting rules to improve and automate the linting tests. The following rules are added :
1. Naming Convention : 

   - Using PascalCase for type names.
   - Using PascalCase for enum values.
   - Using PascalCase for types
   - Parameters, Variables and functions are CamelCase
   - Use _ as a prefix for private properties.

2. Array Type
3. consistent-type-assertions
4. consistent-type-imports
5. explicit-function-return-type
6. typedef

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number: #1275**

Fixes #1275 

**Did you add tests for your changes?** Yes

**Does this PR introduce a breaking change?** No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?** Yes

<!--Yes or No-->
