### PR TITLE
UserUpdate email already exists error fix

### DIFF
--- a/src/resolvers/Mutation/updateUserProfile.ts
+++ b/src/resolvers/Mutation/updateUserProfile.ts
@@ -33,12 +33,12 @@ export const updateUserProfile: MutationResolvers["updateUserProfile"] = async (
     );
   }
 
-  if (args.data?.email !== undefined) {
-    const userWithEmailExists = await User.find({
+  if (args.data?.email && args.data?.email !== currentUser?.email) {
+    const userWithEmailExists = await User.findOne({
       email: args.data?.email,
     });
 
-    if (userWithEmailExists.length > 0) {
+    if (userWithEmailExists) {
       throw new errors.ConflictError(
         requestContext.translate(EMAIL_ALREADY_EXISTS_ERROR.MESSAGE),
         EMAIL_ALREADY_EXISTS_ERROR.MESSAGE,

--- a/tests/resolvers/Mutation/updateUserProfile.spec.ts
+++ b/tests/resolvers/Mutation/updateUserProfile.spec.ts
@@ -188,6 +188,29 @@ describe("resolvers -> Mutation -> updateUserProfile", () => {
     }
   });
 
+  it(`updates if email not changed by user`, async () => {
+    const args: MutationUpdateUserProfileArgs = {
+      data: {
+        email: testUser.email,
+      },
+    };
+
+    const context = {
+      userId: testUser._id,
+    };
+
+    const updateUserProfilePayload = await updateUserProfileResolver?.(
+      {},
+      args,
+      context
+    );
+
+    expect(updateUserProfilePayload).toEqual({
+      ...testUser.toObject(),
+      image: null,
+    });
+  });
+
   it(`updates current user's user object when any single argument(email) is given w/0 changing other fields `, async () => {
     const args: MutationUpdateUserProfileArgs = {
       data: {


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Bugfix

Fixes #1382 

**Did you add tests for your changes?**
Yes

**Summary**
Added a condition that will check if the user changed the email or not. If the email is changed then only it will check if the email already exists or not. Also changed "find" to "findOne" as we know only one user will have a email and it is faster. Unit test is also added.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes
