### PR TITLE
Revert "Feat: Upgrade package express-rate-limit from 5.5.1 to 7.1.5 #1463"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "dotenv": "^8.6.0",
         "express": "^4.18.2",
         "express-mongo-sanitize": "^2.2.0",
-        "express-rate-limit": "^7.1.5",
+        "express-rate-limit": "^5.5.1",
         "firebase-admin": "^11.9.0",
         "graphql": "^16.8.1",
         "graphql-depth-limit": "^1.1.0",
@@ -8897,18 +8897,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.1.5.tgz",
-      "integrity": "sha512-/iVogxu7ueadrepw1bS0X0kaRC/U0afwiYRSLg68Ts+p4Dc85Q5QKsOnPS/QUjPMHvOJQtBDrZgvkOzf8ejUYw==",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": "4 || 5 || ^5.0.0-beta.1"
-      }
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-5.5.1.tgz",
+      "integrity": "sha512-MTjE2eIbHv5DyfuFz4zLYWxpqVhEhkTiwFGuB74Q9CSou2WHO52nlE5y3Zlg6SIsiYUIPj6ifFxnkPz6O3sIUg=="
     },
     "node_modules/express/node_modules/body-parser": {
       "version": "1.20.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "dotenv": "^8.6.0",
     "express": "^4.18.2",
     "express-mongo-sanitize": "^2.2.0",
-    "express-rate-limit": "^7.1.5",
+    "express-rate-limit": "^5.5.1",
     "firebase-admin": "^11.9.0",
     "graphql": "^16.8.1",
     "graphql-depth-limit": "^1.1.0",


### PR DESCRIPTION
Reverts PalisadoesFoundation/talawa-api#1473

1. I'm going to have to revert this. It's causing our push.yml workflow to fail. 
1. Please check it out:
    - https://github.com/PalisadoesFoundation/talawa-api/actions/runs/7152285097
