### PR TITLE
feat: Updated the LAST_RESORT_SUPERADMIN_EMAIL logic during setup

### DIFF
--- a/setup.ts
+++ b/setup.ts
@@ -550,11 +550,14 @@ async function main(): Promise<void> {
   if (shouldSetSuperUserEmail) {
     await superAdmin();
   }
-
-  // get mail_username from .env
-  if (!process.env.LAST_RESORT_SUPERADMIN_EMAIL) {
+  // check if mail_username is set, if not, set it to mail_username's value
+  else if (
+    !shouldSetSuperUserEmail &&
+    !process.env.LAST_RESORT_SUPERADMIN_EMAIL &&
+    process.env.MAIL_USERNAME
+  ) {
     console.log(
-      'No "MAIL_USERNAME" configured, setting it to "LAST_RESORT_SUPERADMIN_EMAIL"\'s value.'
+      "No super admin email configured, setting it to mail username's value."
     );
     const config = dotenv.parse(fs.readFileSync(".env"));
     config.LAST_RESORT_SUPERADMIN_EMAIL = config.MAIL_USERNAME;

--- a/setup.ts
+++ b/setup.ts
@@ -551,6 +551,19 @@ async function main(): Promise<void> {
     await superAdmin();
   }
 
+  // get mail_username from .env
+  if (!process.env.LAST_RESORT_SUPERADMIN_EMAIL) {
+    console.log(
+      'No "MAIL_USERNAME" configured, setting it to "LAST_RESORT_SUPERADMIN_EMAIL"\'s value.'
+    );
+    const config = dotenv.parse(fs.readFileSync(".env"));
+    config.LAST_RESORT_SUPERADMIN_EMAIL = config.MAIL_USERNAME;
+    fs.writeFileSync(".env", "");
+    for (const key in config) {
+      fs.appendFileSync(".env", `${key}=${config[key]}\n`);
+    }
+  }
+
   if (!isDockerInstallation) {
     const { shouldRunDataImport } = await inquirer.prompt([
       {

--- a/setup.ts
+++ b/setup.ts
@@ -553,12 +553,14 @@ async function main(): Promise<void> {
   // check if mail_username is set, if not, set it to mail_username's value
   else if (
     !shouldSetSuperUserEmail &&
-    !process.env.LAST_RESORT_SUPERADMIN_EMAIL &&
-    process.env.MAIL_USERNAME
+    !process.env.LAST_RESORT_SUPERADMIN_EMAIL
+    // process.env.MAIL_USERNAME
   ) {
-    console.log(
-      "No super admin email configured, setting it to mail username's value."
-    );
+    if (process.env.MAIL_USERNAME) {
+      console.log(
+        "No super admin email configured, setting it to mail username's value."
+      );
+    }
     const config = dotenv.parse(fs.readFileSync(".env"));
     config.LAST_RESORT_SUPERADMIN_EMAIL = config.MAIL_USERNAME;
     fs.writeFileSync(".env", "");


### PR DESCRIPTION


**What kind of change does this PR introduce?**

- This is PR is a **feature** as requested in #1550 

**Issue Number:**

- Fixes #1550

**Did you add tests for your changes?**

<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

No

**Snapshots/Videos:**

- When `LAST_RESORT_SUPERADMIN_EMAIL` is not configured:

[not_configured.webm](https://github.com/PalisadoesFoundation/talawa-api/assets/116624667/fb48063e-3479-4610-8af9-dc2fadadbaa6)

- When `LAST_RESORT_SUPERADMIN_EMAIL` is configured:

[configured.webm](https://github.com/PalisadoesFoundation/talawa-api/assets/116624667/7085df2e-207d-4ec2-845f-5b6c8d2b8156)


<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
There's no need to change the documentation.

<!--Add link to Talawa-Docs.-->

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

- **Motivation** : When running the `npm run setup` command, if the `LAST_RESORT_SUPERADMIN_EMAIL` value has not been configured, it would be beneficial for it to default to the value of `MAIL_USERNAME`. 
- **Solution** : Modified the setup process to automatically set the `LAST_RESORT_SUPERADMIN_EMAIL` to the value of `MAIL_USERNAME` if it is not explicitly configured during the setup.


**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->
