### PR TITLE
Post and Organization image deletion fixed

### DIFF
--- a/src/resolvers/Mutation/removeOrganization.ts
+++ b/src/resolvers/Mutation/removeOrganization.ts
@@ -15,6 +15,7 @@ import {
 import { cacheOrganizations } from "../../services/OrganizationCache/cacheOrganizations";
 import { findOrganizationsInCache } from "../../services/OrganizationCache/findOrganizationsInCache";
 import { deleteOrganizationFromCache } from "../../services/OrganizationCache/deleteOrganizationFromCache";
+import { deletePreviousImage as deleteImage } from "../../utilities/encodedImageStorage/deletePreviousImage";
 /**
  * This function enables to remove an organization.
  * @param _parent - parent of current request
@@ -130,6 +131,10 @@ export const removeOrganization: MutationResolvers["removeOrganization"] =
     });
 
     await deleteOrganizationFromCache(organization);
+
+    if (organization?.image) {
+      await deleteImage(organization?.image);
+    }
 
     // Returns updated currentUser.
     return await User.findOne({

--- a/src/resolvers/Mutation/removePost.ts
+++ b/src/resolvers/Mutation/removePost.ts
@@ -11,6 +11,8 @@ import { cacheOrganizations } from "../../services/OrganizationCache/cacheOrgani
 import { deletePostFromCache } from "../../services/PostCache/deletePostFromCache";
 import { findPostsInCache } from "../../services/PostCache/findPostsInCache";
 import { cachePosts } from "../../services/PostCache/cachePosts";
+import { deletePreviousImage as deleteImage } from "../../utilities/encodedImageStorage/deletePreviousImage";
+import { deletePreviousVideo as deleteVideo } from "../../utilities/encodedVideoStorage/deletePreviousVideo";
 /**
  * This function enables to remove a post.
  * @param _parent - parent of current request
@@ -82,11 +84,21 @@ export const removePost: MutationResolvers["removePost"] = async (
   }
 
   // Deletes the post.
-  await Post.deleteOne({
+  const deletedPost = await Post.findOneAndDelete({
     _id: args.id,
   });
 
   await deletePostFromCache(args.id);
+
+  //deletes the image in post
+  if (deletedPost?.imageUrl) {
+    await deleteImage(deletedPost?.imageUrl);
+  }
+
+  //deletes the video in post
+  if (deletedPost?.videoUrl) {
+    await deleteVideo(deletedPost?.videoUrl);
+  }
 
   // Removes the post from the organization, doesn't fail if the post wasn't pinned
   const updatedOrganization = await Organization.findOneAndUpdate(


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

Fixes #1424 

**Did you add tests for your changes?**
Yes

**Summary**
This PR makes sure that when Posts and Organization is deleted, there image is also deleted from file system and encodedImages.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes

**After changes**

https://github.com/PalisadoesFoundation/talawa-api/assets/123248648/dd5b6ca7-471e-46e5-8391-83ed80b74f14


