### PR TITLE
Issue#974 in talawa-api (Docker for Easy Local Devlopment)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:19-bullseye
+FROM node:lts
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:19-bullseye
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+EXPOSE 4000
+
+CMD ["npm", "run", "dev"]

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -6,14 +6,14 @@ This document provides instructions on how to set up and start a running instanc
 
 <!-- TOC -->
 
-- [Talawa-API Installation](#talawa-api-installation)
-- [Table of Contents](#table-of-contents)
-- [Installation](#installation)
-  - [Install node.js](#install-nodejs)
-  - [Install git](#install-git)
-  - [Setting up this repository](#setting-up-this-repository)
+
+- [Prerequisites](#prerequisites)
+  - [Install Node.js](#install-nodejs)
+  - [Install Git](#install-git)
+  - [Setting Up This Repository](#setting-up-this-repository)
   - [Install the Required Packages](#install-the-required-packages)
-  - [Installation using Docker](#installation-using-docker)
+- [Installation with Docker](#installation-using-docker)
+- [Installation without Docker](#installation-without-docker)
   - [Install MongoDB](#install-mongodb)
     - [Setting up the mongoDB database](#setting-up-the-mongodb-database)
   - [Install Redis](#install-redis)
@@ -70,7 +70,7 @@ This document provides instructions on how to set up and start a running instanc
 
 <!-- /TOC -->
 
-# Installation
+# Prerequisites
 
 You will need to have copies of your code on your local system. Here's how to do that.
 
@@ -110,7 +110,7 @@ Install the packages required by `talawa-api` using this command:
 npm install
 ```
 
-## Installation using Docker
+# Installation with Docker
 
 > - **Requires Docker and Docker Compose to be installed**
 > - Will start a local mongodb and redis instances
@@ -134,6 +134,7 @@ OR
 ```sh
 docker-compose up
 ```
+# Installation without Docker
 
 ## Install MongoDB
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -109,6 +109,31 @@ Install the packages required by `talawa-api` using this command:
 npm install
 ```
 
+## Installation using Docker
+
+> - **Requires Docker and Docker Compose to be installed**
+> - Will start a local mongodb and redis instances
+
+It's important to configure Talawa-API to complete it's setup.
+
+You can use our interactive setup script for the configuration. Use the following command for the same.
+
+```
+npm run setup
+```
+
+It can be done manually as well and here's how to do it. - [The .env Configuration File](#the-env-configuration-file)
+
+Now use the following command to run docker containers -
+
+```sh
+docker compose up
+```
+OR
+```sh
+docker-compose up
+```
+
 ## Install MongoDB
 
 Talawa-api makes use of `MongoDB` for its database needs. We make use of `mongoose ODM` to interact with the MongoDB database from within the code.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -13,6 +13,7 @@ This document provides instructions on how to set up and start a running instanc
   - [Install git](#install-git)
   - [Setting up this repository](#setting-up-this-repository)
   - [Install the Required Packages](#install-the-required-packages)
+  - [Installation using Docker](#installation-using-docker)
   - [Install MongoDB](#install-mongodb)
     - [Setting up the mongoDB database](#setting-up-the-mongodb-database)
   - [Install Redis](#install-redis)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,6 +20,10 @@ services:
     depends_on:
       - mongodb
       - redis-stack-server
+    environment:
+      - MONGO_DB_URL=mongodb://mongodb:27017
+      - REDIS_HOST=redis-stack-server
+      - REDIS_PORT=6379
 
 volumes:
   mongodb-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,26 @@
+services:
+  mongodb:
+    image: mongo:latest
+    ports:
+      - 27017:27017
+    volumes:
+      - mongodb-data:/data/db
+  
+  redis-stack-server:
+    image: redis/redis-stack-server:latest
+    ports:
+      - 6379:6379
+    volumes:
+      - redis-data:/data/redis 
+
+  talawa-api-container:
+    build: .
+    ports:
+      - 4000:4000
+    depends_on:
+      - mongodb
+      - redis-stack-server
+
+volumes:
+  mongodb-data:
+  redis-data:

--- a/setup.ts
+++ b/setup.ts
@@ -319,7 +319,8 @@ async function main(): Promise<void> {
   const { shouldSetMongoDb } = await inquirer.prompt({
     type: "confirm",
     name: "shouldSetMongoDb",
-    message: "Would you like to set up a MongoDB URL?",
+    message:
+      "(If using Docker dont set up a MongoDB URL)\nWould you like to set up a MongoDB URL?",
     default: true,
   });
 

--- a/setup.ts
+++ b/setup.ts
@@ -311,23 +311,29 @@ async function main(): Promise<void> {
 
   accessAndRefreshTokens(accessToken, refreshToken);
 
-  if (process.env.MONGO_DB_URL) {
-    console.log(
-      `\nMongoDB URL already exists with the value:\n${process.env.MONGO_DB_URL}`
-    );
-  }
-  const { shouldSetMongoDb } = await inquirer.prompt({
+  const { isDockerInstallation } = await inquirer.prompt({
     type: "confirm",
-    name: "shouldSetMongoDb",
-    message:
-      "(If using Docker dont set up a MongoDB URL)\nWould you like to set up a MongoDB URL?",
-    default: true,
+    name: "isDockerInstallation",
+    message: "Are you setting up this project using Docker?",
+    default: false,
   });
+  if (!isDockerInstallation) {
+    if (process.env.MONGO_DB_URL) {
+      console.log(
+        `\nMongoDB URL already exists with the value:\n${process.env.MONGO_DB_URL}`
+      );
+    }
+    const { shouldSetMongoDb } = await inquirer.prompt({
+      type: "confirm",
+      name: "shouldSetMongoDb",
+      message: "Would you like to set up a MongoDB URL?",
+      default: true,
+    });
 
-  if (shouldSetMongoDb) {
-    await mongoDB();
+    if (shouldSetMongoDb) {
+      await mongoDB();
+    }
   }
-
   if (process.env.RECAPTCHA_SECRET_KEY) {
     console.log(
       `\nreCAPTCHA secret key already exists with the value ${process.env.RECAPTCHA_SECRET_KEY}`


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Added Dockerfile and docker-compose file for easy setup locally

**Issue Number:**

Fixes PalisadoesFoundation/talawa-admin#974

**Did you add tests for your changes?**

No

**Snapshots/Videos:**
N/A

**If relevant, did you update the documentation?**

Yes Updated the Docs

**Does this PR introduce a breaking change?**
No

**Summary:**
I have created method to quickly setup talawa-api on local machines using Docker. The Dockerfile will create a docker image of the talawa-api. Then docker-compose will pull mongodb and redis images from docker hub and will start them locally as containers with talawa-api container.

**Other information**
This PR is Releated to this issue  - https://github.com/PalisadoesFoundation/talawa-admin/issues/974

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes
