### PR TITLE
Make maximum rating of events in feedback to 5 [Fixes #1405]

### DIFF
--- a/src/models/Feedback.ts
+++ b/src/models/Feedback.ts
@@ -19,7 +19,7 @@ const feedbackSchema = new Schema({
     type: Number,
     required: true,
     default: 0,
-    max: 10,
+    max: 5,
   },
   review: {
     type: String,

--- a/src/resolvers/Event/averageFeedbackScore.ts
+++ b/src/resolvers/Event/averageFeedbackScore.ts
@@ -9,8 +9,7 @@ export const averageFeedbackScore: EventResolvers["averageFeedbackScore"] =
       .select("rating")
       .lean();
 
-    // Return null if no feedback has been submitted
-    if (feedbacks.length === 0) return null;
+    if (feedbacks.length === 0) return 0;
 
     // Return the average feedback score
     const sum = feedbacks.reduce(

--- a/tests/helpers/feedback.ts
+++ b/tests/helpers/feedback.ts
@@ -15,7 +15,7 @@ export const createFeedbackWithIDs = async (
 ): Promise<TestFeedbackType> => {
   const feedback = await Feedback.create({
     eventId,
-    rating: 7,
+    rating: 3,
     review: nanoid(),
   });
 

--- a/tests/resolvers/Event/averageFeedbackScore.test.ts
+++ b/tests/resolvers/Event/averageFeedbackScore.test.ts
@@ -47,6 +47,6 @@ describe("resolvers -> Event -> averageFeedbackScore", () => {
       {}
     );
 
-    expect(averageFeedbackScorePayload).toEqual(7);
+    expect(averageFeedbackScorePayload).toEqual(3);
   });
 });

--- a/tests/resolvers/Event/averageFeedbackScore.test.ts
+++ b/tests/resolvers/Event/averageFeedbackScore.test.ts
@@ -24,7 +24,7 @@ afterAll(async () => {
 });
 
 describe("resolvers -> Event -> averageFeedbackScore", () => {
-  it(`Should return null if there are no submitted feedbacks for the event`, async () => {
+  it(`Should return 0 if there are no submitted feedbacks for the event`, async () => {
     const parent = testEvent!.toObject();
 
     const averageFeedbackScorePayload = await averageFeedbackScoreResolver?.(
@@ -33,7 +33,7 @@ describe("resolvers -> Event -> averageFeedbackScore", () => {
       {}
     );
 
-    expect(averageFeedbackScorePayload).toEqual(null);
+    expect(averageFeedbackScorePayload).toEqual(0);
   });
 
   it(`Should return the proper average score if there are some submitted feedbacks for the event`, async () => {

--- a/tests/resolvers/Mutation/addFeedback.spec.ts
+++ b/tests/resolvers/Mutation/addFeedback.spec.ts
@@ -75,7 +75,7 @@ describe("resolvers -> Query -> addFeedback", () => {
       const args: MutationAddFeedbackArgs = {
         data: {
           eventId: testEvent!._id,
-          rating: 7,
+          rating: 4,
           review: "Test Review",
         },
       };

--- a/tests/resolvers/Mutation/addFeedback.spec.ts
+++ b/tests/resolvers/Mutation/addFeedback.spec.ts
@@ -42,7 +42,7 @@ describe("resolvers -> Query -> addFeedback", () => {
       const args: MutationAddFeedbackArgs = {
         data: {
           eventId: Types.ObjectId().toString(),
-          rating: 7,
+          rating: 4,
           review: "Test Review",
         },
       };
@@ -116,7 +116,7 @@ describe("resolvers -> Query -> addFeedback", () => {
       const args: MutationAddFeedbackArgs = {
         data: {
           eventId: testEvent!._id,
-          rating: 7,
+          rating: 4,
           review: "Test Review",
         },
       };
@@ -149,7 +149,7 @@ describe("resolvers -> Query -> addFeedback", () => {
     const args: MutationAddFeedbackArgs = {
       data: {
         eventId: testEvent!._id,
-        rating: 7,
+        rating: 4,
         review: "Test Review",
       },
     };
@@ -166,7 +166,7 @@ describe("resolvers -> Query -> addFeedback", () => {
 
     expect(payload).toMatchObject({
       eventId: testEvent!._id,
-      rating: 7,
+      rating: 4,
       review: "Test Review",
     });
   });
@@ -182,7 +182,7 @@ describe("resolvers -> Query -> addFeedback", () => {
       const args: MutationAddFeedbackArgs = {
         data: {
           eventId: testEvent!._id,
-          rating: 7,
+          rating: 4,
           review: "Test Review",
         },
       };


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Bugfix
<!-- E.g. a bugfix, feature, refactoring, etc… -->
Fixes #1405

**Did you add tests for your changes?**
Yes
<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**
NA
<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
NA
<!--Add link to Talawa-Docs.-->

**Summary**
As discussed with @palisadoes, the maximum feedback rating in event management should be `5` to maintain consistency. This PR updates the same to be 5 instead of 10. 
 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
NA
<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->
