### PR TITLE
 Added support to change pre-login imagery

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -26,5 +26,6 @@
   "registrant.alreadyUnregistered": "Already unregistered for the event",
   "translation.alreadyPresent": "Translation Already Present",
   "translation.notFound": "Translation not found",
-  "parameter.missing": "Missing Skip parameter. Set it to either 0 or some other value not found"
+  "parameter.missing": "Missing Skip parameter. Set it to either 0 or some other value not found",
+  "community.notFound": "Community not found"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -25,5 +25,6 @@
   "registrant.alreadyUnregistered": "Déjà non inscrit à l'événement",
   "translation.alreadyPresent": "Traduction déjà présente",
   "translation.notFound": "Traduction introuvable",
-  "parameter.missing": "Paramètre de saut manquant. Réglez-le sur 0 ou sur une autre valeur"
+  "parameter.missing": "Paramètre de saut manquant. Réglez-le sur 0 ou sur une autre valeur",
+  "community.notFound": "Communauté introuvable"
 }

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -26,5 +26,6 @@
   "registrant.alreadyUnregistered": "घटना के लिए पहले से ही अपंजीकृत",
   "translation.alreadyPresent": "अनुवाद पहले से मौजूद है",
   "translation.notFound": "अनुवाद नहीं मिला",
-  "parameter.missing": "छोड़ें पैरामीटर मौजूद नहीं है. इसे 0 या किसी अन्य मान पर सेट करें"
+  "parameter.missing": "छोड़ें पैरामीटर मौजूद नहीं है. इसे 0 या किसी अन्य मान पर सेट करें",
+  "community.notFound": "समुदाय नहीं मिला"
 }

--- a/locales/sp.json
+++ b/locales/sp.json
@@ -25,5 +25,6 @@
   "registrant.alreadyUnregistered": "Ya no está registrado para el evento",
   "translation.alreadyPresent": "Traducción ya presente",
   "translation.notFound": "Traducción no encontrada",
-  "parameter.missing": "Falta el parámetro Omitir. Establézcalo en 0 o en algún otro valor"
+  "parameter.missing": "Falta el parámetro Omitir. Establézcalo en 0 o en algún otro valor",
+  "community.notFound": "Comunidad no encontrada"
 }

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -25,5 +25,6 @@
   "registrant.alreadyUnregistered": "已取消注册该活动",
   "translation.alreadyPresent": "翻译已经存在",
   "translation.notFound": "找不到翻译",
-  "parameter.missing": "缺少跳过参数。将其设置为 0 或其他值"
+  "parameter.missing": "缺少跳过参数。将其设置为 0 或其他值",
+  "community.notFound": "未找到社群"
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -87,6 +87,17 @@ input CommentInput {
   text: String!
 }
 
+type Community {
+  _id: ID!
+  createdAt: DateTime
+  description: String!
+  image: String
+  name: String!
+  socialMediaUrls: SocialMediaUrls
+  timeout: Int
+  websiteLink: String
+}
+
 union ConnectionError = InvalidCursor | MaximumValueError
 
 type ConnectionPageInfo {
@@ -524,6 +535,7 @@ type Mutation {
   unlikeComment(id: ID!): Comment
   unlikePost(id: ID!): Post
   unregisterForEventByUser(id: ID!): Event!
+  updateCommunity(data: UpdateCommunityInput, file: String, id: ID!): Community!
   updateEvent(data: UpdateEventInput, id: ID!): Event!
   updateLanguage(languageCode: String!): User!
   updateOrganization(data: UpdateOrganizationInput, file: String, id: ID!): Organization!
@@ -818,6 +830,26 @@ enum Recurrance {
   YEARLY
 }
 
+type SocialMediaUrls {
+  facebook: String
+  gitHub: String
+  linkedIn: String
+  reddit: String
+  slack: String
+  twitter: String
+  youTube: String
+}
+
+input SocialMediaUrlsInput {
+  facebook: String
+  gitHub: String
+  linkedIn: String
+  reddit: String
+  slack: String
+  twitter: String
+  youTube: String
+}
+
 enum Status {
   ACTIVE
   BLOCKED
@@ -858,6 +890,13 @@ type UnauthenticatedError implements Error {
 
 type UnauthorizedError implements Error {
   message: String!
+}
+
+input UpdateCommunityInput {
+  description: String
+  name: String
+  socialMediaUrls: SocialMediaUrlsInput
+  websiteLink: String
 }
 
 input UpdateEventInput {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,14 @@ export const COMMENT_NOT_FOUND_ERROR = {
   MESSAGE: "comment.notFound",
   PARAM: "comment",
 };
+
+export const COMMUNITY_NOT_FOUND_ERROR = {
+  DESC: "Community not found",
+  CODE: "community.notFound",
+  MESSAGE: "community.notFound",
+  PARAM: "community",
+};
+
 export const ERROR_IN_SENDING_MAIL = "Error in sending mail";
 export const EVENT_NOT_FOUND_ERROR = {
   DESC: "Event not found",

--- a/src/models/Community.ts
+++ b/src/models/Community.ts
@@ -1,0 +1,101 @@
+import { Schema, model, models } from "mongoose";
+import type { Types, Model, PopulatedDoc } from "mongoose";
+import type { InterfaceOrganization } from "./Organization";
+
+/**
+ * This is an interface that represents a database(MongoDB) document for Community.
+ */
+export interface InterfaceCommunity {
+  _id: Types.ObjectId;
+  name: string;
+  image: string | undefined;
+  description: string;
+  websiteLink: string | undefined;
+  socialMediaUrls: {
+    facebook: string | undefined;
+    twitter: string | undefined;
+    linkedIn: string | undefined;
+    gitHub: string | undefined;
+    youTube: string | undefined;
+    slack: string | undefined;
+    reddit: string | undefined;
+  };
+  timeout: number;
+  createdAt: Date;
+}
+
+/**
+ * This describes the schema for a `Community` that corresponds to `InterfaceCommunity` document.
+ * @param image - Community logo URL.
+ * @param description - Community description.
+ * @param socialMediaUrls - Social media URLs.
+ * @param facebook - Facebook URL.
+ * @param twitter - Twitter URL.
+ * @param linkedIn - LinkedIn URL.
+ * @param gitHub - GitHub URL.
+ * @param youTube - YouTube URL.
+ * @param slack - Slack URL.
+ * @param reddit - Reddit URL.
+ * @param websiteLink - Community website URL.
+ * @param name - Community name.
+ * @param timeout - Timeout duration in minutes (default is 30 minutes).
+ * @param createdAt - Time stamp of data creation.
+ */
+
+const communitySchema = new Schema({
+  name: {
+    type: String,
+    required: true,
+  },
+  image: {
+    type: String,
+  },
+  description: {
+    type: String,
+    required: true,
+  },
+  websiteLink: {
+    type: String,
+  },
+  socialMediaUrls: {
+    facebook: {
+      type: String,
+    },
+    twitter: {
+      type: String,
+    },
+    linkedIn: {
+      type: String,
+    },
+    gitHub: {
+      type: String,
+    },
+    youTube: {
+      type: String,
+    },
+    slack: {
+      type: String,
+    },
+    reddit: {
+      type: String,
+    },
+  },
+  timeout: {
+    type: Number,
+    default: 30,
+    min: [15, "Timeout should be at least 15 minutes."],
+    max: [60, "Timeout should not exceed 60 minutes."],
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now,
+  },
+});
+
+const communityModel = (): Model<InterfaceCommunity> =>
+  model<InterfaceCommunity>("Community", communitySchema);
+
+// This syntax is needed to prevent Mongoose OverwriteModelError while running tests.
+export const Community = (models.Community || communityModel()) as ReturnType<
+  typeof communityModel
+>;

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -2,6 +2,7 @@ export * from "./Advertisement";
 export * from "./CheckIn";
 export * from "./MessageChat";
 export * from "./Comment";
+export * from "./Community";
 export * from "./DirectChat";
 export * from "./DirectChatMessage";
 export * from "./Donation";

--- a/src/resolvers/Mutation/index.ts
+++ b/src/resolvers/Mutation/index.ts
@@ -74,6 +74,7 @@ import { unblockUser } from "./unblockUser";
 import { unlikeComment } from "./unlikeComment";
 import { unlikePost } from "./unlikePost";
 import { unregisterForEventByUser } from "./unregisterForEventByUser";
+import { updateCommunity } from "./updateCommunity";
 import { updateEvent } from "./updateEvent";
 import { updateLanguage } from "./updateLanguage";
 import { updateOrganization } from "./updateOrganization";
@@ -162,6 +163,7 @@ export const Mutation: MutationResolvers = {
   unlikeComment,
   unlikePost,
   unregisterForEventByUser,
+  updateCommunity,
   updateEvent,
   updateLanguage,
   updateOrganization,

--- a/src/resolvers/Mutation/updateCommunity.ts
+++ b/src/resolvers/Mutation/updateCommunity.ts
@@ -1,0 +1,76 @@
+import {
+  COMMUNITY_NOT_FOUND_ERROR,
+  USER_NOT_FOUND_ERROR,
+} from "../../constants";
+import { errors, requestContext } from "../../libraries";
+import { Community, User } from "../../models";
+import type { InterfaceCommunity } from "../../models/Community";
+import type { MutationResolvers } from "../../types/generatedGraphQLTypes";
+import { superAdminCheck } from "../../utilities";
+import { uploadEncodedImage } from "../../utilities/encodedImageStorage/uploadEncodedImage";
+
+export const updateCommunity: MutationResolvers["updateCommunity"] = async (
+  _parent,
+  args,
+  context
+) => {
+  const user = await User.findById(context.userId);
+  if (!user)
+    throw new errors.NotFoundError(
+      requestContext.translate(USER_NOT_FOUND_ERROR.MESSAGE),
+      USER_NOT_FOUND_ERROR.CODE,
+      USER_NOT_FOUND_ERROR.PARAM
+    );
+
+  superAdminCheck(user);
+
+  const community = await Community.findById(args.id);
+  if (!community)
+    throw new errors.NotFoundError(
+      requestContext.translate(COMMUNITY_NOT_FOUND_ERROR.MESSAGE),
+      COMMUNITY_NOT_FOUND_ERROR.CODE,
+      COMMUNITY_NOT_FOUND_ERROR.PARAM
+    );
+
+  const updateObj: Partial<InterfaceCommunity> = {
+    name: args.data?.name || community.name,
+    description: args.data?.description || community.description,
+    websiteLink: args.data?.websiteLink || community.websiteLink,
+    socialMediaUrls: {
+      facebook:
+        args.data?.socialMediaUrls?.facebook ||
+        community.socialMediaUrls.facebook,
+      twitter:
+        args.data?.socialMediaUrls?.twitter ||
+        community.socialMediaUrls.twitter,
+      linkedIn:
+        args.data?.socialMediaUrls?.linkedIn ||
+        community.socialMediaUrls.linkedIn,
+      gitHub:
+        args.data?.socialMediaUrls?.gitHub || community.socialMediaUrls.gitHub,
+      youTube:
+        args.data?.socialMediaUrls?.youTube ||
+        community.socialMediaUrls.youTube,
+      slack:
+        args.data?.socialMediaUrls?.slack || community.socialMediaUrls.slack,
+      reddit:
+        args.data?.socialMediaUrls?.reddit || community.socialMediaUrls.reddit,
+    },
+  };
+
+  if (args.file) {
+    const uploadImageFileName = await uploadEncodedImage(
+      args.file,
+      community.image
+    );
+    updateObj.image = uploadImageFileName;
+  }
+
+  const updatedCommunity = await Community.findOneAndUpdate(
+    { _id: args.id },
+    { $set: updateObj },
+    { new: true }
+  );
+
+  return updatedCommunity!;
+};

--- a/src/typeDefs/inputs.ts
+++ b/src/typeDefs/inputs.ts
@@ -234,6 +234,16 @@ export const inputs = gql`
     recaptchaToken: String!
   }
 
+  input SocialMediaUrlsInput {
+    facebook: String
+    twitter: String
+    linkedIn: String
+    gitHub: String
+    youTube: String
+    slack: String
+    reddit: String
+  }
+
   input ToggleUserTagAssignInput {
     userId: ID!
     tagId: ID!
@@ -268,6 +278,13 @@ export const inputs = gql`
     cursor: String
     direction: PaginationDirection!
     limit: PositiveInt!
+  }
+
+  input UpdateCommunityInput {
+    name: String
+    description: String
+    websiteLink: String
+    socialMediaUrls: SocialMediaUrlsInput
   }
 
   input UpdateOrganizationInput {

--- a/src/typeDefs/mutations.ts
+++ b/src/typeDefs/mutations.ts
@@ -200,6 +200,12 @@ export const mutations = gql`
 
     unregisterForEventByUser(id: ID!): Event! @auth
 
+    updateCommunity(
+      id: ID!
+      data: UpdateCommunityInput
+      file: String
+    ): Community! @auth @role(requires: SUPERADMIN)
+
     updateEvent(id: ID!, data: UpdateEventInput): Event! @auth
 
     updatePost(id: ID!, data: PostUpdateInput): Post! @auth

--- a/src/typeDefs/types.ts
+++ b/src/typeDefs/types.ts
@@ -44,6 +44,17 @@ export const types = gql`
     likeCount: Int
   }
 
+  type Community {
+    _id: ID!
+    name: String!
+    image: String
+    description: String!
+    websiteLink: String
+    socialMediaUrls: SocialMediaUrls
+    timeout: Int
+    createdAt: DateTime
+  }
+
   # A page info type adhering to Relay Specification for both cursor based pagination
   type ConnectionPageInfo {
     hasNextPage: Boolean!
@@ -309,6 +320,16 @@ export const types = gql`
     edges: [Post]!
 
     aggregate: AggregatePost!
+  }
+
+  type SocialMediaUrls {
+    facebook: String
+    twitter: String
+    linkedIn: String
+    gitHub: String
+    youTube: String
+    slack: String
+    reddit: String
   }
 
   type Translation {

--- a/src/types/generatedGraphQLTypes.ts
+++ b/src/types/generatedGraphQLTypes.ts
@@ -140,6 +140,18 @@ export type CommentInput = {
   text: Scalars['String'];
 };
 
+export type Community = {
+  __typename?: 'Community';
+  _id: Scalars['ID'];
+  createdAt?: Maybe<Scalars['DateTime']>;
+  description: Scalars['String'];
+  image?: Maybe<Scalars['String']>;
+  name: Scalars['String'];
+  socialMediaUrls?: Maybe<SocialMediaUrls>;
+  timeout?: Maybe<Scalars['Int']>;
+  websiteLink?: Maybe<Scalars['String']>;
+};
+
 export type ConnectionError = InvalidCursor | MaximumValueError;
 
 export type ConnectionPageInfo = {
@@ -585,6 +597,7 @@ export type Mutation = {
   unlikeComment?: Maybe<Comment>;
   unlikePost?: Maybe<Post>;
   unregisterForEventByUser: Event;
+  updateCommunity: Community;
   updateEvent: Event;
   updateLanguage: User;
   updateOrganization: Organization;
@@ -975,6 +988,13 @@ export type MutationUnlikePostArgs = {
 
 
 export type MutationUnregisterForEventByUserArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type MutationUpdateCommunityArgs = {
+  data?: InputMaybe<UpdateCommunityInput>;
+  file?: InputMaybe<Scalars['String']>;
   id: Scalars['ID'];
 };
 
@@ -1499,6 +1519,27 @@ export type Recurrance =
   | 'WEEKLY'
   | 'YEARLY';
 
+export type SocialMediaUrls = {
+  __typename?: 'SocialMediaUrls';
+  facebook?: Maybe<Scalars['String']>;
+  gitHub?: Maybe<Scalars['String']>;
+  linkedIn?: Maybe<Scalars['String']>;
+  reddit?: Maybe<Scalars['String']>;
+  slack?: Maybe<Scalars['String']>;
+  twitter?: Maybe<Scalars['String']>;
+  youTube?: Maybe<Scalars['String']>;
+};
+
+export type SocialMediaUrlsInput = {
+  facebook?: InputMaybe<Scalars['String']>;
+  gitHub?: InputMaybe<Scalars['String']>;
+  linkedIn?: InputMaybe<Scalars['String']>;
+  reddit?: InputMaybe<Scalars['String']>;
+  slack?: InputMaybe<Scalars['String']>;
+  twitter?: InputMaybe<Scalars['String']>;
+  youTube?: InputMaybe<Scalars['String']>;
+};
+
 export type Status =
   | 'ACTIVE'
   | 'BLOCKED'
@@ -1537,6 +1578,13 @@ export type UnauthenticatedError = Error & {
 export type UnauthorizedError = Error & {
   __typename?: 'UnauthorizedError';
   message: Scalars['String'];
+};
+
+export type UpdateCommunityInput = {
+  description?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']>;
+  socialMediaUrls?: InputMaybe<SocialMediaUrlsInput>;
+  websiteLink?: InputMaybe<Scalars['String']>;
 };
 
 export type UpdateEventInput = {
@@ -1886,6 +1934,7 @@ export type ResolversTypes = {
   CheckInStatus: ResolverTypeWrapper<Omit<CheckInStatus, 'checkIn' | 'user'> & { checkIn?: Maybe<ResolversTypes['CheckIn']>, user: ResolversTypes['User'] }>;
   Comment: ResolverTypeWrapper<InterfaceCommentModel>;
   CommentInput: CommentInput;
+  Community: ResolverTypeWrapper<Community>;
   ConnectionError: ResolversTypes['InvalidCursor'] | ResolversTypes['MaximumValueError'];
   ConnectionPageInfo: ResolverTypeWrapper<ConnectionPageInfo>;
   CountryCode: ResolverTypeWrapper<Scalars['CountryCode']>;
@@ -1962,6 +2011,8 @@ export type ResolversTypes = {
   Query: ResolverTypeWrapper<{}>;
   RecaptchaVerification: RecaptchaVerification;
   Recurrance: Recurrance;
+  SocialMediaUrls: ResolverTypeWrapper<SocialMediaUrls>;
+  SocialMediaUrlsInput: SocialMediaUrlsInput;
   Status: Status;
   String: ResolverTypeWrapper<Scalars['String']>;
   Subscription: ResolverTypeWrapper<{}>;
@@ -1972,6 +2023,7 @@ export type ResolversTypes = {
   URL: ResolverTypeWrapper<Scalars['URL']>;
   UnauthenticatedError: ResolverTypeWrapper<UnauthenticatedError>;
   UnauthorizedError: ResolverTypeWrapper<UnauthorizedError>;
+  UpdateCommunityInput: UpdateCommunityInput;
   UpdateEventInput: UpdateEventInput;
   UpdateOrganizationInput: UpdateOrganizationInput;
   UpdateUserInput: UpdateUserInput;
@@ -2017,6 +2069,7 @@ export type ResolversParentTypes = {
   CheckInStatus: Omit<CheckInStatus, 'checkIn' | 'user'> & { checkIn?: Maybe<ResolversParentTypes['CheckIn']>, user: ResolversParentTypes['User'] };
   Comment: InterfaceCommentModel;
   CommentInput: CommentInput;
+  Community: Community;
   ConnectionError: ResolversParentTypes['InvalidCursor'] | ResolversParentTypes['MaximumValueError'];
   ConnectionPageInfo: ConnectionPageInfo;
   CountryCode: Scalars['CountryCode'];
@@ -2084,6 +2137,8 @@ export type ResolversParentTypes = {
   PostWhereInput: PostWhereInput;
   Query: {};
   RecaptchaVerification: RecaptchaVerification;
+  SocialMediaUrls: SocialMediaUrls;
+  SocialMediaUrlsInput: SocialMediaUrlsInput;
   String: Scalars['String'];
   Subscription: {};
   Time: Scalars['Time'];
@@ -2092,6 +2147,7 @@ export type ResolversParentTypes = {
   URL: Scalars['URL'];
   UnauthenticatedError: UnauthenticatedError;
   UnauthorizedError: UnauthorizedError;
+  UpdateCommunityInput: UpdateCommunityInput;
   UpdateEventInput: UpdateEventInput;
   UpdateOrganizationInput: UpdateOrganizationInput;
   UpdateUserInput: UpdateUserInput;
@@ -2200,6 +2256,18 @@ export type CommentResolvers<ContextType = any, ParentType extends ResolversPare
   likedBy?: Resolver<Maybe<Array<Maybe<ResolversTypes['User']>>>, ParentType, ContextType>;
   post?: Resolver<ResolversTypes['Post'], ParentType, ContextType>;
   text?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type CommunityResolvers<ContextType = any, ParentType extends ResolversParentTypes['Community'] = ResolversParentTypes['Community']> = {
+  _id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  description?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  image?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  socialMediaUrls?: Resolver<Maybe<ResolversTypes['SocialMediaUrls']>, ParentType, ContextType>;
+  timeout?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  websiteLink?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2510,6 +2578,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   unlikeComment?: Resolver<Maybe<ResolversTypes['Comment']>, ParentType, ContextType, RequireFields<MutationUnlikeCommentArgs, 'id'>>;
   unlikePost?: Resolver<Maybe<ResolversTypes['Post']>, ParentType, ContextType, RequireFields<MutationUnlikePostArgs, 'id'>>;
   unregisterForEventByUser?: Resolver<ResolversTypes['Event'], ParentType, ContextType, RequireFields<MutationUnregisterForEventByUserArgs, 'id'>>;
+  updateCommunity?: Resolver<ResolversTypes['Community'], ParentType, ContextType, RequireFields<MutationUpdateCommunityArgs, 'id'>>;
   updateEvent?: Resolver<ResolversTypes['Event'], ParentType, ContextType, RequireFields<MutationUpdateEventArgs, 'id'>>;
   updateLanguage?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationUpdateLanguageArgs, 'languageCode'>>;
   updateOrganization?: Resolver<ResolversTypes['Organization'], ParentType, ContextType, RequireFields<MutationUpdateOrganizationArgs, 'id'>>;
@@ -2663,6 +2732,17 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   usersConnection?: Resolver<Array<Maybe<ResolversTypes['User']>>, ParentType, ContextType, Partial<QueryUsersConnectionArgs>>;
 };
 
+export type SocialMediaUrlsResolvers<ContextType = any, ParentType extends ResolversParentTypes['SocialMediaUrls'] = ResolversParentTypes['SocialMediaUrls']> = {
+  facebook?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  gitHub?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  linkedIn?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  reddit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  slack?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  twitter?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  youTube?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type SubscriptionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = {
   directMessageChat?: SubscriptionResolver<Maybe<ResolversTypes['MessageChat']>, "directMessageChat", ParentType, ContextType>;
   messageSentToDirectChat?: SubscriptionResolver<Maybe<ResolversTypes['DirectChatMessage']>, "messageSentToDirectChat", ParentType, ContextType>;
@@ -2810,6 +2890,7 @@ export type Resolvers<ContextType = any> = {
   CheckIn?: CheckInResolvers<ContextType>;
   CheckInStatus?: CheckInStatusResolvers<ContextType>;
   Comment?: CommentResolvers<ContextType>;
+  Community?: CommunityResolvers<ContextType>;
   ConnectionError?: ConnectionErrorResolvers<ContextType>;
   ConnectionPageInfo?: ConnectionPageInfoResolvers<ContextType>;
   CountryCode?: GraphQLScalarType;
@@ -2854,6 +2935,7 @@ export type Resolvers<ContextType = any> = {
   Post?: PostResolvers<ContextType>;
   PostConnection?: PostConnectionResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
+  SocialMediaUrls?: SocialMediaUrlsResolvers<ContextType>;
   Subscription?: SubscriptionResolvers<ContextType>;
   Time?: GraphQLScalarType;
   Translation?: TranslationResolvers<ContextType>;

--- a/tests/helpers/community.ts
+++ b/tests/helpers/community.ts
@@ -1,0 +1,26 @@
+import type { InterfaceCommunity } from "../../src/models";
+import { Community } from "../../src/models";
+import { nanoid } from "nanoid";
+import type { Document } from "mongoose";
+
+export type TestCommunityType =
+  | (InterfaceCommunity & Document<any, any, InterfaceCommunity>)
+  | null;
+
+export const createTestCommunity = async (): Promise<TestCommunityType> => {
+  const testCommunity = await Community.create({
+    name: `Test Community ${nanoid()}`,
+    image: "test-image.jpg",
+    description: "Test community description",
+    websiteLink: "https://testcommunity.com",
+    organizations: [],
+    timeout: 30,
+  });
+
+  return testCommunity;
+};
+
+export const createTestCommunityFunc = async (): Promise<TestCommunityType> => {
+  const testCommunity = await createTestCommunity();
+  return testCommunity;
+};

--- a/tests/helpers/user.ts
+++ b/tests/helpers/user.ts
@@ -23,3 +23,25 @@ export const createTestUserFunc = async (): Promise<TestUserType> => {
   const testUser = await createTestUser();
   return testUser;
 };
+
+export const createTestUserWithUserType = async (
+  userType: string
+): Promise<TestUserType> => {
+  const testUser = await User.create({
+    email: `email${nanoid().toLowerCase()}@gmail.com`,
+    password: `pass${nanoid().toLowerCase()}`,
+    firstName: `firstName${nanoid().toLowerCase()}`,
+    lastName: `lastName${nanoid().toLowerCase()}`,
+    appLanguageCode: "en",
+    userType: userType.toUpperCase(),
+  });
+
+  return testUser;
+};
+
+export const createTestUserWithUserTypeFunc = async (
+  userType: string
+): Promise<TestUserType> => {
+  const testUser = await createTestUserWithUserType(userType);
+  return testUser;
+};

--- a/tests/resolvers/Mutation/updateCommunity.spec.ts
+++ b/tests/resolvers/Mutation/updateCommunity.spec.ts
@@ -1,0 +1,204 @@
+import "dotenv/config";
+import type mongoose from "mongoose";
+import { Types } from "mongoose";
+import { User, Community } from "../../../src/models";
+import type { MutationUpdateCommunityArgs } from "../../../src/types/generatedGraphQLTypes";
+import { connect, disconnect } from "../../helpers/db";
+
+import {
+  COMMUNITY_NOT_FOUND_ERROR,
+  USER_NOT_AUTHORIZED_ERROR,
+  USER_NOT_FOUND_ERROR,
+} from "../../../src/constants";
+import * as uploadEncodedImage from "../../../src/utilities/encodedImageStorage/uploadEncodedImage";
+import { updateCommunity } from "../../../src/resolvers/Mutation/updateCommunity";
+import {
+  beforeAll,
+  afterAll,
+  afterEach,
+  describe,
+  it,
+  vi,
+  expect,
+} from "vitest";
+import type { TestUserType } from "../../helpers/user";
+import type { TestCommunityType } from "../../helpers/community";
+import { createTestUserWithUserTypeFunc } from "../../helpers/user";
+import { createTestCommunityFunc } from "../../helpers/community";
+import { errors } from "../../../src/libraries";
+
+let MONGOOSE_INSTANCE: typeof mongoose;
+let testUser1: TestUserType;
+let testUser2: TestUserType;
+let testCommunity: TestCommunityType;
+
+vi.mock("../../utilities/uploadEncodedImage", () => ({
+  uploadEncodedImage: vi.fn(),
+}));
+
+beforeAll(async () => {
+  MONGOOSE_INSTANCE = await connect();
+  testUser1 = await createTestUserWithUserTypeFunc("SUPERADMIN");
+  testUser2 = await createTestUserWithUserTypeFunc("USER");
+  testCommunity = await createTestCommunityFunc();
+});
+
+afterAll(async () => {
+  await disconnect(MONGOOSE_INSTANCE);
+});
+
+afterEach(() => {
+  vi.doUnmock("../../../src/constants");
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.doUnmock("../../../src/constants");
+  vi.resetModules();
+});
+
+describe("resolvers -> Mutation -> updateCommunity", () => {
+  it(`throws NotFoundError if no user exists with _id === args.id`, async () => {
+    const { requestContext } = await import("../../../src/libraries");
+
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementation((message) => `Translated ${message}`);
+
+    try {
+      const args: MutationUpdateCommunityArgs = {
+        id: Types.ObjectId().toString(),
+      };
+
+      const context = {
+        userId: Types.ObjectId().toString(),
+      };
+
+      await updateCommunity?.({}, args, context);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        expect(spy).toHaveBeenCalledWith(USER_NOT_FOUND_ERROR.MESSAGE);
+        expect(error.message).toEqual(
+          `Translated ${USER_NOT_FOUND_ERROR.MESSAGE}`
+        );
+      }
+    }
+  });
+
+  it(`throws UnauthorizedError if user with _id === context.userId is not superadmin with _id === args.id`, async () => {
+    const { requestContext } = await import("../../../src/libraries");
+
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementation((message) => `Translated ${message}`);
+
+    try {
+      const args: MutationUpdateCommunityArgs = {
+        id: testCommunity?._id,
+      };
+
+      const context = {
+        userId: testUser1?._id,
+      };
+
+      await updateCommunity?.({}, args, context);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        expect(spy).toHaveBeenCalledWith(USER_NOT_AUTHORIZED_ERROR.MESSAGE);
+        expect(error.message).toEqual(
+          `Translated ${USER_NOT_AUTHORIZED_ERROR.MESSAGE}`
+        );
+      }
+    }
+  });
+
+  it(`throws NotFoundError if no community exists with _id === args.id`, async () => {
+    const { requestContext } = await import("../../../src/libraries");
+
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementation((message) => `Translated ${message}`);
+
+    try {
+      const args: MutationUpdateCommunityArgs = {
+        id: Types.ObjectId().toString(),
+      };
+
+      const context = {
+        userId: testUser1?._id,
+      };
+
+      await updateCommunity?.({}, args, context);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        // expect(spy).toHaveBeenCalledWith(COMMUNITY_NOT_FOUND_ERROR.MESSAGE);
+        expect(error.message).toEqual(
+          `Translated ${COMMUNITY_NOT_FOUND_ERROR.MESSAGE}`
+        );
+      }
+    }
+  });
+
+  it(`updates the community with _id === args.id and returns the updated community`, async () => {
+    const args: MutationUpdateCommunityArgs = {
+      id: testCommunity?._id,
+      data: {
+        description: "newDescription",
+        name: "newName",
+        websiteLink: "newWebsiteLink",
+        socialMediaUrls: {
+          facebook: "newFacebook",
+          gitHub: "newGitHub",
+          linkedIn: "newLinkedIn",
+          reddit: "newReddit",
+          slack: "newSlack",
+          twitter: "newTwitter",
+          youTube: "newYouTube",
+        },
+      },
+    };
+
+    const context = {
+      userId: testUser1?._id,
+    };
+
+    const updatedCommunityPayload = await updateCommunity?.({}, args, context);
+
+    const testUpdateCommunityPayload = await Community.findOne({
+      _id: testCommunity?._id,
+    }).lean();
+
+    expect(JSON.parse(JSON.stringify(updatedCommunityPayload))).toEqual(
+      JSON.parse(JSON.stringify(testUpdateCommunityPayload))
+    );
+  });
+
+  it(`updates the organization with _id === args.id and returns the updated organization when image is given`, async () => {
+    const args: MutationUpdateCommunityArgs = {
+      id: testCommunity?._id,
+      data: {
+        description: "newDescription",
+        name: "newName",
+      },
+      file: "newImageFile.png",
+    };
+
+    vi.spyOn(uploadEncodedImage, "uploadEncodedImage").mockImplementation(
+      async (encodedImageURL: string) => encodedImageURL
+    );
+
+    const context = {
+      userId: testUser1?._id,
+    };
+
+    const updatedCommunityPayload = await updateCommunity?.({}, args, context);
+
+    const testUpdateCommunityPayload = await Community.findOne({
+      _id: testCommunity?._id,
+    }).lean();
+
+    expect(JSON.parse(JSON.stringify(updatedCommunityPayload))).toEqual(
+      JSON.parse(JSON.stringify(testUpdateCommunityPayload))
+    );
+  });
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature

**Issue Number:**

Fixes #1611 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

Working:

https://github.com/PalisadoesFoundation/talawa-api/assets/97614113/7837685b-fcf9-416f-8939-57f5a2ab4e24

Tests:

![image](https://github.com/PalisadoesFoundation/talawa-api/assets/97614113/8a47a6de-10ad-4118-96f4-d776af043a88)

**Summary**

This PR adds support for changing pre-login imagery and links to various social media for a community by creating an API for updating these details.

**Other information**

Related issue in Talawa-Admin [#1334](https://github.com/PalisadoesFoundation/talawa-admin/issues/1334)

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes
