### PR TITLE
Session timeout

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -548,6 +548,7 @@ type Mutation {
   updateEventProject(data: UpdateEventProjectInput!, id: ID!): EventProject!
   updateLanguage(languageCode: String!): User!
   updateOrganization(data: UpdateOrganizationInput, file: String, id: ID!): Organization!
+  updateOrganizationTimeout(organizationId: ID!, timeout: Int!): Boolean!
   updatePluginStatus(id: ID!, orgId: ID!): Plugin!
   updatePost(data: PostUpdateInput, id: ID!): Post!
   updateTask(data: UpdateTaskInput!, id: ID!): Task
@@ -806,6 +807,7 @@ type Query {
   getDonationById(id: ID!): Donation!
   getDonationByOrgId(orgId: ID!): [Donation]
   getDonationByOrgIdConnection(first: Int, orgId: ID!, skip: Int, where: DonationWhereInput): [Donation!]!
+  getOrganizationTimeout(id: ID!): Int!
   getPlugins: [Plugin]
   getlanguage(lang_code: String!): [Translation]
   hasSubmittedFeedback(eventId: ID!, userId: ID!): Boolean

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -41,6 +41,20 @@ export const FEEDBACK_ALREADY_SUBMITTED = {
 
 export const INVALID_OTP = "Invalid OTP";
 
+export const INVALID_TIMEOUT_RANGE = {
+  DESC: "Timeout should be in the range of 15 to 60 minutes.",
+  CODE: "invalid.timeoutRange",
+  MESSAGE: "invalid.timeoutRange",
+  PARAM: "timeout",
+};
+
+export const UPDATE_ORGANIZATION_TIMEOUT_ARGUMENT_MISSING_ERROR = {
+  DESC: "OrganizationId and timeout is required.",
+  CODE: ".arguments.isMissing",
+  MESSAGE: "arguments.isMissing",
+  PARAM: "argumentsMissing",
+};
+
 export const IN_PRODUCTION = process.env.NODE_ENV === "production";
 export const MEMBER_NOT_FOUND_ERROR = {
   DESC: "Member not found",

--- a/src/models/Organization.ts
+++ b/src/models/Organization.ts
@@ -28,6 +28,7 @@ export interface InterfaceOrganization {
   visibleInSearch: boolean | undefined;
   customFields: PopulatedDoc<InterfaceOrganizationCustomField & Document>[];
   createdAt: Date;
+  timeout: number | undefined | null;
 }
 /**
  * This describes the schema for a `Organization` that corresponds to `InterfaceOrganization` document.
@@ -47,6 +48,7 @@ export interface InterfaceOrganization {
  * @param blockedUsers - Collection of Blocked User in the Organization, each object refer to `User` model.
  * @param tags - Collection of tags.
  * @param createdAt - Time stamp of data creation.
+ * @param timeout - Timeout duration in minutes (default is 30 minutes).
  */
 const organizationSchema = new Schema({
   apiUrl: {
@@ -137,6 +139,10 @@ const organizationSchema = new Schema({
   createdAt: {
     type: Date,
     default: Date.now,
+  },
+  timeout: {
+    type: Number,
+    default: 30,
   },
 });
 

--- a/src/resolvers/Mutation/index.ts
+++ b/src/resolvers/Mutation/index.ts
@@ -83,6 +83,7 @@ import { updateEvent } from "./updateEvent";
 import { updateEventProject } from "./updateEventProject";
 import { updateLanguage } from "./updateLanguage";
 import { updateOrganization } from "./updateOrganization";
+import { updateOrganizationTimeout } from "./updateOrganizationTimeout";
 import { updatePluginStatus } from "./updatePluginStatus";
 import { updatePost } from "./updatePost";
 import { updateTask } from "./updateTask";
@@ -178,6 +179,7 @@ export const Mutation: MutationResolvers = {
   updateEventProject,
   updateLanguage,
   updateOrganization,
+  updateOrganizationTimeout,
   updatePluginStatus,
   updateTask,
   updateUserProfile,

--- a/src/resolvers/Mutation/updateOrganizationTimeout.ts
+++ b/src/resolvers/Mutation/updateOrganizationTimeout.ts
@@ -1,0 +1,85 @@
+import { Organization, User } from "../../models";
+import {
+  ORGANIZATION_NOT_FOUND_ERROR,
+  INVALID_TIMEOUT_RANGE,
+  USER_NOT_FOUND_ERROR,
+  UPDATE_ORGANIZATION_TIMEOUT_ARGUMENT_MISSING_ERROR,
+} from "../../constants";
+import type { MutationResolvers } from "../../types/generatedGraphQLTypes";
+import { errors, requestContext } from "../../libraries";
+import { adminCheck } from "../../utilities";
+
+/**
+ * Payload provided with the request for updating organization timeout.
+ */
+interface InterfaceUpdateTimeoutArgs {
+  organizationId: string;
+  timeout: number;
+}
+
+/**
+ * This function updates the timeout for an organization and can only be performed by admin or superadmin users.
+ * @param _parent - parent of the current request
+ * @param args - payload provided with the request, including organizationId and timeout
+ * @param context - context of the entire application, containing user information
+ * @returns - A message true if the organization timeout is updated successfully
+ * @throws - NotFoundError: If the user or organization is not found
+ * @throws - ValidationError: If the user is not an admin or superadmin, or if the timeout is outside the valid range
+ * @throws - InternalServerError: If there is an error updating the organization timeout
+ */
+
+export const updateOrganizationTimeout: MutationResolvers["updateOrganizationTimeout"] =
+  async (_parent, args: InterfaceUpdateTimeoutArgs, context) => {
+    if (!args.organizationId || !args.timeout) {
+      throw new errors.InputValidationError(
+        requestContext.translate(
+          UPDATE_ORGANIZATION_TIMEOUT_ARGUMENT_MISSING_ERROR.MESSAGE
+        ),
+        UPDATE_ORGANIZATION_TIMEOUT_ARGUMENT_MISSING_ERROR.CODE,
+        UPDATE_ORGANIZATION_TIMEOUT_ARGUMENT_MISSING_ERROR.PARAM
+      );
+    }
+    const userId = context.userId;
+    const user = await User.findById(userId).lean();
+    const organization = await Organization.findById(
+      args.organizationId
+    ).lean();
+
+    if (!user) {
+      throw new errors.NotFoundError(
+        requestContext.translate(USER_NOT_FOUND_ERROR.MESSAGE),
+        USER_NOT_FOUND_ERROR.CODE,
+        USER_NOT_FOUND_ERROR.PARAM
+      );
+    }
+    if (!organization) {
+      throw new errors.NotFoundError(
+        requestContext.translate(ORGANIZATION_NOT_FOUND_ERROR.MESSAGE),
+        ORGANIZATION_NOT_FOUND_ERROR.CODE,
+        ORGANIZATION_NOT_FOUND_ERROR.PARAM
+      );
+    }
+
+    // Check if the user is an admin or super admin
+    adminCheck(userId, organization);
+    // superAdminCheck(user);
+
+    // Check if the timeout is in the valid range of 15 to 60 minutes
+    if (args.timeout < 15 || args.timeout > 60) {
+      throw new errors.ValidationError([
+        {
+          message: requestContext.translate(INVALID_TIMEOUT_RANGE.MESSAGE),
+          code: INVALID_TIMEOUT_RANGE.CODE,
+          param: INVALID_TIMEOUT_RANGE.PARAM,
+        },
+      ]);
+    }
+
+    await Organization.findByIdAndUpdate(
+      args.organizationId,
+      { timeout: args.timeout },
+      { new: true }
+    );
+
+    return true;
+  };

--- a/src/resolvers/Mutation/updateOrganizationTimeout.ts
+++ b/src/resolvers/Mutation/updateOrganizationTimeout.ts
@@ -61,8 +61,7 @@ export const updateOrganizationTimeout: MutationResolvers["updateOrganizationTim
     }
 
     // Check if the user is an admin or super admin
-    adminCheck(userId, organization);
-    // superAdminCheck(user);
+    await adminCheck(userId, organization);
 
     // Check if the timeout is in the valid range of 15 to 60 minutes
     if (args.timeout < 15 || args.timeout > 60 || args.timeout % 5 !== 0) {

--- a/src/resolvers/Mutation/updateOrganizationTimeout.ts
+++ b/src/resolvers/Mutation/updateOrganizationTimeout.ts
@@ -65,7 +65,7 @@ export const updateOrganizationTimeout: MutationResolvers["updateOrganizationTim
     // superAdminCheck(user);
 
     // Check if the timeout is in the valid range of 15 to 60 minutes
-    if (args.timeout < 15 || args.timeout > 60) {
+    if (args.timeout < 15 || args.timeout > 60 || args.timeout % 5 !== 0) {
       throw new errors.ValidationError([
         {
           message: requestContext.translate(INVALID_TIMEOUT_RANGE.MESSAGE),

--- a/src/resolvers/Query/getOrganizationTimeout.ts
+++ b/src/resolvers/Query/getOrganizationTimeout.ts
@@ -1,0 +1,36 @@
+// Assuming you have the necessary imports for types and libraries
+
+import {
+  ORGANIZATION_NOT_FOUND_ERROR,
+  USER_NOT_FOUND_ERROR,
+} from "../../constants";
+import { errors, requestContext } from "../../libraries";
+import { Organization, User } from "../../models";
+import type { QueryResolvers } from "../../types/generatedGraphQLTypes";
+import { adminCheck } from "../../utilities";
+
+export const getOrganizationTimeout: QueryResolvers["getOrganizationTimeout"] =
+  async (_parent, args, context) => {
+    const userId = context.userId;
+    const user = await User.findById(userId).lean();
+    const organization = await Organization.findById(args.id).lean();
+
+    if (!user) {
+      throw new errors.NotFoundError(
+        requestContext.translate(USER_NOT_FOUND_ERROR.MESSAGE),
+        USER_NOT_FOUND_ERROR.CODE,
+        USER_NOT_FOUND_ERROR.PARAM
+      );
+    }
+    if (!organization) {
+      throw new errors.NotFoundError(
+        requestContext.translate(ORGANIZATION_NOT_FOUND_ERROR.MESSAGE),
+        ORGANIZATION_NOT_FOUND_ERROR.CODE,
+        ORGANIZATION_NOT_FOUND_ERROR.PARAM
+      );
+    }
+
+    adminCheck(userId, organization);
+
+    return organization?.timeout || 0;
+  };

--- a/src/resolvers/Query/index.ts
+++ b/src/resolvers/Query/index.ts
@@ -11,6 +11,7 @@ import { getDonationById } from "./getDonationById";
 import { getDonationByOrgId } from "./getDonationByOrgId";
 import { getDonationByOrgIdConnection } from "./getDonationByOrgIdConnection";
 import { getlanguage } from "./getlanguage";
+import { getOrganizationTimeout } from "./getOrganizationTimeout";
 import { getPlugins } from "./getPlugins";
 import { me } from "./me";
 import { myLanguage } from "./myLanguage";
@@ -42,6 +43,7 @@ export const Query: QueryResolvers = {
   getDonationByOrgId,
   getDonationByOrgIdConnection,
   getlanguage,
+  getOrganizationTimeout,
   getPlugins,
   isSampleOrganization,
   me,

--- a/src/typeDefs/mutations.ts
+++ b/src/typeDefs/mutations.ts
@@ -225,6 +225,9 @@ export const mutations = gql`
       file: String
     ): Organization! @auth
 
+    updateOrganizationTimeout(organizationId: ID!, timeout: Int!): Boolean!
+      @auth
+
     updatePluginStatus(id: ID!, orgId: ID!): Plugin!
 
     updateUserTag(input: UpdateUserTagInput!): UserTag @auth

--- a/src/typeDefs/queries.ts
+++ b/src/typeDefs/queries.ts
@@ -41,6 +41,8 @@ export const queries = gql`
 
     getlanguage(lang_code: String!): [Translation]
 
+    getOrganizationTimeout(id: ID!): Int! @auth
+
     getPlugins: [Plugin]
     getAdvertisements: [Advertisement]
 

--- a/src/types/generatedGraphQLTypes.ts
+++ b/src/types/generatedGraphQLTypes.ts
@@ -612,6 +612,7 @@ export type Mutation = {
   updateEventProject: EventProject;
   updateLanguage: User;
   updateOrganization: Organization;
+  updateOrganizationTimeout: Scalars['Boolean'];
   updatePluginStatus: Plugin;
   updatePost: Post;
   updateTask?: Maybe<Task>;
@@ -1055,6 +1056,12 @@ export type MutationUpdateOrganizationArgs = {
 };
 
 
+export type MutationUpdateOrganizationTimeoutArgs = {
+  organizationId: Scalars['ID'];
+  timeout: Scalars['Int'];
+};
+
+
 export type MutationUpdatePluginStatusArgs = {
   id: Scalars['ID'];
   orgId: Scalars['ID'];
@@ -1360,6 +1367,7 @@ export type Query = {
   getDonationById: Donation;
   getDonationByOrgId?: Maybe<Array<Maybe<Donation>>>;
   getDonationByOrgIdConnection: Array<Donation>;
+  getOrganizationTimeout: Scalars['Int'];
   getPlugins?: Maybe<Array<Maybe<Plugin>>>;
   getlanguage?: Maybe<Array<Maybe<Translation>>>;
   hasSubmittedFeedback?: Maybe<Scalars['Boolean']>;
@@ -1442,6 +1450,11 @@ export type QueryGetDonationByOrgIdConnectionArgs = {
   orgId: Scalars['ID'];
   skip?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<DonationWhereInput>;
+};
+
+
+export type QueryGetOrganizationTimeoutArgs = {
+  id: Scalars['ID'];
 };
 
 
@@ -2649,6 +2662,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   updateEventProject?: Resolver<ResolversTypes['EventProject'], ParentType, ContextType, RequireFields<MutationUpdateEventProjectArgs, 'data' | 'id'>>;
   updateLanguage?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationUpdateLanguageArgs, 'languageCode'>>;
   updateOrganization?: Resolver<ResolversTypes['Organization'], ParentType, ContextType, RequireFields<MutationUpdateOrganizationArgs, 'id'>>;
+  updateOrganizationTimeout?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationUpdateOrganizationTimeoutArgs, 'organizationId' | 'timeout'>>;
   updatePluginStatus?: Resolver<ResolversTypes['Plugin'], ParentType, ContextType, RequireFields<MutationUpdatePluginStatusArgs, 'id' | 'orgId'>>;
   updatePost?: Resolver<ResolversTypes['Post'], ParentType, ContextType, RequireFields<MutationUpdatePostArgs, 'id'>>;
   updateTask?: Resolver<Maybe<ResolversTypes['Task']>, ParentType, ContextType, RequireFields<MutationUpdateTaskArgs, 'data' | 'id'>>;
@@ -2778,6 +2792,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   getDonationById?: Resolver<ResolversTypes['Donation'], ParentType, ContextType, RequireFields<QueryGetDonationByIdArgs, 'id'>>;
   getDonationByOrgId?: Resolver<Maybe<Array<Maybe<ResolversTypes['Donation']>>>, ParentType, ContextType, RequireFields<QueryGetDonationByOrgIdArgs, 'orgId'>>;
   getDonationByOrgIdConnection?: Resolver<Array<ResolversTypes['Donation']>, ParentType, ContextType, RequireFields<QueryGetDonationByOrgIdConnectionArgs, 'orgId'>>;
+  getOrganizationTimeout?: Resolver<ResolversTypes['Int'], ParentType, ContextType, RequireFields<QueryGetOrganizationTimeoutArgs, 'id'>>;
   getPlugins?: Resolver<Maybe<Array<Maybe<ResolversTypes['Plugin']>>>, ParentType, ContextType>;
   getlanguage?: Resolver<Maybe<Array<Maybe<ResolversTypes['Translation']>>>, ParentType, ContextType, RequireFields<QueryGetlanguageArgs, 'lang_code'>>;
   hasSubmittedFeedback?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<QueryHasSubmittedFeedbackArgs, 'eventId' | 'userId'>>;

--- a/src/utilities/getTimeoutFromJoinedOrganization.ts
+++ b/src/utilities/getTimeoutFromJoinedOrganization.ts
@@ -1,0 +1,23 @@
+import type { Types } from "mongoose";
+import { Organization } from "../models";
+
+interface InterfaceGetTimeoutFromJoinedOrganization {
+  _id: Types.ObjectId;
+  timeout: number | undefined | null;
+}
+
+export const getTimeoutFromJoinedOrganization = async (
+  userId: Types.ObjectId
+): Promise<InterfaceGetTimeoutFromJoinedOrganization[]> => {
+  const organizations = await Organization.find({ members: userId })
+    .select("timeout")
+    .lean();
+
+  const organizationWithTimeout: InterfaceGetTimeoutFromJoinedOrganization[] =
+    organizations.map((org) => ({
+      _id: org._id,
+      timeout: org.timeout,
+    }));
+
+  return organizationWithTimeout;
+};

--- a/tests/helpers/user.ts
+++ b/tests/helpers/user.ts
@@ -19,7 +19,29 @@ export const createTestUser = async (): Promise<TestUserType> => {
   return testUser;
 };
 
+export const createTestUserWithUserType = async (
+  userType: string
+): Promise<TestUserType> => {
+  const testUser = await User.create({
+    email: `email${nanoid().toLowerCase()}@gmail.com`,
+    password: `pass${nanoid().toLowerCase()}`,
+    firstName: `firstName${nanoid().toLowerCase()}`,
+    lastName: `lastName${nanoid().toLowerCase()}`,
+    appLanguageCode: "en",
+    userType: userType.toUpperCase(),
+  });
+
+  return testUser;
+};
+
 export const createTestUserFunc = async (): Promise<TestUserType> => {
   const testUser = await createTestUser();
+  return testUser;
+};
+
+export const createTestUserWithUserTypeFunc = async (
+  userType: string
+): Promise<TestUserType> => {
+  const testUser = await createTestUserWithUserType(userType);
   return testUser;
 };

--- a/tests/helpers/userAndOrg.ts
+++ b/tests/helpers/userAndOrg.ts
@@ -100,3 +100,35 @@ export const createOrganizationwithVisibility = async (
 
   return testOrganization;
 };
+
+export const createdOrganizationWithoutTimeout = async (
+  userID: string,
+  isMember = true,
+  isAdmin = true,
+  isPublic = true
+): Promise<TestOrganizationType> => {
+  const testOrganization = await Organization.create({
+    name: `orgName${nanoid().toLowerCase()}`,
+    description: `orgDesc${nanoid().toLowerCase()}`,
+    isPublic: isPublic ? true : false,
+    creator: userID,
+    admins: isAdmin ? [userID] : [],
+    members: isMember ? [userID] : [],
+    timeout: null,
+  });
+
+  await User.updateOne(
+    {
+      _id: userID,
+    },
+    {
+      $push: {
+        createdOrganizations: testOrganization._id,
+        adminFor: testOrganization._id,
+        joinedOrganizations: testOrganization._id,
+      },
+    }
+  );
+
+  return testOrganization;
+};

--- a/tests/resolvers/Mutation/updateOrganizationTimeout.spec.ts
+++ b/tests/resolvers/Mutation/updateOrganizationTimeout.spec.ts
@@ -1,0 +1,147 @@
+import type mongoose from "mongoose";
+import { updateOrganizationTimeout } from "../../../src/resolvers/Mutation/updateOrganizationTimeout";
+import { Organization } from "../../../src/models";
+import { errors } from "../../../src/libraries";
+import { connect, disconnect } from "../../helpers/db";
+import { createTestUserWithUserTypeFunc } from "../../helpers/user";
+import type { TestUserType } from "../../helpers/user";
+import { createTestOrganizationWithAdmin } from "../../helpers/userAndOrg";
+import type { TestOrganizationType } from "../../helpers/userAndOrg";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  INVALID_TIMEOUT_RANGE,
+  ORGANIZATION_NOT_FOUND_ERROR,
+  USER_NOT_FOUND_ERROR,
+} from "../../../src/constants";
+
+let MONGOOSE_INSTANCE: typeof mongoose;
+
+let testOrganization: TestOrganizationType;
+let testOrganization2: TestOrganizationType;
+
+let testUser1: TestUserType;
+let testUser2: TestUserType;
+
+beforeAll(async () => {
+  MONGOOSE_INSTANCE = await connect();
+
+  testUser1 = await createTestUserWithUserTypeFunc("ADMIN");
+  testUser2 = await createTestUserWithUserTypeFunc("USER");
+  if (testUser1)
+    testOrganization = await createTestOrganizationWithAdmin(
+      testUser1._id,
+      true,
+      true,
+      true
+    );
+
+  if (testUser2)
+    testOrganization2 = await createTestOrganizationWithAdmin(
+      testUser2._id,
+      true,
+      false,
+      true
+    );
+});
+
+afterAll(async () => {
+  await disconnect(MONGOOSE_INSTANCE);
+});
+
+describe("resolvers -> Mutation -> updateOrganizationTimeout", () => {
+  it("should throw InputValidationError if organizationId is missing", async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    vi.spyOn(requestContext, "translate").mockImplementation(
+      (message) => `Translated ${message}`
+    );
+
+    const context = { userId: testUser1 ? testUser1._id.toString() : null };
+    const args = { timeout: 20, organizationId: "" };
+
+    await expect(
+      updateOrganizationTimeout?.({}, args, context)
+    ).rejects.toThrow(errors.InputValidationError);
+  });
+
+  it("should throw NotFoundError if user does not exist", async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementation((message) => `Translated ${message}`);
+    const context = { userId: "6737904485008f171cf29924" };
+    const args = { organizationId: testOrganization?._id, timeout: 20 };
+
+    await expect(
+      updateOrganizationTimeout?.({}, args, context)
+    ).rejects.toThrow(errors.NotFoundError);
+    expect(spy).toHaveBeenCalledWith(USER_NOT_FOUND_ERROR.MESSAGE);
+  });
+
+  it("should throw NotFoundError if organization does not exist", async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementation((message) => `Translated ${message}`);
+
+    const context = { userId: testUser1 ? testUser1._id.toString() : null };
+    const args = {
+      organizationId: "6737904485008f171cf29924",
+      timeout: 20,
+    };
+
+    await expect(
+      updateOrganizationTimeout?.({}, args, context)
+    ).rejects.toThrow(errors.NotFoundError);
+    expect(spy).toHaveBeenCalledWith(ORGANIZATION_NOT_FOUND_ERROR.MESSAGE);
+  });
+
+  it("should throw ValidationError if timeout is not in valid range", async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementation((message) => `Translated ${message}`);
+    try {
+      const context = { userId: testUser1 ? testUser1._id.toString() : null };
+      const args = {
+        organizationId: testOrganization
+          ? testOrganization._id.toString()
+          : null,
+        timeout: 70,
+      };
+
+      await expect(
+        updateOrganizationTimeout?.({}, args, context)
+      ).rejects.toThrow(errors.ValidationError);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        expect(spy).toHaveBeenCalledWith(INVALID_TIMEOUT_RANGE.MESSAGE);
+        expect(error.message).toEqual(INVALID_TIMEOUT_RANGE.MESSAGE);
+      }
+    }
+  });
+
+  it("should update organization timeout", async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    vi.spyOn(requestContext, "translate").mockImplementation(
+      (message) => `Translated ${message}`
+    );
+
+    const context = { userId: testUser1 ? testUser1._id.toString() : null };
+    const args = {
+      organizationId: testOrganization ? testOrganization._id.toString() : null,
+      timeout: 20,
+    };
+
+    if (args.organizationId) {
+      await updateOrganizationTimeout?.({}, args, context);
+
+      const updatedOrganization = await Organization.findById(
+        args.organizationId
+      ).lean();
+
+      if (updatedOrganization) {
+        expect(updatedOrganization.timeout).toBe(args.timeout);
+      }
+    }
+  });
+});

--- a/tests/resolvers/Query/getOrganizationTimeout.spec.ts
+++ b/tests/resolvers/Query/getOrganizationTimeout.spec.ts
@@ -1,0 +1,98 @@
+import type mongoose from "mongoose";
+import { getOrganizationTimeout } from "../../../src/resolvers/Query/getOrganizationTimeout";
+import { errors } from "../../../src/libraries";
+import { connect, disconnect } from "../../helpers/db";
+import { createTestUserWithUserTypeFunc } from "../../helpers/user";
+import {
+  createTestOrganizationWithAdmin,
+  createdOrganizationWithoutTimeout,
+} from "../../helpers/userAndOrg";
+import type { TestUserType } from "../../helpers/user";
+import type { TestOrganizationType } from "../../helpers/userAndOrg";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  ORGANIZATION_NOT_FOUND_ERROR,
+  USER_NOT_FOUND_ERROR,
+} from "../../../src/constants";
+import { Types } from "mongoose";
+
+let MONGOOSE_INSTANCE: typeof mongoose;
+let testUser: TestUserType;
+let testUser2: TestUserType;
+let testOrganization: TestOrganizationType;
+let testOrganizationWithoutTimeout: TestOrganizationType;
+
+beforeAll(async () => {
+  MONGOOSE_INSTANCE = await connect();
+
+  testUser = await createTestUserWithUserTypeFunc("ADMIN");
+  testUser2 = await createTestUserWithUserTypeFunc("ADMIN");
+
+  if (testUser) {
+    testOrganization = await createTestOrganizationWithAdmin(testUser._id);
+  }
+  if (testUser2) {
+    testOrganizationWithoutTimeout = await createdOrganizationWithoutTimeout(
+      testUser2._id
+    );
+  }
+});
+
+afterAll(async () => {
+  await disconnect(MONGOOSE_INSTANCE);
+});
+
+describe("resolvers -> Query -> getOrganizationTimeout", () => {
+  it("should return 0 if organization has no timeout", async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    vi.spyOn(requestContext, "translate").mockImplementation(
+      (message) => `Translated ${message}`
+    );
+    const context = { userId: testUser2?._id?.toString() };
+    const args = { id: testOrganizationWithoutTimeout?._id?.toString() };
+
+    const result = await getOrganizationTimeout?.({}, args, context);
+    expect(result).toBe(0);
+  });
+
+  it("should return organization timeout for admin user", async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    vi.spyOn(requestContext, "translate").mockImplementation(
+      (message) => `Translated ${message}`
+    );
+    const context = { userId: testUser?._id?.toString() };
+    const args = { id: testOrganization?._id?.toString() };
+
+    const result = await getOrganizationTimeout?.({}, args, context);
+
+    expect(result).toBe(testOrganization?.timeout);
+  });
+
+  it("should throw NotFoundError if user does not exist", async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementation((message) => `Translated ${message}`);
+    const context = { userId: Types.ObjectId().toString() };
+    const args = { id: testOrganization?._id?.toString() };
+
+    await expect(getOrganizationTimeout?.({}, args, context)).rejects.toThrow(
+      errors.NotFoundError
+    );
+    expect(spy).toHaveBeenCalledWith(USER_NOT_FOUND_ERROR.MESSAGE);
+  });
+
+  it("should throw NotFoundError if organization does not exist", async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementation((message) => `Translated ${message}`);
+    const context = { userId: testUser?._id?.toString() };
+    const args = { id: Types.ObjectId().toString() };
+
+    await expect(getOrganizationTimeout?.({}, args, context)).rejects.toThrow(
+      errors.NotFoundError
+    );
+    expect(spy).toHaveBeenCalledWith(ORGANIZATION_NOT_FOUND_ERROR.MESSAGE);
+  });
+});

--- a/tests/utilities/auth.spec.ts
+++ b/tests/utilities/auth.spec.ts
@@ -39,7 +39,7 @@ describe("createAccessToken", () => {
 
     expect(token).toBeDefined();
 
-    const decodedToken = jwt.decode(token);
+    const decodedToken = jwt.decode(await token) as unknown;
 
     expect(decodedToken).not.toBeNull();
     expect((decodedToken as InterfaceJwtTokenPayload).tokenVersion).toBe(

--- a/tests/utilities/getTimeoutFromJoinedOrganization.spec.ts
+++ b/tests/utilities/getTimeoutFromJoinedOrganization.spec.ts
@@ -1,0 +1,65 @@
+import type mongoose from "mongoose";
+import { getTimeoutFromJoinedOrganization } from "../../src/utilities/getTimeoutFromJoinedOrganization";
+import { connect, disconnect } from "../helpers/db";
+import { createTestOrganizationWithAdmin } from "../helpers/userAndOrg";
+import type { TestUserType } from "../helpers/user";
+import { createTestUserWithUserTypeFunc } from "../helpers/user";
+import type { TestOrganizationType } from "../helpers/userAndOrg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+let MONGOOSE_INSTANCE: typeof mongoose;
+let testUser1: TestUserType;
+let testUser2: TestUserType;
+let testOrganization1: TestOrganizationType;
+let testOrganization2: TestOrganizationType;
+
+beforeAll(async () => {
+  MONGOOSE_INSTANCE = await connect();
+
+  // Create a test user and two test organizations with the user as a member
+  testUser1 = await createTestUserWithUserTypeFunc("USER");
+  testUser2 = await createTestUserWithUserTypeFunc("USER");
+
+  if (testUser1) {
+    testOrganization1 = await createTestOrganizationWithAdmin(
+      testUser1._id,
+      true,
+      true,
+      true
+    );
+
+    testOrganization2 = await createTestOrganizationWithAdmin(
+      testUser1._id,
+      true,
+      false,
+      true
+    );
+  }
+});
+
+afterAll(async () => {
+  await disconnect(MONGOOSE_INSTANCE);
+});
+
+describe("utils -> organizations -> getTimeoutFromJoinedOrganization", () => {
+  it("should return an array with timeout information for joined organizations", async () => {
+    const result = await getTimeoutFromJoinedOrganization(testUser1?._id);
+
+    expect(result).toEqual([
+      {
+        _id: testOrganization1 ? testOrganization1._id : null,
+        timeout: testOrganization1 ? testOrganization1.timeout : null,
+      },
+      {
+        _id: testOrganization2 ? testOrganization2._id : null,
+        timeout: testOrganization2 ? testOrganization2.timeout : null,
+      },
+    ]);
+  });
+
+  it("should return an empty array if the user is not a member of any organizations", async () => {
+    const result = await getTimeoutFromJoinedOrganization(testUser2?._id);
+
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature

**Issue Number:**

Fixes #1637

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

[session-management-api.webm](https://github.com/PalisadoesFoundation/talawa-api/assets/97614113/ecf48e22-6b86-4d73-ab90-1a95ab9c9cec)

**Summary**

**Changes:**
1. Implemented configurable session-timeout for an organization by the admin or super-admin.
2. Implemented retrieval of session-timeout for an organization by the admin or super-admin.
3. Added tests for all the changes made.

**Constraints:**
1. Only admins and super-admins can update and retrieve the session-timeout for any organization.
2. Admins can only update the session-timeout of organizations they are admin of.
3. Timeout should be in range of 15 to 60 minutes (both including), and a multiple of 5. 

**Does this PR introduce a breaking change?**

No

**Other information**

Related to Talawa-Admin issue [#1305](https://github.com/PalisadoesFoundation/talawa-admin/issues/1305)

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes
