### PR TITLE
Deprecated titles for non-pinned posts

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -234,13 +234,13 @@ export const POST_NEEDS_TO_BE_PINNED = {
   MESSAGE: "Post needs to be pinned inorder to add a title",
   CODE: "post.notAllowedToAddTitle",
   PARAM: "post.notAllowedToAddTitle",
-}
+};
 
 export const PLEASE_PROVIDE_TITLE = {
   MESSAGE: "Please provide a title to pin post",
   CODE: "post.provideTitle",
-  PARAM: "post.provideTitle"
-}
+  PARAM: "post.provideTitle",
+};
 
 export const USER_NOT_AUTHORIZED_TO_PIN = {
   MESSAGE:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -230,6 +230,18 @@ export const ADMIN_CANNOT_CHANGE_ITS_ROLE = {
   PARAM: "admin.changeOwnRole",
 };
 
+export const POST_NEEDS_TO_BE_PINNED = {
+  MESSAGE: "Post needs to be pinned inorder to add a title",
+  CODE: "post.notAllowedToAddTitle",
+  PARAM: "post.notAllowedToAddTitle",
+}
+
+export const PLEASE_PROVIDE_TITLE = {
+  MESSAGE: "Please provide a title to pin post",
+  CODE: "post.provideTitle",
+  PARAM: "post.provideTitle"
+}
+
 export const USER_NOT_AUTHORIZED_TO_PIN = {
   MESSAGE:
     "The user must be a superadmin or an admin of the organization to pin/unpin posts",

--- a/src/resolvers/Mutation/createPost.ts
+++ b/src/resolvers/Mutation/createPost.ts
@@ -6,6 +6,8 @@ import {
   ORGANIZATION_NOT_FOUND_ERROR,
   USER_NOT_FOUND_ERROR,
   USER_NOT_AUTHORIZED_TO_PIN,
+  POST_NEEDS_TO_BE_PINNED,
+  PLEASE_PROVIDE_TITLE,
 } from "../../constants";
 import { isValidString } from "../../libraries/validators/validateString";
 import { uploadEncodedImage } from "../../utilities/encodedImageStorage/uploadEncodedImage";
@@ -79,6 +81,23 @@ export const createPost: MutationResolvers["createPost"] = async (
     } else {
       throw new Error("Unsupported file type.");
     }
+  }
+
+  // Check title and pinpost
+  if (args.data?.title && !args.data.pinned) {
+    throw new errors.InputValidationError(
+      requestContext.translate(
+        POST_NEEDS_TO_BE_PINNED.MESSAGE
+      ),
+      POST_NEEDS_TO_BE_PINNED.CODE
+    );
+  } else if (!args.data?.title && args.data.pinned) {
+    throw new errors.InputValidationError(
+      requestContext.translate(
+        PLEASE_PROVIDE_TITLE.MESSAGE
+      ),
+      PLEASE_PROVIDE_TITLE.CODE
+    );
   }
 
   // Checks if the recieved arguments are valid according to standard input norms

--- a/src/resolvers/Mutation/createPost.ts
+++ b/src/resolvers/Mutation/createPost.ts
@@ -86,16 +86,12 @@ export const createPost: MutationResolvers["createPost"] = async (
   // Check title and pinpost
   if (args.data?.title && !args.data.pinned) {
     throw new errors.InputValidationError(
-      requestContext.translate(
-        POST_NEEDS_TO_BE_PINNED.MESSAGE
-      ),
+      requestContext.translate(POST_NEEDS_TO_BE_PINNED.MESSAGE),
       POST_NEEDS_TO_BE_PINNED.CODE
     );
   } else if (!args.data?.title && args.data.pinned) {
     throw new errors.InputValidationError(
-      requestContext.translate(
-        PLEASE_PROVIDE_TITLE.MESSAGE
-      ),
+      requestContext.translate(PLEASE_PROVIDE_TITLE.MESSAGE),
       PLEASE_PROVIDE_TITLE.CODE
     );
   }

--- a/src/resolvers/Mutation/togglePostPin.ts
+++ b/src/resolvers/Mutation/togglePostPin.ts
@@ -121,7 +121,7 @@ export const togglePostPin: MutationResolvers["togglePostPin"] = async (
       {
         $set: {
           pinned: false,
-          title: '',
+          title: "",
         },
       }
     ).lean();
@@ -132,12 +132,9 @@ export const togglePostPin: MutationResolvers["togglePostPin"] = async (
 
     return updatedPost!;
   } else {
-
     if (!args.title) {
       throw new errors.InputValidationError(
-        requestContext.translate(
-          PLEASE_PROVIDE_TITLE.MESSAGE
-        ),
+        requestContext.translate(PLEASE_PROVIDE_TITLE.MESSAGE),
         PLEASE_PROVIDE_TITLE.CODE
       );
     }
@@ -178,7 +175,7 @@ export const togglePostPin: MutationResolvers["togglePostPin"] = async (
       {
         $set: {
           pinned: true,
-          title: args?.title
+          title: args?.title,
         },
       }
     ).lean();

--- a/src/resolvers/Mutation/togglePostPin.ts
+++ b/src/resolvers/Mutation/togglePostPin.ts
@@ -2,6 +2,8 @@ import {
   POST_NOT_FOUND_ERROR,
   USER_NOT_FOUND_ERROR,
   USER_NOT_AUTHORIZED_TO_PIN,
+  PLEASE_PROVIDE_TITLE,
+  LENGTH_VALIDATION_ERROR,
 } from "../../constants";
 import type { MutationResolvers } from "../../types/generatedGraphQLTypes";
 import { errors, requestContext } from "../../libraries";
@@ -12,6 +14,7 @@ import { findOrganizationsInCache } from "../../services/OrganizationCache/findO
 import { Types } from "mongoose";
 import { findPostsInCache } from "../../services/PostCache/findPostsInCache";
 import { cachePosts } from "../../services/PostCache/cachePosts";
+import { isValidString } from "../../libraries/validators/validateString";
 
 export const togglePostPin: MutationResolvers["togglePostPin"] = async (
   _parent,
@@ -118,6 +121,7 @@ export const togglePostPin: MutationResolvers["togglePostPin"] = async (
       {
         $set: {
           pinned: false,
+          title: '',
         },
       }
     ).lean();
@@ -128,6 +132,28 @@ export const togglePostPin: MutationResolvers["togglePostPin"] = async (
 
     return updatedPost!;
   } else {
+
+    if (!args.title) {
+      throw new errors.InputValidationError(
+        requestContext.translate(
+          PLEASE_PROVIDE_TITLE.MESSAGE
+        ),
+        PLEASE_PROVIDE_TITLE.CODE
+      );
+    }
+
+    if (args?.title) {
+      const validationResultTitle = isValidString(args?.title, 256);
+      if (!validationResultTitle.isLessThanMaxLength) {
+        throw new errors.InputValidationError(
+          requestContext.translate(
+            `${LENGTH_VALIDATION_ERROR.MESSAGE} 256 characters in title`
+          ),
+          LENGTH_VALIDATION_ERROR.CODE
+        );
+      }
+    }
+
     const updatedOrganization = await Organization.findOneAndUpdate(
       {
         _id: post.organization,
@@ -152,6 +178,7 @@ export const togglePostPin: MutationResolvers["togglePostPin"] = async (
       {
         $set: {
           pinned: true,
+          title: args?.title
         },
       }
     ).lean();

--- a/src/resolvers/Mutation/updatePost.ts
+++ b/src/resolvers/Mutation/updatePost.ts
@@ -72,16 +72,12 @@ export const updatePost: MutationResolvers["updatePost"] = async (
   // Check title and pinpost
   if (args.data?.title && !post.pinned) {
     throw new errors.InputValidationError(
-      requestContext.translate(
-        POST_NEEDS_TO_BE_PINNED.MESSAGE
-      ),
+      requestContext.translate(POST_NEEDS_TO_BE_PINNED.MESSAGE),
       POST_NEEDS_TO_BE_PINNED.CODE
     );
   } else if (!args.data?.title && post.pinned) {
     throw new errors.InputValidationError(
-      requestContext.translate(
-        PLEASE_PROVIDE_TITLE.MESSAGE
-      ),
+      requestContext.translate(PLEASE_PROVIDE_TITLE.MESSAGE),
       PLEASE_PROVIDE_TITLE.CODE
     );
   }

--- a/src/resolvers/Mutation/updatePost.ts
+++ b/src/resolvers/Mutation/updatePost.ts
@@ -6,6 +6,8 @@ import {
   USER_NOT_AUTHORIZED_ERROR,
   POST_NOT_FOUND_ERROR,
   LENGTH_VALIDATION_ERROR,
+  POST_NEEDS_TO_BE_PINNED,
+  PLEASE_PROVIDE_TITLE,
 } from "../../constants";
 import { isValidString } from "../../libraries/validators/validateString";
 import { findPostsInCache } from "../../services/PostCache/findPostsInCache";
@@ -64,6 +66,23 @@ export const updatePost: MutationResolvers["updatePost"] = async (
     args.data.videoUrl = await uploadEncodedVideo(
       args.data.videoUrl,
       post.videoUrl
+    );
+  }
+
+  // Check title and pinpost
+  if (args.data?.title && !post.pinned) {
+    throw new errors.InputValidationError(
+      requestContext.translate(
+        POST_NEEDS_TO_BE_PINNED.MESSAGE
+      ),
+      POST_NEEDS_TO_BE_PINNED.CODE
+    );
+  } else if (!args.data?.title && post.pinned) {
+    throw new errors.InputValidationError(
+      requestContext.translate(
+        PLEASE_PROVIDE_TITLE.MESSAGE
+      ),
+      PLEASE_PROVIDE_TITLE.CODE
     );
   }
 

--- a/src/typeDefs/mutations.ts
+++ b/src/typeDefs/mutations.ts
@@ -188,7 +188,7 @@ export const mutations = gql`
 
     signUp(data: UserInput!, file: String): AuthData!
 
-    togglePostPin(id: ID!): Post! @auth
+    togglePostPin(id: ID!, title: String): Post! @auth
 
     unassignUserTag(input: ToggleUserTagAssignInput!): User @auth
 

--- a/src/types/generatedGraphQLTypes.ts
+++ b/src/types/generatedGraphQLTypes.ts
@@ -979,6 +979,7 @@ export type MutationSignUpArgs = {
 
 export type MutationTogglePostPinArgs = {
   id: Scalars['ID']['input'];
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 

--- a/tests/resolvers/Mutation/createPost.spec.ts
+++ b/tests/resolvers/Mutation/createPost.spec.ts
@@ -210,6 +210,7 @@ describe("resolvers -> Mutation -> createPost", () => {
         text: "text",
         videoUrl: "videoUrl",
         title: "title",
+        pinned: true,
       },
     };
 
@@ -277,6 +278,7 @@ describe("resolvers -> Mutation -> createPost", () => {
           title:
             "AfGtN9o7IJXH9Xr5P4CcKTWMVWKOOHTldleLrWfZcThgoX5scPE5o0jARvtVA8VhneyxXquyhWb5nluW2jtP0Ry1zIOUFYfJ6BUXvpo4vCw4GVleGBnoKwkFLp5oW9L8OsEIrjVtYBwaOtXZrkTEBySZ1prr0vFcmrSoCqrCTaChNOxL3tDoHK6h44ChFvgmoVYMSq3IzJohKtbBn68D9NfEVMEtoimkGarUnVBAOsGkKv0mIBJaCl2pnR8Xwq1cG1",
           imageUrl: null,
+          pinned: true,
         },
       };
 
@@ -308,6 +310,7 @@ describe("resolvers -> Mutation -> createPost", () => {
           videoUrl: "",
           title: "random",
           imageUrl: null,
+          pinned: true,
         },
       };
 
@@ -324,6 +327,66 @@ describe("resolvers -> Mutation -> createPost", () => {
       expect(error.message).toEqual(
         `${LENGTH_VALIDATION_ERROR.MESSAGE} 500 characters in information`
       );
+    }
+  });
+
+  it("throws error if title is provided and post is not pinned", async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    vi.spyOn(requestContext, "translate").mockImplementationOnce(
+      (message) => message
+    );
+    try {
+      const args: MutationCreatePostArgs = {
+        data: {
+          organizationId: testOrganization?._id,
+          title: "Test title",
+          text: "Test text",
+          pinned: false,
+        },
+      };
+
+      const context = {
+        userId: testUser?.id,
+      };
+
+      const { createPost: createPostResolver } = await import(
+        "../../../src/resolvers/Mutation/createPost"
+      );
+      await createPostResolver?.({}, args, context);
+    } catch (error: any) {
+      expect(error.message).toEqual(
+        `Post needs to be pinned inorder to add a title`
+      )
+    }
+  });
+
+  it("throws error if title is not provided and post is pinned", async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    vi.spyOn(requestContext, "translate").mockImplementationOnce(
+      (message) => message
+    );
+    try {
+      const args: MutationCreatePostArgs = {
+        data: {
+          organizationId: testOrganization?._id,
+          title: "",
+          text: "Test text",
+          pinned: true,
+        },
+      };
+
+      const context = {
+        userId: testUser?.id,
+      };
+
+      const { createPost: createPostResolver } = await import(
+        "../../../src/resolvers/Mutation/createPost"
+      );
+      await createPostResolver?.({}, args, context);
+    } catch (error: any) {
+      expect(error.message).toEqual(
+        `Please provide a title to pin post`
+      )
     }
   });
 });

--- a/tests/resolvers/Mutation/createPost.spec.ts
+++ b/tests/resolvers/Mutation/createPost.spec.ts
@@ -356,7 +356,7 @@ describe("resolvers -> Mutation -> createPost", () => {
     } catch (error: any) {
       expect(error.message).toEqual(
         `Post needs to be pinned inorder to add a title`
-      )
+      );
     }
   });
 
@@ -384,9 +384,7 @@ describe("resolvers -> Mutation -> createPost", () => {
       );
       await createPostResolver?.({}, args, context);
     } catch (error: any) {
-      expect(error.message).toEqual(
-        `Please provide a title to pin post`
-      )
+      expect(error.message).toEqual(`Please provide a title to pin post`);
     }
   });
 });

--- a/tests/resolvers/Mutation/togglePostPin.spec.ts
+++ b/tests/resolvers/Mutation/togglePostPin.spec.ts
@@ -9,6 +9,7 @@ import {
   POST_NOT_FOUND_ERROR,
   USER_NOT_FOUND_ERROR,
   USER_NOT_AUTHORIZED_TO_PIN,
+  LENGTH_VALIDATION_ERROR,
 } from "../../../src/constants";
 import {
   beforeAll,
@@ -139,6 +140,7 @@ describe("resolvers -> Mutation -> togglePostPin", () => {
     );
     const args: MutationTogglePostPinArgs = {
       id: testPost?._id,
+      title: "Test title",
     };
 
     const context = {
@@ -198,5 +200,59 @@ describe("resolvers -> Mutation -> togglePostPin", () => {
 
     expect(currentPostIsPinned).toBeFalsy();
     expect(updatedPost?.pinned).toBeFalsy();
+  });
+
+  it("throws error if title is not provided to pin post", async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    vi.spyOn(requestContext, "translate").mockImplementationOnce(
+      (message) => message
+    );
+    try {
+      const args: MutationTogglePostPinArgs = {
+        id: testPost?._id,
+      };
+
+      const context = {
+        userId: testUser?._id,
+      };
+
+      const { togglePostPin: togglePostPinResolver } = await import(
+        "../../../src/resolvers/Mutation/togglePostPin"
+      );
+
+      await togglePostPinResolver?.({}, args, context);
+    } catch (error: any) {
+      expect(error.message).toEqual(
+        `Please provide a title to pin post`
+      )
+    }
+  });
+
+  it(`throws String Length Validation error if title is greater than 256 characters`, async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    vi.spyOn(requestContext, "translate").mockImplementationOnce(
+      (message) => message
+    );
+    try {
+      const args: MutationTogglePostPinArgs = {
+        id: testPost?._id,
+        title:
+          "AfGtN9o7IJXH9Xr5P4CcKTWMVWKOOHTldleLrWfZcThgoX5scPE5o0jARvtVA8VhneyxXquyhWb5nluW2jtP0Ry1zIOUFYfJ6BUXvpo4vCw4GVleGBnoKwkFLp5oW9L8OsEIrjVtYBwaOtXZrkTEBySZ1prr0vFcmrSoCqrCTaChNOxL3tDoHK6h44ChFvgmoVYMSq3IzJohKtbBn68D9NfEVMEtoimkGarUnVBAOsGkKv0mIBJaCl2pnR8Xwq1cG1",
+      };
+
+      const context = {
+        userId: testUser?._id,
+      };
+
+      const { togglePostPin: togglePostPinResolver } = await import(
+        "../../../src/resolvers/Mutation/togglePostPin"
+      );
+
+      await togglePostPinResolver?.({}, args, context);
+    } catch (error: any) {
+      expect(error.message).toEqual(
+        `${LENGTH_VALIDATION_ERROR.MESSAGE} 256 characters in title`
+      );
+    }
   });
 });

--- a/tests/resolvers/Mutation/togglePostPin.spec.ts
+++ b/tests/resolvers/Mutation/togglePostPin.spec.ts
@@ -222,9 +222,7 @@ describe("resolvers -> Mutation -> togglePostPin", () => {
 
       await togglePostPinResolver?.({}, args, context);
     } catch (error: any) {
-      expect(error.message).toEqual(
-        `Please provide a title to pin post`
-      )
+      expect(error.message).toEqual(`Please provide a title to pin post`);
     }
   });
 

--- a/tests/resolvers/Mutation/updatePost.spec.ts
+++ b/tests/resolvers/Mutation/updatePost.spec.ts
@@ -10,18 +10,23 @@ import {
   USER_NOT_AUTHORIZED_ERROR,
 } from "../../../src/constants";
 import { beforeEach, afterEach, describe, it, expect, vi } from "vitest";
-import type { TestUserType } from "../../helpers/userAndOrg";
+import type { TestOrganizationType, TestUserType } from "../../helpers/userAndOrg";
 import type { TestPostType } from "../../helpers/posts";
-import { createTestPost } from "../../helpers/posts";
+import { createTestPost, createTestSinglePost } from "../../helpers/posts";
 
 let testUser: TestUserType;
 let testPost: TestPostType;
+let testOrganization: TestOrganizationType
+let testPost2: TestPostType;
 
 beforeEach(async () => {
   await connect();
-  const temp = await createTestPost();
+  const temp = await createTestPost(true);
   testUser = temp[0];
+  testOrganization = temp[1];
   testPost = temp[2];
+  testPost2 = await createTestSinglePost(testUser?.id, testOrganization?.id)
+
   const { requestContext } = await import("../../../src/libraries");
   vi.spyOn(requestContext, "translate").mockImplementation(
     (message) => message
@@ -196,6 +201,65 @@ describe("resolvers -> Mutation -> updatePost", () => {
     } catch (error: any) {
       expect(error.message).toEqual(
         `${LENGTH_VALIDATION_ERROR.MESSAGE} 500 characters in information`
+      );
+    }
+  });
+
+  it("throws error if title is provided and post is not pinned", async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    vi.spyOn(requestContext, "translate").mockImplementationOnce(
+      (message) => message
+    );
+    try {
+      const args: MutationUpdatePostArgs = {
+        id: testPost2?._id,
+        data: {
+          title: "Test title",
+          text: "Test text"
+        },
+      };
+
+      const context = {
+        userId: testUser?.id,
+      };
+
+      const { updatePost: updatePostResolver } = await import(
+        "../../../src/resolvers/Mutation/updatePost"
+      );
+
+      await updatePostResolver?.({}, args, context);
+    } catch (error: any) {
+      expect(error.message).toEqual(
+        `Post needs to be pinned inorder to add a title`
+      )
+    }
+  });
+
+  it(`throws error if title is not provided and post is pinned`, async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    vi.spyOn(requestContext, "translate").mockImplementationOnce(
+      (message) => message
+    );
+    try {
+      const args: MutationUpdatePostArgs = {
+        id: testPost?._id,
+        data: {
+          text:"Testing text",
+        },
+      };
+
+      const context = {
+        userId: testUser?.id,
+      };
+
+      const { updatePost: updatePostResolver } = await import(
+        "../../../src/resolvers/Mutation/updatePost"
+      );
+
+      await updatePostResolver?.({}, args, context);
+    } catch (error: any) {
+      expect(error.message).toEqual(
+        `Please provide a title to pin post`
       );
     }
   });

--- a/tests/resolvers/Mutation/updatePost.spec.ts
+++ b/tests/resolvers/Mutation/updatePost.spec.ts
@@ -10,13 +10,16 @@ import {
   USER_NOT_AUTHORIZED_ERROR,
 } from "../../../src/constants";
 import { beforeEach, afterEach, describe, it, expect, vi } from "vitest";
-import type { TestOrganizationType, TestUserType } from "../../helpers/userAndOrg";
+import type {
+  TestOrganizationType,
+  TestUserType,
+} from "../../helpers/userAndOrg";
 import type { TestPostType } from "../../helpers/posts";
 import { createTestPost, createTestSinglePost } from "../../helpers/posts";
 
 let testUser: TestUserType;
 let testPost: TestPostType;
-let testOrganization: TestOrganizationType
+let testOrganization: TestOrganizationType;
 let testPost2: TestPostType;
 
 beforeEach(async () => {
@@ -25,7 +28,7 @@ beforeEach(async () => {
   testUser = temp[0];
   testOrganization = temp[1];
   testPost = temp[2];
-  testPost2 = await createTestSinglePost(testUser?.id, testOrganization?.id)
+  testPost2 = await createTestSinglePost(testUser?.id, testOrganization?.id);
 
   const { requestContext } = await import("../../../src/libraries");
   vi.spyOn(requestContext, "translate").mockImplementation(
@@ -215,7 +218,7 @@ describe("resolvers -> Mutation -> updatePost", () => {
         id: testPost2?._id,
         data: {
           title: "Test title",
-          text: "Test text"
+          text: "Test text",
         },
       };
 
@@ -231,7 +234,7 @@ describe("resolvers -> Mutation -> updatePost", () => {
     } catch (error: any) {
       expect(error.message).toEqual(
         `Post needs to be pinned inorder to add a title`
-      )
+      );
     }
   });
 
@@ -244,7 +247,7 @@ describe("resolvers -> Mutation -> updatePost", () => {
       const args: MutationUpdatePostArgs = {
         id: testPost?._id,
         data: {
-          text:"Testing text",
+          text: "Testing text",
         },
       };
 
@@ -258,9 +261,7 @@ describe("resolvers -> Mutation -> updatePost", () => {
 
       await updatePostResolver?.({}, args, context);
     } catch (error: any) {
-      expect(error.message).toEqual(
-        `Please provide a title to pin post`
-      );
+      expect(error.message).toEqual(`Please provide a title to pin post`);
     }
   });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

**Issue Number: #1739**

Fixes #1739

Deprecated title for non-pinned posts

Following API endpoints are changed:
 
- Create post
- Update post
- Toggle post pin

Title should be provided to pin post. Non pinned posts will throw error if title is provided.

In toggle post pin, an input for title should be provided on the client side if the post is getting pinned, and the title will be automatically removed if the post is getting unpinned.

**Did you add tests for your changes?**

Yes

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

No

**Does this PR introduce a breaking change?**

Yes

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes