### PR TITLE
fix: removes all unused containers and images after deploy.yaml workflow

### DIFF
--- a/scripts/cloud-api-demo/deploy.sh
+++ b/scripts/cloud-api-demo/deploy.sh
@@ -17,3 +17,6 @@ docker-compose down
 
 # Build and launch containers in the background
 docker-compose up -d --build
+
+# Remove all unused containers, networks, and images (both dangling and all unused)
+docker system prune -f


### PR DESCRIPTION

**What kind of change does this PR introduce?**

Bugfix mentioned here - https://github.com/PalisadoesFoundation/talawa-api/issues/1428#issuecomment-1891002800

**Issue Number:**

None

**Did you add tests for your changes?**

N/A

**Snapshots/Videos:**

N/A

**If relevant, did you update the documentation?**

N/A

**Summary**
The cloud instance of talawa-api was out of storage due to old containers and images created by workflow: 
![Screenshot_14-Jan_22-51-38_5075](https://github.com/PalisadoesFoundation/talawa-api/assets/69643310/1622831b-c956-41fa-8b40-c41db76d3828)

Added the step to remove all the unwanted images and containers after the talawa-api containers are up and running in deploy.yaml workflow.

**Does this PR introduce a breaking change?**

No

**Other information**

N/A

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes
