### PR TITLE
Fix: The INSTALLATION.md file doesn't tell you to create a .env file before running setup.  #1530

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -234,6 +234,13 @@ Remember to adjust any paths or details as needed for your specific environment.
 
 # Configuration
 
+## The .env Configuration File
+
+A file named `.env` is required in the root directory of talawa-api for storing environment variables used at runtime. It is not a part of the repo and you will have to create it. For a sample of `.env` file there is a file named `.env.sample` in the root directory. Create a new `.env` file by copying the contents of the `.env.sample` into `.env` file.
+
+```
+cp .env.sample .env
+```
 It's important to configure Talawa-API to complete it's setup.
 
 You can use our interactive setup script for the configuration. Use the following command for the same.
@@ -243,14 +250,6 @@ npm run setup
 ```
 
 It can be done manually as well and here's how to do it.
-
-## The .env Configuration File
-
-A file named `.env` is required in the root directory of talawa-api for storing environment variables used at runtime. It is not a part of the repo and you will have to create it. For a sample of `.env` file there is a file named `.env.sample` in the root directory. Create a new `.env` file by copying the contents of the `.env.sample` into `.env` file.
-
-```
-cp .env.sample .env
-```
 
 This `.env` file must be populated with the following environment variables for talawa-api to work:
 

--- a/setup.ts
+++ b/setup.ts
@@ -301,7 +301,8 @@ async function main(): Promise<void> {
   console.log("Welcome to the Talawa API setup! 🚀");
 
   if (!fs.existsSync(".env")) {
-    fs.copyFileSync(".env.sample", ".env");
+    console.log("Please copy the contents of .env.sample to .env file");
+    abort();
   } else {
     checkEnvFile();
   }


### PR DESCRIPTION

**What kind of change does this PR introduce?**
Two file changes, adding content for copied .env.sample into  .env file before running setup.and on trying  setup before copied   .env.sample into  .env file , throw an message in console for copied .env.sample into .env file


**Issue Number:**

Fixes #1530 

**Did you add tests for your changes?**

NA

**Snapshots/Videos:**
![talwa-api](https://github.com/PalisadoesFoundation/talawa-api/assets/125847751/8c504597-c96a-4fdf-b02a-68977ca6d5ca)
![Screenshot 2023-12-25 081657](https://github.com/PalisadoesFoundation/talawa-api/assets/125847751/536489b2-8c0e-4261-a4d3-71201974eddf)



**If relevant, did you update the documentation?**

**Summary**

**Does this PR introduce a breaking change?**

**Other information**

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes
