### PR TITLE
fix: Removed `organizationUserBelongsTo` field

### DIFF
--- a/sample_data/users.json
+++ b/sample_data/users.json
@@ -19,7 +19,6 @@
     "lastName": "Shepherd",
     "email": "testsuperadmin@example.com",
     "password": "$2a$12$bSYpay6TRMpTOaAmYPFXku4avwmqfFBtmgg39TabxmtFEiz4plFtW",
-    "organizationUserBelongsTo": null,
     "image": null,
     "createdAt": "2023-04-13T04:53:17.742Z",
     "__v": 0
@@ -44,7 +43,6 @@
     "lastName": "Kerry",
     "email": "testadmin1@example.com",
     "password": "$2a$12$bSYpay6TRMpTOaAmYPFXku4avwmqfFBtmgg39TabxmtFEiz4plFtW",
-    "organizationUserBelongsTo": null,
     "image": null,
     "createdAt": "2023-04-13T04:53:17.742Z",
     "__v": 0
@@ -69,7 +67,6 @@
     "lastName": "Solomon",
     "email": "testadmin2@example.com",
     "password": "$2a$12$bSYpay6TRMpTOaAmYPFXku4avwmqfFBtmgg39TabxmtFEiz4plFtW",
-    "organizationUserBelongsTo": null,
     "image": null,
     "createdAt": "2023-04-13T04:53:17.742Z",
     "__v": 0
@@ -94,7 +91,6 @@
     "lastName": "Wilf",
     "email": "testadmin3@example.com",
     "password": "$2a$12$bSYpay6TRMpTOaAmYPFXku4avwmqfFBtmgg39TabxmtFEiz4plFtW",
-    "organizationUserBelongsTo": null,
     "image": null,
     "createdAt": "2023-04-13T04:53:17.742Z",
     "__v": 0
@@ -119,7 +115,6 @@
     "lastName": "Lance",
     "email": "testuser1@example.com",
     "password": "$2a$12$bSYpay6TRMpTOaAmYPFXku4avwmqfFBtmgg39TabxmtFEiz4plFtW",
-    "organizationUserBelongsTo": null,
     "image": null,
     "createdAt": "2023-04-13T04:53:17.742Z",
     "__v": 0
@@ -144,7 +139,6 @@
     "lastName": "Norris",
     "email": "testuser2@example.com",
     "password": "$2a$12$bSYpay6TRMpTOaAmYPFXku4avwmqfFBtmgg39TabxmtFEiz4plFtW",
-    "organizationUserBelongsTo": null,
     "image": null,
     "createdAt": "2023-04-13T04:53:17.742Z",
     "__v": 0
@@ -169,7 +163,6 @@
     "lastName": "Tony",
     "email": "testuser3@example.com",
     "password": "$2a$12$bSYpay6TRMpTOaAmYPFXku4avwmqfFBtmgg39TabxmtFEiz4plFtW",
-    "organizationUserBelongsTo": null,
     "image": null,
     "createdAt": "2023-04-13T04:53:17.742Z",
     "__v": 0

--- a/schema.graphql
+++ b/schema.graphql
@@ -960,7 +960,6 @@ type User {
   lastName: String!
   maritalStatus: MaritalStatus
   membershipRequests: [MembershipRequest]
-  organizationUserBelongsTo: Organization
   organizationsBlockedBy: [Organization]
   phone: UserPhone
   pluginCreationAllowed: Boolean!

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -39,9 +39,6 @@ export interface InterfaceUser {
   maritalStatus: string;
   membershipRequests: PopulatedDoc<InterfaceMembershipRequest & Document>[];
   organizationsBlockedBy: PopulatedDoc<InterfaceOrganization & Document>[];
-  organizationUserBelongsTo:
-    | PopulatedDoc<InterfaceOrganization & Document>
-    | undefined;
   password: string;
   phone: {
     home: string;
@@ -78,7 +75,6 @@ export interface InterfaceUser {
  * @param maritalStatus - User marital status
  * @param membershipRequests - Collections of the membership request, each object refer to `MembershipRequest` model.
  * @param organizationsBlockedBy - Collections of organizations where user is blocked, each object refer to `Organization` model.
- * @param organizationUserBelongsTo - Organization where user belongs to currently.
  * @param password - User hashed password.
  * @param phone - User contact numbers, for mobile, home and work
  * @param pluginCreationAllowed - Wheather user is allowed to create plugins.
@@ -229,10 +225,6 @@ const userSchema = new Schema(
         ref: "Organization",
       },
     ],
-    organizationUserBelongsTo: {
-      type: Schema.Types.ObjectId,
-      ref: "Organization",
-    },
     password: {
       type: String,
       required: true,

--- a/src/resolvers/Mutation/login.ts
+++ b/src/resolvers/Mutation/login.ts
@@ -91,7 +91,6 @@ export const login: MutationResolvers["login"] = async (_parent, args) => {
     .populate("adminFor")
     .populate("membershipRequests")
     .populate("organizationsBlockedBy")
-    .populate("organizationUserBelongsTo")
     .lean();
 
   return {

--- a/src/resolvers/Mutation/signUp.ts
+++ b/src/resolvers/Mutation/signUp.ts
@@ -122,7 +122,6 @@ export const signUp: MutationResolvers["signUp"] = async (_parent, args) => {
 
   const createdUser = await User.create({
     ...args.data,
-    organizationUserBelongsTo: organization ? organization._id : null,
     email: args.data.email.toLowerCase(), // ensure all emails are stored as lowercase to prevent duplicated due to comparison errors
     image: uploadImageFileName ? uploadImageFileName : null,
     password: hashedPassword,

--- a/src/typeDefs/types.ts
+++ b/src/typeDefs/types.ts
@@ -379,7 +379,6 @@ export const types = gql`
     lastName: String!
     maritalStatus: MaritalStatus
     membershipRequests: [MembershipRequest]
-    organizationUserBelongsTo: Organization
     organizationsBlockedBy: [Organization]
     phone: UserPhone
     pluginCreationAllowed: Boolean!

--- a/src/types/generatedGraphQLTypes.ts
+++ b/src/types/generatedGraphQLTypes.ts
@@ -1640,7 +1640,6 @@ export type User = {
   lastName: Scalars['String']['output'];
   maritalStatus?: Maybe<MaritalStatus>;
   membershipRequests?: Maybe<Array<Maybe<MembershipRequest>>>;
-  organizationUserBelongsTo?: Maybe<Organization>;
   organizationsBlockedBy?: Maybe<Array<Maybe<Organization>>>;
   phone?: Maybe<UserPhone>;
   pluginCreationAllowed: Scalars['Boolean']['output'];
@@ -2781,7 +2780,6 @@ export type UserResolvers<ContextType = any, ParentType extends ResolversParentT
   lastName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   maritalStatus?: Resolver<Maybe<ResolversTypes['MaritalStatus']>, ParentType, ContextType>;
   membershipRequests?: Resolver<Maybe<Array<Maybe<ResolversTypes['MembershipRequest']>>>, ParentType, ContextType>;
-  organizationUserBelongsTo?: Resolver<Maybe<ResolversTypes['Organization']>, ParentType, ContextType>;
   organizationsBlockedBy?: Resolver<Maybe<Array<Maybe<ResolversTypes['Organization']>>>, ParentType, ContextType>;
   phone?: Resolver<Maybe<ResolversTypes['UserPhone']>, ParentType, ContextType>;
   pluginCreationAllowed?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;

--- a/talawa-api-docs/interfaces/models_User.InterfaceUser.md
+++ b/talawa-api-docs/interfaces/models_User.InterfaceUser.md
@@ -30,7 +30,6 @@ This is an interface that represents a database(MongoDB) document for User.
 - [lastName](models_User.InterfaceUser.md#lastname)
 - [maritalStatus](models_User.InterfaceUser.md#maritalstatus)
 - [membershipRequests](models_User.InterfaceUser.md#membershiprequests)
-- [organizationUserBelongsTo](models_User.InterfaceUser.md#organizationuserbelongsto)
 - [organizationsBlockedBy](models_User.InterfaceUser.md#organizationsblockedby)
 - [password](models_User.InterfaceUser.md#password)
 - [phone](models_User.InterfaceUser.md#phone)
@@ -254,16 +253,6 @@ ___
 #### Defined in
 
 [src/models/User.ts:40](https://github.com/PalisadoesFoundation/talawa-api/blob/ae7aa4f/src/models/User.ts#L40)
-
-___
-
-### organizationUserBelongsTo
-
-• **organizationUserBelongsTo**: `any`
-
-#### Defined in
-
-[src/models/User.ts:42](https://github.com/PalisadoesFoundation/talawa-api/blob/ae7aa4f/src/models/User.ts#L42)
 
 ___
 

--- a/talawa-api-docs/modules/types_generatedGraphQLTypes.md
+++ b/talawa-api-docs/modules/types_generatedGraphQLTypes.md
@@ -6523,7 +6523,6 @@ ___
 | `lastName` | [`Scalars`](types_generatedGraphQLTypes.md#scalars)[``"String"``][``"output"``] |
 | `maritalStatus?` | [`Maybe`](types_generatedGraphQLTypes.md#maybe)\<[`MaritalStatus`](types_generatedGraphQLTypes.md#maritalstatus)\> |
 | `membershipRequests?` | [`Maybe`](types_generatedGraphQLTypes.md#maybe)\<[`Maybe`](types_generatedGraphQLTypes.md#maybe)\<[`MembershipRequest`](types_generatedGraphQLTypes.md#membershiprequest)\>[]\> |
-| `organizationUserBelongsTo?` | [`Maybe`](types_generatedGraphQLTypes.md#maybe)\<[`Organization`](types_generatedGraphQLTypes.md#organization)\> |
 | `organizationsBlockedBy?` | [`Maybe`](types_generatedGraphQLTypes.md#maybe)\<[`Maybe`](types_generatedGraphQLTypes.md#maybe)\<[`Organization`](types_generatedGraphQLTypes.md#organization)\>[]\> |
 | `phone?` | [`Maybe`](types_generatedGraphQLTypes.md#maybe)\<[`UserPhone`](types_generatedGraphQLTypes.md#userphone)\> |
 | `pluginCreationAllowed` | [`Scalars`](types_generatedGraphQLTypes.md#scalars)[``"Boolean"``][``"output"``] |
@@ -6821,7 +6820,6 @@ ___
 | `lastName?` | [`Resolver`](types_generatedGraphQLTypes.md#resolver)\<[`ResolversTypes`](types_generatedGraphQLTypes.md#resolverstypes)[``"String"``], `ParentType`, `ContextType`\> |
 | `maritalStatus?` | [`Resolver`](types_generatedGraphQLTypes.md#resolver)\<[`Maybe`](types_generatedGraphQLTypes.md#maybe)\<[`ResolversTypes`](types_generatedGraphQLTypes.md#resolverstypes)[``"MaritalStatus"``]\>, `ParentType`, `ContextType`\> |
 | `membershipRequests?` | [`Resolver`](types_generatedGraphQLTypes.md#resolver)\<[`Maybe`](types_generatedGraphQLTypes.md#maybe)\<[`Maybe`](types_generatedGraphQLTypes.md#maybe)\<[`ResolversTypes`](types_generatedGraphQLTypes.md#resolverstypes)[``"MembershipRequest"``]\>[]\>, `ParentType`, `ContextType`\> |
-| `organizationUserBelongsTo?` | [`Resolver`](types_generatedGraphQLTypes.md#resolver)\<[`Maybe`](types_generatedGraphQLTypes.md#maybe)\<[`ResolversTypes`](types_generatedGraphQLTypes.md#resolverstypes)[``"Organization"``]\>, `ParentType`, `ContextType`\> |
 | `organizationsBlockedBy?` | [`Resolver`](types_generatedGraphQLTypes.md#resolver)\<[`Maybe`](types_generatedGraphQLTypes.md#maybe)\<[`Maybe`](types_generatedGraphQLTypes.md#maybe)\<[`ResolversTypes`](types_generatedGraphQLTypes.md#resolverstypes)[``"Organization"``]\>[]\>, `ParentType`, `ContextType`\> |
 | `phone?` | [`Resolver`](types_generatedGraphQLTypes.md#resolver)\<[`Maybe`](types_generatedGraphQLTypes.md#maybe)\<[`ResolversTypes`](types_generatedGraphQLTypes.md#resolverstypes)[``"UserPhone"``]\>, `ParentType`, `ContextType`\> |
 | `pluginCreationAllowed?` | [`Resolver`](types_generatedGraphQLTypes.md#resolver)\<[`ResolversTypes`](types_generatedGraphQLTypes.md#resolverstypes)[``"Boolean"``], `ParentType`, `ContextType`\> |

--- a/tests/resolvers/Mutation/login.spec.ts
+++ b/tests/resolvers/Mutation/login.spec.ts
@@ -187,7 +187,7 @@ email === args.data.email`, async () => {
 
   it(`returns the user object with populated fields joinedOrganizations, createdOrganizations,
   createdEvents, registeredEvents, eventAdmin, adminFor, membershipRequests, 
-  organizationsBlockedBy, organizationUserBelongsTo`, async () => {
+  organizationsBlockedBy`, async () => {
     const args: MutationLoginArgs = {
       data: {
         email: testUser?.email,
@@ -209,7 +209,6 @@ email === args.data.email`, async () => {
       .populate("adminFor")
       .populate("membershipRequests")
       .populate("organizationsBlockedBy")
-      .populate("organizationUserBelongsTo")
       .lean();
 
     expect(loginPayload).toEqual(


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR ensures the removal of `organizationUserBelongsTo` field from the schema.

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #1651 

**Did you add tests for your changes?**
No
- Ensured that this change did not affect any tests.

<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
Yes, I have made relevant changes to update the documentation with my change.

<!--Add link to Talawa-Docs.-->

**Summary**
- Removed all organizationUserBelongsTo field from User Collection.
- As it is not being used in other applications except in MemberDetail.tsx in Talawa admin, where it is not being modified.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

<!--Add extra information about this PR here-->
Yes

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->
