### PR TITLE
Feature: Private events visibilty by UserType

### DIFF
--- a/src/resolvers/Mutation/createMember.ts
+++ b/src/resolvers/Mutation/createMember.ts
@@ -1,4 +1,4 @@
-import { MutationResolvers } from "../../types/generatedGraphQLTypes";
+import type { MutationResolvers } from "../../types/generatedGraphQLTypes";
 import { errors, requestContext } from "../../libraries";
 import { User, Organization } from "../../models";
 import { superAdminCheck } from "../../utilities";

--- a/src/resolvers/Query/eventsByUserType.ts
+++ b/src/resolvers/Query/eventsByUserType.ts
@@ -1,0 +1,90 @@
+import type { QueryResolvers } from "../../types/generatedGraphQLTypes";
+import type { InterfaceEvent, InterfaceUserAttende } from "../../models";
+import { Event, Organization, User } from "../../models";
+import { STATUS_ACTIVE } from "../../constants";
+import { getSort } from "./helperFunctions/getSort";
+/**
+ * This query will fetch all events for the organization which have `ACTIVE` status from database.
+ * @param _parent-
+ * @param args - An object that contains `orderBy` to sort the object as specified and `id` of the Organization.
+ * @returns An `events` object that holds all events with `ACTIVE` status for the Organization.
+ */
+
+export const eventsByUserType: QueryResolvers["eventsByUserType"] = async (
+  _parent,
+  args
+) => {
+  const sort = getSort(args.orderBy);
+
+  const user = await User.findById({ _id: args.userId });
+  const organization = await Organization.findById({ _id: args.orgId });
+  const filteredEvents: InterfaceEvent[] = [];
+  if (user?.userType === "SUPERADMIN") {
+    const events = await Event.find({
+      organization: args.orgId,
+      status: "ACTIVE",
+    })
+      .sort(sort)
+      .populate("creator", "-password")
+      .populate("tasks")
+      .populate("admins", "-password")
+      .lean();
+
+    events.forEach((event) => {
+      event.registrants = event.registrants.filter(
+        (registrant: InterfaceUserAttende) =>
+          registrant.status === STATUS_ACTIVE
+      );
+    });
+    return events;
+  }
+
+  if (organization?.admins.includes(args.userId)) {
+    const events = await Event.find({
+      organization: args.orgId,
+      status: "ACTIVE",
+    })
+      .sort(sort)
+      .populate("creator", "-password")
+      .populate("tasks")
+      .populate("admins", "-password")
+      .lean();
+
+    events?.forEach((event) => {
+      event.registrants = event.registrants.filter(
+        (registrant: InterfaceUserAttende) =>
+          registrant.status === STATUS_ACTIVE
+      );
+    });
+    return events;
+  }
+  const events = await Event.find({
+    organization: args.orgId,
+    status: "ACTIVE",
+  })
+    .sort(sort)
+    .populate("creator", "-password")
+    .populate("tasks")
+    .populate("admins", "-password")
+    .lean();
+
+  events?.forEach((event) => {
+    if (event.isPublic) filteredEvents.push(event);
+    if (
+      !event.isPublic &&
+      event.registrants?.some(
+        (registrant: InterfaceUserAttende) =>
+          registrant.userId === String(args.userId)
+      )
+    ) {
+      filteredEvents.push(event);
+    }
+  });
+
+  filteredEvents?.forEach((event) => {
+    event.registrants = event.registrants.filter(
+      (registrant: InterfaceUserAttende) => registrant.status === STATUS_ACTIVE
+    );
+  });
+  return filteredEvents;
+};

--- a/src/resolvers/Query/index.ts
+++ b/src/resolvers/Query/index.ts
@@ -5,6 +5,7 @@ import { directChatsMessagesByChatID } from "./directChatsMessagesByChatID";
 import { event } from "./event";
 import { eventsByOrganization } from "./eventsByOrganization";
 import { eventsByOrganizationConnection } from "./eventsByOrganizationConnection";
+import { eventsByUserType } from "./eventsByUserType";
 import { getDonationById } from "./getDonationById";
 import { getDonationByOrgId } from "./getDonationByOrgId";
 import { getDonationByOrgIdConnection } from "./getDonationByOrgIdConnection";
@@ -35,6 +36,7 @@ export const Query: QueryResolvers = {
   event,
   eventsByOrganization,
   eventsByOrganizationConnection,
+  eventsByUserType,
   getDonationById,
   getDonationByOrgId,
   getDonationByOrgIdConnection,

--- a/src/typeDefs/queries.ts
+++ b/src/typeDefs/queries.ts
@@ -24,6 +24,8 @@ export const queries = gql`
       orderBy: EventOrderByInput
     ): [Event!]!
 
+    eventsByUserType(userId:ID!, orgId:ID!, orderBy: EventOrderByInput): [Event]
+
     getDonationById(id: ID!): Donation!
 
     getDonationByOrgId(orgId: ID!): [Donation]

--- a/src/typeDefs/queries.ts
+++ b/src/typeDefs/queries.ts
@@ -24,7 +24,11 @@ export const queries = gql`
       orderBy: EventOrderByInput
     ): [Event!]!
 
-    eventsByUserType(userId:ID!, orgId:ID!, orderBy: EventOrderByInput): [Event]
+    eventsByUserType(
+      userId: ID!
+      orgId: ID!
+      orderBy: EventOrderByInput
+    ): [Event]
 
     getDonationById(id: ID!): Donation!
 

--- a/src/types/generatedGraphQLTypes.ts
+++ b/src/types/generatedGraphQLTypes.ts
@@ -1080,6 +1080,7 @@ export type Query = {
   event?: Maybe<Event>;
   eventsByOrganization?: Maybe<Array<Maybe<Event>>>;
   eventsByOrganizationConnection: Array<Event>;
+  eventsByUserType?: Maybe<Array<Maybe<Event>>>;
   getDonationById: Donation;
   getDonationByOrgId?: Maybe<Array<Maybe<Donation>>>;
   getDonationByOrgIdConnection: Array<Donation>;
@@ -1138,6 +1139,13 @@ export type QueryEventsByOrganizationConnectionArgs = {
   orderBy?: InputMaybe<EventOrderByInput>;
   skip?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<EventWhereInput>;
+};
+
+
+export type QueryEventsByUserTypeArgs = {
+  orderBy?: InputMaybe<EventOrderByInput>;
+  orgId: Scalars['ID'];
+  userId: Scalars['ID'];
 };
 
 
@@ -2241,6 +2249,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   event?: Resolver<Maybe<ResolversTypes['Event']>, ParentType, ContextType, RequireFields<QueryEventArgs, 'id'>>;
   eventsByOrganization?: Resolver<Maybe<Array<Maybe<ResolversTypes['Event']>>>, ParentType, ContextType, Partial<QueryEventsByOrganizationArgs>>;
   eventsByOrganizationConnection?: Resolver<Array<ResolversTypes['Event']>, ParentType, ContextType, Partial<QueryEventsByOrganizationConnectionArgs>>;
+  eventsByUserType?: Resolver<Maybe<Array<Maybe<ResolversTypes['Event']>>>, ParentType, ContextType, RequireFields<QueryEventsByUserTypeArgs, 'orgId' | 'userId'>>;
   getDonationById?: Resolver<ResolversTypes['Donation'], ParentType, ContextType, RequireFields<QueryGetDonationByIdArgs, 'id'>>;
   getDonationByOrgId?: Resolver<Maybe<Array<Maybe<ResolversTypes['Donation']>>>, ParentType, ContextType, RequireFields<QueryGetDonationByOrgIdArgs, 'orgId'>>;
   getDonationByOrgIdConnection?: Resolver<Array<ResolversTypes['Donation']>, ParentType, ContextType, RequireFields<QueryGetDonationByOrgIdConnectionArgs, 'orgId'>>;

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -30,6 +30,14 @@ export async function dropDatabase(
   await mongooseInstance.connection.db.dropDatabase();
 }
 
+// drop a collection
+export async function dropCollection(
+  mongooseInstance: typeof mongoose,
+  collectionName: string
+): Promise<void> {
+  await mongooseInstance.connection.db.collection(collectionName).drop();
+}
+
 // Disconnects from the provided mongoose instance
 export async function disconnect(
   mongooseInstance: typeof mongoose

--- a/tests/helpers/events.ts
+++ b/tests/helpers/events.ts
@@ -54,20 +54,22 @@ export const createEventWithRegistrant = async (
   userId: string,
   organizationId: string,
   allDay: boolean,
-  recurrance: string
+  recurrance: string,
+  registrantId?: string | undefined,
+  isPublic: boolean = true
 ): Promise<TestEventType> => {
   const testEvent = await Event.create({
     creator: userId,
     registrants: [
       {
-        userId: userId,
-        user: userId,
+        userId: registrantId ? registrantId : userId,
+        user: registrantId ? registrantId : userId,
       },
     ],
     admins: [userId],
     organization: organizationId,
     isRegisterable: true,
-    isPublic: true,
+    isPublic: isPublic,
     title: `title${nanoid()}`,
     description: `description${nanoid()}`,
     allDay: allDay,

--- a/tests/helpers/userAndOrg.ts
+++ b/tests/helpers/userAndOrg.ts
@@ -11,14 +11,28 @@ export type TestUserType =
   | (InterfaceUser & Document<any, any, InterfaceUser>)
   | null;
 
-export const createTestUser = async (): Promise<TestUserType> => {
-  const testUser = await User.create({
-    email: `email${nanoid().toLowerCase()}@gmail.com`,
-    password: `pass${nanoid().toLowerCase()}`,
-    firstName: `firstName${nanoid().toLowerCase()}`,
-    lastName: `lastName${nanoid().toLowerCase()}`,
-    appLanguageCode: "en",
-  });
+export const createTestUser = async (
+  userType?: string
+): Promise<TestUserType> => {
+  let testUser;
+  if (userType !== undefined) {
+    testUser = await User.create({
+      email: `email${nanoid().toLowerCase()}@gmail.com`,
+      password: `pass${nanoid().toLowerCase()}`,
+      firstName: `firstName${nanoid().toLowerCase()}`,
+      lastName: `lastName${nanoid().toLowerCase()}`,
+      appLanguageCode: "en",
+      userType: userType,
+    });
+  } else {
+    testUser = await User.create({
+      email: `email${nanoid().toLowerCase()}@gmail.com`,
+      password: `pass${nanoid().toLowerCase()}`,
+      firstName: `firstName${nanoid().toLowerCase()}`,
+      lastName: `lastName${nanoid().toLowerCase()}`,
+      appLanguageCode: "en",
+    });
+  }
 
   return testUser;
 };
@@ -55,11 +69,12 @@ export const createTestOrganizationWithAdmin = async (
 };
 
 export const createTestUserAndOrganization = async (
-  isMember = true,
-  isAdmin = true,
-  isPublic = true
+  isMember: boolean = true,
+  isAdmin: boolean = true,
+  isPublic: boolean = true,
+  userType?: string
 ): Promise<[TestUserType, TestOrganizationType]> => {
-  const testUser = await createTestUser();
+  const testUser = await createTestUser(userType);
   const testOrganization = await createTestOrganizationWithAdmin(
     testUser?._id,
     isMember,

--- a/tests/resolvers/Mutation/createMember.spec.ts
+++ b/tests/resolvers/Mutation/createMember.spec.ts
@@ -1,7 +1,8 @@
 import "dotenv/config";
-import mongoose, { Types } from "mongoose";
+import type mongoose from "mongoose";
+import { Types } from "mongoose";
 import { User, Organization } from "../../../src/models";
-import { MutationCreateMemberArgs } from "../../../src/types/generatedGraphQLTypes";
+import type { MutationCreateMemberArgs } from "../../../src/types/generatedGraphQLTypes";
 import { connect, disconnect } from "../../helpers/db";
 
 import { createMember as createMemberResolver } from "../../../src/resolvers/Mutation/createMember";
@@ -11,11 +12,11 @@ import {
   MEMBER_NOT_FOUND_ERROR,
 } from "../../../src/constants";
 import { beforeAll, afterAll, describe, it, expect, vi } from "vitest";
-import {
-  createTestUserAndOrganization,
+import type {
   TestOrganizationType,
   TestUserType,
 } from "../../helpers/userAndOrg";
+import { createTestUserAndOrganization } from "../../helpers/userAndOrg";
 
 let testUser: TestUserType;
 let testOrganization: TestOrganizationType;

--- a/tests/resolvers/Query/eventsByUserType.spec.ts
+++ b/tests/resolvers/Query/eventsByUserType.spec.ts
@@ -1,0 +1,206 @@
+// Write three tests for all user types
+// Create User as Super admin and create a public and private event for an organization
+// Super admin should have access
+// Create a ADMIN user of an organization and admin should have access
+// Create a User; add user to a private event as registrant, user should be able to see the event
+// Create another private event under the same organization
+// Normal user who is not a registrant shouldn't have access.
+
+import "dotenv/config";
+import { Event } from "../../../src/models";
+import { connect, disconnect, dropCollection } from "../../helpers/db";
+import type { QueryEventsByUserTypeArgs } from "../../../src/types/generatedGraphQLTypes";
+import { beforeAll, afterAll, describe, it, expect } from "vitest";
+import type {
+  TestUserType,
+  TestOrganizationType,
+} from "../../helpers/userAndOrg";
+import {
+  createTestUserAndOrganization,
+  createTestUser,
+} from "../../helpers/userAndOrg";
+
+import { createEventWithRegistrant } from "../../helpers/events";
+import type mongoose from "mongoose";
+
+let MONGOOSE_INSTANCE: typeof mongoose;
+let testUser: TestUserType;
+let testUser2: TestUserType;
+let testUser3: TestUserType;
+let testOrganization2: TestOrganizationType;
+let testOrganization3: TestOrganizationType;
+
+beforeAll(async () => {
+  MONGOOSE_INSTANCE = await connect();
+  testUser = await createTestUser("SUPERADMIN");
+  [testUser2, testOrganization2] = await createTestUserAndOrganization();
+  [testUser3, testOrganization3] = await createTestUserAndOrganization(
+    true,
+    false,
+    true,
+    undefined
+  );
+});
+
+afterAll(async () => {
+  await disconnect(MONGOOSE_INSTANCE);
+});
+
+describe("resolvers -> Query -> eventsByUserType", () => {
+  describe("resolvers -> Query -> events -> SUPERADMIN", () => {
+    beforeAll(async () => {
+      await createEventWithRegistrant(
+        testUser2?._id,
+        testOrganization2?._id,
+        true,
+        "ONCE"
+      );
+      await createEventWithRegistrant(
+        testUser2?._id,
+        testOrganization2?._id,
+        true,
+        "ONCE",
+        undefined,
+        false
+      );
+    });
+
+    afterAll(async () => {
+      await dropCollection(MONGOOSE_INSTANCE, "events");
+    });
+
+    it(`returns list of existing public and private events sorted by ascending order of event._id for SUPERADMIN
+          if args.orderBy === 'id_ASC'`, async () => {
+      const sort = {
+        _id: 1,
+      };
+
+      const args: QueryEventsByUserTypeArgs = {
+        orgId: testOrganization2?._id,
+        userId: testUser?._id,
+        orderBy: "id_ASC",
+      };
+      const { eventsByUserType } = await import(
+        "../../../src/resolvers/Query/eventsByUserType"
+      );
+      const eventsByUserTypePayload = await eventsByUserType?.({}, args, {});
+
+      const eventsByUserTypeInfo = await Event.find({
+        organization: testOrganization2?._id,
+        status: "ACTIVE",
+      })
+        .sort(sort)
+        .populate("creator", "-password")
+        .populate("tasks")
+        .populate("admins", "-password")
+        .lean();
+
+      expect(eventsByUserTypePayload).toEqual(eventsByUserTypeInfo);
+    });
+  });
+
+  describe("resolvers -> Query -> events -> ADMIN", () => {
+    beforeAll(async () => {
+      await createEventWithRegistrant(
+        testUser2?._id,
+        testOrganization2?._id,
+        true,
+        "ONCE"
+      );
+      await createEventWithRegistrant(
+        testUser2?._id,
+        testOrganization2?._id,
+        true,
+        "ONCE",
+        testUser3?._id,
+        false
+      );
+      await createEventWithRegistrant(
+        testUser?._id,
+        testOrganization3?._id,
+        true,
+        "ONCE"
+      );
+    });
+
+    afterAll(async () => {
+      await dropCollection(MONGOOSE_INSTANCE, "events");
+    });
+
+    it(`returns list of existing public and private events sorted by ascending order of event._id for Organization ADMIN
+          if args.orderBy === 'id_ASC'`, async () => {
+      const args: QueryEventsByUserTypeArgs = {
+        orderBy: "id_ASC",
+        orgId: testOrganization2?._id,
+        userId: testUser2?._id,
+      };
+      const { eventsByUserType } = await import(
+        "../../../src/resolvers/Query/eventsByUserType"
+      );
+      const eventsByUserTypePayload = await eventsByUserType?.({}, args, {});
+
+      expect(eventsByUserTypePayload).toHaveLength(2);
+    });
+
+    it(`does not return list of another organization's existing events sorted by ascending order of event._id for organization's ADMIN
+    if args.orderBy === 'id_ASC'`, async () => {
+      const args: QueryEventsByUserTypeArgs = {
+        orgId: testOrganization2?._id,
+        userId: testUser2?._id,
+        orderBy: "id_ASC",
+      };
+      const { eventsByUserType } = await import(
+        "../../../src/resolvers/Query/eventsByUserType"
+      );
+      const eventsByUserTypePayload = await eventsByUserType?.({}, args, {});
+
+      expect(eventsByUserTypePayload).toHaveLength(2);
+    });
+  });
+
+  describe("resolvers -> Query -> events -> USER", () => {
+    beforeAll(async () => {
+      await createEventWithRegistrant(
+        testUser?._id,
+        testOrganization3?._id,
+        true,
+        "ONCE"
+      );
+      await createEventWithRegistrant(
+        testUser?._id,
+        testOrganization3?._id,
+        true,
+        "ONCE",
+        testUser3?._id,
+        false
+      );
+      await createEventWithRegistrant(
+        testUser?._id,
+        testOrganization3?._id,
+        true,
+        "ONCE",
+        undefined,
+        false
+      );
+    });
+
+    afterAll(async () => {
+      await dropCollection(MONGOOSE_INSTANCE, "events");
+    });
+
+    it(`returns list of existing public events sorted by ascending order of event._id for Organization User
+          if args.orderBy === 'id_ASC'`, async () => {
+      const args: QueryEventsByUserTypeArgs = {
+        orgId: testOrganization3?._id,
+        userId: testUser3?._id,
+        orderBy: "id_ASC",
+      };
+      const { eventsByUserType } = await import(
+        "../../../src/resolvers/Query/eventsByUserType"
+      );
+      const eventsByUserTypePayload = await eventsByUserType?.({}, args, {});
+
+      expect(eventsByUserTypePayload).toHaveLength(2);
+    });
+  });
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR Fixes:
- The ability to make events private where only participants can see who is attending
- The optional ability to make private events invisible to persons not attending

**Issue Number:**
Fixes #354 

**Did you add tests for your changes?**
In progress

**Snapshots/Videos:**
```JS
 query getEventByUserType ($userId: ID!, $orgId:ID!){
  eventsByUserType(userId: $userId,orgId:$orgId){
    _id
    title
    description
    isPublic
    admins{
      _id
    }
  }
}
```

**If relevant, did you update the documentation?**
N/A

**Summary**
The query takes in the signed-in `userId` and `orgId` which is passed through the client and returns the events based on `UserType`

- `SUPERADMIN` will see all public and private events
-  `ADMIN` will see all organization's public and private events.
- `USER` will see all Organization's public events and only private events they registered as an attendee.

**Does this PR introduce a breaking change?**
No, We only need to change the query used by the client to use this current implementation.


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes
