### PR TITLE
Fixes access to image from the frontend

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -70,6 +70,10 @@ app.use(
 );
 app.use(mongoSanitize());
 app.use(cors());
+app.use("/images", (req, res, next) => {
+  res.setHeader("Cross-Origin-Resource-Policy", "cross-origin");
+  next();
+});
 app.use(express.json({ limit: "50mb" }));
 app.use(graphqlUploadExpress());
 app.use(express.urlencoded({ limit: "50mb", extended: true }));

--- a/src/app.ts
+++ b/src/app.ts
@@ -70,10 +70,12 @@ app.use(
 );
 app.use(mongoSanitize());
 app.use(cors());
+
 app.use("/images", (req, res, next) => {
   res.setHeader("Cross-Origin-Resource-Policy", "cross-origin");
   next();
 });
+
 app.use(express.json({ limit: "50mb" }));
 app.use(graphqlUploadExpress());
 app.use(express.urlencoded({ limit: "50mb", extended: true }));


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug Fix: Images doesn't render on the frontend because same-origin policy in server blocks access to image stored inside the images folder on the server.

**Issue Number:**

Fixes #1626 

**Snapshots/Videos:**

Before:
![image](https://github.com/PalisadoesFoundation/talawa-api/assets/49762303/7de30cbe-e463-4804-92d9-bdc160082657)

After:
![image](https://github.com/PalisadoesFoundation/talawa-api/assets/49762303/cd8efef9-e49c-4dd9-8a86-7a0238c958e5)

Posts along with the image now renders.
