### PR TITLE
Feat: Fix issue #1453

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,11 +13,6 @@ updates:
       - "dependencies"
     # Specify the target branch for PRs
     target-branch: "develop"
-    # Include all minor updates in a single PR
-    grouping:
-      minor:
-        include:
-          - "*"
     # Customize commit message prefix
     commit-message:
       prefix: "chore(deps):"


### PR DESCRIPTION
[grouping] is not available for npm package management

<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

bugfix

**Issue Number:**

Fixes #1453

**Did you add tests for your changes?**

NA

**Snapshots/Videos:**

NA

**If relevant, did you update the documentation?**

NA

**Summary**

This PR introduces a bugfix to address the ignored configuration issue identified in the recent dependabot run.

**Does this PR introduce a breaking change?**

No

**Other information**

None

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes
