### PR TITLE
Revert "dotenv 16.3.1 upgrade"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "copy-paste": "^1.5.3",
         "cors": "^2.8.5",
         "cross-env": "^7.0.3",
-        "dotenv": "^16.3.1",
+        "dotenv": "^8.6.0",
         "express": "^4.18.2",
         "express-mongo-sanitize": "^2.2.0",
         "express-rate-limit": "^5.5.1",
@@ -3849,6 +3849,18 @@
         "fast-querystring": "^1.1.1",
         "fast-url-parser": "^1.1.3",
         "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@graphql-tools/prisma-loader/node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/@graphql-tools/prisma-loader/node_modules/urlpattern-polyfill": {
@@ -7851,14 +7863,11 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+        "node": ">=10"
       }
     },
     "node_modules/dset": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "copy-paste": "^1.5.3",
     "cors": "^2.8.5",
     "cross-env": "^7.0.3",
-    "dotenv": "^16.3.1",
+    "dotenv": "^8.6.0",
     "express": "^4.18.2",
     "express-mongo-sanitize": "^2.2.0",
     "express-rate-limit": "^5.5.1",


### PR DESCRIPTION
Reverts PalisadoesFoundation/talawa-api#1501

I'm going to have to revert this. It's causing errors in our documentation workflow.

Please take a look at the error message we are getting to determine the cause of the problem

- https://github.com/PalisadoesFoundation/talawa-api/actions/runs/7232029454