### PR TITLE
added-node-version-in-docs

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -72,7 +72,9 @@ You will need to have copies of your code on your local system. Here's how to do
 
 ## Install node.js
 
-Best way to install and manage `node.js` is making use of node version managers. Two most popular node version managers right now are [fnm](https://github.com/Schniz/fnm) and [nvm](https://github.com/nvm-sh/nvm). We'd recommend `fnm` because it's written in `rust` and is much faster than `nvm`. Install whichever one you want and follow their guide to set up `node.js` on your system.
+Best way to install and manage `node.js` is making use of node version managers. Two most popular node version managers right now are [fnm](https://github.com/Schniz/fnm) and [nvm](https://github.com/nvm-sh/nvm). We'd recommend `fnm` because it's written in `rust` and is much faster than `nvm`. Install whichever one you want and follow their guide to set up `node.js` on your system. It is advised to use Node.js version `v18` or later.
+
+> Note: If you encounter a warning about the deprecated punycode module and are using Node.js version 20 or above, please be aware that this warning is expected and can be safely ignored. This will be fixed automatically in a future release of graphql-tools.
 
 ## Install git
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR updates the documentation in Installation.md to specify the recommended Node.js version (`v18` or above) and provides a rationale for this recommendation.

**Issue Number:**

Fixes #1547 

**Did you add tests for your changes?**

No - Markdown was modified, so testing is not required in this case.

**If relevant, did you update the documentation?**

Yes

**Summary**

This PR addresses the deprecation of the `PunyCode` module in Node.js v21. This becomes a concern as the `fast-url-parser` library, a dependency of `@graphql-tools`, relies on this module. While the immediate fix is beyond the scope of this PR, it is recommended to monitor future updates of `@graphql-tools` for a resolution.

**Does this PR introduce a breaking change?**

No

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes
