### PR TITLE
Added node_modules caching for CI workflows.

### DIFF
--- a/.github/workflows/inspect.yml
+++ b/.github/workflows/inspect.yml
@@ -1,22 +1,37 @@
 name: CI
 
 on: [push]
- 
+
 jobs:
   test:
     name: Check Schema
     runs-on: ubuntu-latest
- 
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Restore node_modules from cache
+        id: cache-npm
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: |
+            ~/.npm
+            node_modules
+          key: ${{ runner.os }}-node-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ env.cache-name }}-
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install dependencies
         run: npm ci
 
       - name: Generate schema.graphql
-        run: npm run gen:schema 
- 
+        run: npm run gen:schema
+
       - uses: kamilkisiela/graphql-inspector@master
         with:
           schema: develop:schema.graphql

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,10 +14,10 @@ on:
   pull_request:
     branches:
       - '**'
-      
+
 env:
-    CODECOV_UNIQUE_NAME: CODECOV_UNIQUE_NAME-${{ github.run_id }}-${{ github.run_number }}
-          
+  CODECOV_UNIQUE_NAME: CODECOV_UNIQUE_NAME-${{ github.run_id }}-${{ github.run_number }}
+
 jobs:
   Code-Quality-Checks:
     name: Check for linting, formatting, and type errors
@@ -26,18 +26,33 @@ jobs:
       - name: Checkout repository content
         uses: actions/checkout@v3
 
+      - name: Restore node_modules from cache
+        id: cache-npm
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: |
+            ~/.npm
+            node_modules
+          key: ${{ runner.os }}-code-quality-checks-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-code-quality-checks-${{ env.cache-name }}-
+            ${{ runner.os }}-code-quality-checks-
+            ${{ runner.os }}-
+
       - name: Install Dependencies
         run: npm ci
-            
+
       - name: Run ESLint to check for linting errors
         run: npm run lint:check
-          
+
       - name: Check for formatting errors
         run: npm run format:check
-          
+
       - name: Run Typescript Type-Checker
         run: npm run typecheck
-  
+
   Test-Application:
     name: Testing Application
     runs-on: ubuntu-latest
@@ -68,16 +83,16 @@ jobs:
       MONGO_DB_URL: mongodb://localhost:27017/talawa-test-db
       REDIS_HOST: localhost
       REDIS_PORT: 6379
-#       ACCESS_TOKEN_SECRET: ${{ secrets.ACCESS_TOKEN_SECRET }}
-#       REFRESH_TOKEN_SECRET: ${{ secrets.REFRESH_TOKEN_SECRET }}
+    #       ACCESS_TOKEN_SECRET: ${{ secrets.ACCESS_TOKEN_SECRET }}
+    #       REFRESH_TOKEN_SECRET: ${{ secrets.REFRESH_TOKEN_SECRET }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        
+
       - name: Generate Access Token Secret
         run: echo "ACCESS_TOKEN_SECRET=$(openssl rand -hex 32)" >> $GITHUB_ENV
-        
+
       - name: Generate Refresh Token Secret
         run: echo "REFRESH_TOKEN_SECRET=$(openssl rand -hex 32)" >> $GITHUB_ENV
 
@@ -100,7 +115,7 @@ jobs:
         with:
           verbose: true
           fail_ci_if_error: false
-          name: '${{env.CODECOV_UNIQUE_NAME}}'  
+          name: '${{env.CODECOV_UNIQUE_NAME}}'
 
       - name: Test acceptable level of code coverage
         uses: VeryGoodOpenSource/very_good_coverage@v2
@@ -123,4 +138,3 @@ jobs:
         if: env.RUN_JSDOCS == 'True'
         run: echo "Run JSdocs :${{ env.RUN_JSDOCS }}"
 
-          


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Added caching of node_modules for GitHub workflows. Caching was only needed in these 2 files coz other workflows are using `actions/setup-node@v3` action, which comes with caching.
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #1471

**Did you add tests for your changes?**
This changes doesn't require tests.



<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
NO
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
YES
<!--Yes or No-->
