### PR TITLE
fix: downgraded to nanoid@3.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "mongoose": "^5.13.21",
         "mongoose-paginate-v2": "^1.7.0",
         "morgan": "^1.10.0",
-        "nanoid": "^5.0.4",
+        "nanoid": "^3.3.7",
         "nodemailer": "^6.9.8",
         "pm2": "^5.2.0",
         "redis": "^4.6.12",
@@ -12382,9 +12382,9 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "node_modules/nanoid": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.4.tgz",
-      "integrity": "sha512-vAjmBf13gsmhXSgBrtIclinISzFFy22WwCYoyilZlsrRXNIHSwgFQ1bEdjRwMT3aoadeIF6HMuDRlOxzfXV8ig==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "funding": [
         {
           "type": "github",
@@ -12392,10 +12392,10 @@
         }
       ],
       "bin": {
-        "nanoid": "bin/nanoid.js"
+        "nanoid": "bin/nanoid.cjs"
       },
       "engines": {
-        "node": "^18 || >=20"
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/natural-compare": {
@@ -13273,23 +13273,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "mongoose": "^5.13.21",
     "mongoose-paginate-v2": "^1.7.0",
     "morgan": "^1.10.0",
-    "nanoid": "^5.0.4",
+    "nanoid": "^3.3.7",
     "nodemailer": "^6.9.8",
     "pm2": "^5.2.0",
     "redis": "^4.6.12",


### PR DESCRIPTION
- this is to fix `import:sample-data` script


**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #1679 

**Did you add tests for your changes?**

N/A

**Snapshots/Videos:**

N/A

**If relevant, did you update the documentation?**

N/A

**Summary**

It downgrade the nanoId version, to resolve the CommonJS support issue in nanoid 4 or higher, which fixes the error when running script `import:sample-data`

**Does this PR introduce a breaking change?**

No

**Other information**


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes