### PR TITLE
resolved adminRemoveGroup return type error

### DIFF
--- a/src/resolvers/Mutation/adminRemoveGroup.ts
+++ b/src/resolvers/Mutation/adminRemoveGroup.ts
@@ -19,7 +19,6 @@ import {
  * 4. If the user is an admin of organization
  * @returns Deleted group chat
  */
-// @ts-ignore
 export const adminRemoveGroup: MutationResolvers["adminRemoveGroup"] = async (
   _parent,
   args,

--- a/src/typeDefs/mutations.ts
+++ b/src/typeDefs/mutations.ts
@@ -20,7 +20,7 @@ export const mutations = gql`
 
     adminRemoveEvent(eventId: ID!): Event! @auth
 
-    adminRemoveGroup(groupId: ID!): Message! @auth
+    adminRemoveGroup(groupId: ID!): GroupChat! @auth
 
     assignUserTag(input: ToggleUserTagAssignInput!): User @auth
 

--- a/src/types/generatedGraphQLTypes.ts
+++ b/src/types/generatedGraphQLTypes.ts
@@ -375,7 +375,7 @@ export type Mutation = {
   addUserImage: User;
   addUserToGroupChat: GroupChat;
   adminRemoveEvent: Event;
-  adminRemoveGroup: Message;
+  adminRemoveGroup: GroupChat;
   assignUserTag?: Maybe<User>;
   blockPluginCreationBySuperadmin: User;
   blockUser: User;
@@ -2061,7 +2061,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   addUserImage?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationAddUserImageArgs, 'file'>>;
   addUserToGroupChat?: Resolver<ResolversTypes['GroupChat'], ParentType, ContextType, RequireFields<MutationAddUserToGroupChatArgs, 'chatId' | 'userId'>>;
   adminRemoveEvent?: Resolver<ResolversTypes['Event'], ParentType, ContextType, RequireFields<MutationAdminRemoveEventArgs, 'eventId'>>;
-  adminRemoveGroup?: Resolver<ResolversTypes['Message'], ParentType, ContextType, RequireFields<MutationAdminRemoveGroupArgs, 'groupId'>>;
+  adminRemoveGroup?: Resolver<ResolversTypes['GroupChat'], ParentType, ContextType, RequireFields<MutationAdminRemoveGroupArgs, 'groupId'>>;
   assignUserTag?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationAssignUserTagArgs, 'input'>>;
   blockPluginCreationBySuperadmin?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationBlockPluginCreationBySuperadminArgs, 'blockUser' | 'userId'>>;
   blockUser?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationBlockUserArgs, 'organizationId' | 'userId'>>;


### PR DESCRIPTION
**What kind of change does this PR introduce?** This PR fixes the return type of `adminRemoveGroup` Mutation Resolver to `InterfaceGroupChat`

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number: #1307**

Fixes #1307

**Did you add tests for your changes? - Yes** The changes were tested against already coded test suites

<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**If relevant, did you update the documentation?** No

**Does this PR introduce a breaking change?** - No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?** - Yes

<!--Yes or No-->
