### PR TITLE
 feat : Creating support for Event Agendas, part1 : Agenda Category CRUD.

### DIFF
--- a/codegen.ts
+++ b/codegen.ts
@@ -64,6 +64,8 @@ const config: CodegenConfig = {
 
           Message: "../models/Message#InterfaceMessage",
 
+          AgendaCategory: "../models/AgendaCategory#InterfaceAgendaCategory",
+
           Organization: "../models/Organization#InterfaceOrganization",
 
           Plugin: "../models/Plugin#InterfacePlugin",

--- a/schema.graphql
+++ b/schema.graphql
@@ -137,7 +137,7 @@ type DeletePayload {
 
 type DirectChat {
   _id: ID!
-  agendacategories: [AgendaCategory]
+  agendaCategories: [AgendaCategory]
   creator: User!
   messages: [DirectChatMessage]
   organization: Organization!

--- a/schema.graphql
+++ b/schema.graphql
@@ -137,6 +137,7 @@ type DeletePayload {
 
 type DirectChat {
   _id: ID!
+  agendacategories: [AgendaCategory]
   creator: User!
   messages: [DirectChatMessage]
   organization: Organization!

--- a/schema.graphql
+++ b/schema.graphql
@@ -34,6 +34,17 @@ type Advertisement {
   type: String!
 }
 
+type AgendaCategory {
+  _id: ID!
+  createdAt: Date!
+  createdBy: User!
+  description: String
+  name: String!
+  organization: Organization
+  updatedAt: Date
+  updatedBy: User
+}
+
 type AggregatePost {
   count: Int!
 }
@@ -97,6 +108,12 @@ type ConnectionPageInfo {
 }
 
 scalar CountryCode
+
+input CreateAgendaCategoryInput {
+  description: String
+  name: String!
+  organization: ID!
+}
 
 input CreateUserTagInput {
   name: String!
@@ -483,6 +500,7 @@ type Mutation {
   checkIn(data: CheckInInput!): CheckIn!
   createAdmin(data: UserAndOrganizationInput!): User!
   createAdvertisement(endDate: Date!, link: String!, name: String!, orgId: ID!, startDate: Date!, type: String!): Advertisement!
+  createAgendaCategory(input: CreateAgendaCategoryInput!): AgendaCategory!
   createComment(data: CommentInput!, postId: ID!): Comment
   createDirectChat(data: createChatInput!): DirectChat!
   createDonation(amount: Float!, nameOfOrg: String!, nameOfUser: String!, orgId: ID!, payPalId: ID!, userId: ID!): Donation!
@@ -498,6 +516,7 @@ type Mutation {
   createTask(data: TaskInput!, eventProjectId: ID!): Task!
   createUserTag(input: CreateUserTagInput!): UserTag
   deleteAdvertisementById(id: ID!): DeletePayload!
+  deleteAgendaCategory(id: ID!): ID!
   deleteDonationById(id: ID!): DeletePayload!
   forgotPassword(data: ForgotPasswordData!): Boolean!
   joinPublicOrganization(organizationId: ID!): User!
@@ -544,6 +563,7 @@ type Mutation {
   unlikeComment(id: ID!): Comment
   unlikePost(id: ID!): Post
   unregisterForEventByUser(id: ID!): Event!
+  updateAgendaCategory(id: ID!, input: UpdateAgendaCategoryInput!): AgendaCategory!
   updateEvent(data: UpdateEventInput, id: ID!): Event!
   updateEventProject(data: UpdateEventProjectInput!, id: ID!): EventProject!
   updateLanguage(languageCode: String!): User!
@@ -794,6 +814,8 @@ input PostWhereInput {
 
 type Query {
   adminPlugin(orgId: ID!): [Plugin]
+  agendaCategories: [AgendaCategory]
+  agendaCategory(id: ID!): AgendaCategory
   checkAuth: User!
   customDataByOrganization(organizationId: ID!): [UserCustomData!]!
   customFieldsByOrganization(id: ID!): [OrganizationCustomField]
@@ -911,6 +933,12 @@ type UnauthenticatedError implements Error {
 
 type UnauthorizedError implements Error {
   message: String!
+}
+
+input UpdateAgendaCategoryInput {
+  description: String
+  name: String
+  organizationId: ID
 }
 
 input UpdateEventInput {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -211,6 +211,13 @@ export const ADMIN_CANNOT_CHANGE_ITS_ROLE = {
   PARAM: "admin.changeOwnRole",
 };
 
+export const AGENDA_CATEGORY_NOT_FOUND_ERROR = {
+  DESC: "Agenda category not found",
+  CODE: "agendaCategory.notFound",
+  MESSAGE: "agendaCategory.notFound",
+  PARAM: "agendaCategory",
+};
+
 export const USER_NOT_AUTHORIZED_TO_PIN = {
   MESSAGE:
     "The user must be a superadmin or an admin of the organization to pin/unpin posts",

--- a/src/models/AgendaCategory.ts
+++ b/src/models/AgendaCategory.ts
@@ -1,0 +1,67 @@
+import type { PopulatedDoc, Model, Types } from "mongoose";
+import { Schema, model, models } from "mongoose";
+import type { InterfaceOrganization } from "./Organization";
+import type { InterfaceUser } from "./User";
+/**
+ * This is an interface representing a document for an agenda category in the database (MongoDB).
+ */
+export interface InterfaceAgendaCategory {
+  _id: Types.ObjectId; // Unique identifier for the agenda category.
+  name: string; // Name of the agenda category.
+  description?: string; // Optional description of the agenda category.
+  organization: PopulatedDoc<InterfaceOrganization & Document>; // Reference to the organization associated with the agenda category.
+  createdBy: PopulatedDoc<InterfaceUser & Document>; // Reference to the user who created the agenda category.
+  updatedBy: PopulatedDoc<InterfaceUser & Document>; // Reference to the user who last updated the agenda category.
+}
+
+/**
+ * This is the Mongoose schema for an agenda category.
+ * @param name - Name of the agenda category.
+ * @param description - Optional description of the agenda category.
+ * @param organization - Reference to the organization associated with the agenda category.
+ * @param createdBy - Reference to the user who created the agenda category.
+ * @param updatedBy - Reference to the user who last updated the agenda category.
+ * @param createdAt - Date when the agenda category was created.
+ * @param updatedAt - Date when the agenda category was last updated.
+ */
+export const AgendaCategorySchema = new Schema({
+  name: {
+    type: String,
+    required: true,
+    trim: true,
+  },
+  description: {
+    type: String,
+    trim: true,
+  },
+  organization: {
+    type: Schema.Types.ObjectId,
+    ref: "Organization",
+  },
+  createdBy: {
+    type: Schema.Types.ObjectId,
+    ref: "User",
+    required: true,
+  },
+  updatedBy: {
+    type: Schema.Types.ObjectId,
+    ref: "User",
+  },
+  createdAt: {
+    type: Date,
+    required: true,
+    default: Date.now,
+  },
+  updatedAt: {
+    type: Date,
+
+    default: Date.now,
+  },
+});
+
+const agendaCategoryModel = (): Model<InterfaceAgendaCategory> =>
+  model<InterfaceAgendaCategory>("AgendaCategory", AgendaCategorySchema);
+
+// Check if the AgendaItem model is already defined, if not, create a new one
+export const AgendaCategoryModel = (models.AgendaCategory ||
+  agendaCategoryModel()) as ReturnType<typeof agendaCategoryModel>;

--- a/src/models/Organization.ts
+++ b/src/models/Organization.ts
@@ -5,6 +5,7 @@ import type { InterfaceMessage } from "./Message";
 import type { InterfacePost } from "./Post";
 import type { InterfaceUser } from "./User";
 import type { InterfaceOrganizationCustomField } from "./OrganizationCustomField";
+import type { InterfaceAgendaCategory } from "./AgendaCategory";
 /**
  * This is an interface that represents a database(MongoDB) document for Organization.
  */
@@ -20,6 +21,7 @@ export interface InterfaceOrganization {
   status: string;
   members: PopulatedDoc<InterfaceUser & Document>[];
   admins: PopulatedDoc<InterfaceUser & Document>[];
+  agendaCategories: PopulatedDoc<InterfaceAgendaCategory & Document>[];
   groupChats: PopulatedDoc<InterfaceMessage & Document>[];
   posts: PopulatedDoc<InterfacePost & Document>[];
   pinnedPosts: PopulatedDoc<InterfacePost & Document>[];
@@ -75,6 +77,12 @@ const organizationSchema = new Schema({
     ref: "User",
     required: true,
   },
+  agendaCategories: [
+    {
+      type: Schema.Types.ObjectId,
+      ref: "AgendaCategory",
+    },
+  ],
   status: {
     type: String,
     required: true,

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -28,3 +28,4 @@ export * from "./Task";
 export * from "./TaskVolunteer";
 export * from "./User";
 export * from "./TagUser";
+export * from "./AgendaCategory";

--- a/src/resolvers/Mutation/createAgendaCategory.ts
+++ b/src/resolvers/Mutation/createAgendaCategory.ts
@@ -1,72 +1,87 @@
-// import type { MutationResolvers } from "../../types/generatedGraphQLTypes";
-// import { errors, requestContext } from "../../libraries";
-// import { AgendaCategoryModel, Organization, User } from "../../models";
-// import {
-//   USER_NOT_FOUND_ERROR,
-//   ORGANIZATION_NOT_FOUND_ERROR,
-//   USER_NOT_AUTHORIZED_ERROR,
-// } from "../../constants";
-// import { adminCheck, superAdminCheck } from "../../utilities";
+import type { MutationResolvers } from "../../types/generatedGraphQLTypes";
+import { errors, requestContext } from "../../libraries";
+import { AgendaCategoryModel, Organization, User } from "../../models";
+import {
+  USER_NOT_FOUND_ERROR,
+  ORGANIZATION_NOT_FOUND_ERROR,
+  USER_NOT_AUTHORIZED_ERROR,
+} from "../../constants";
+import { adminCheck, superAdminCheck } from "../../utilities";
+import { cacheOrganizations } from "../../services/OrganizationCache/cacheOrganizations";
+import { findOrganizationsInCache } from "../../services/OrganizationCache/findOrganizationsInCache";
 
-// /**
-//  * Resolver function for the GraphQL mutation 'createAgendaCategory'.
-//  *
-//  * This resolver creates a new agenda category, associates it with an organization,
-//  * and updates the organization with the new agenda category.
-//  *
-//  * @param {Object} _parent - The parent object, not used in this resolver.
-//  * @param {Object} args - The input arguments for the mutation.
-//  * @param {Object} context - The context object containing user information.
-//  * @returns {Promise<Object>} A promise that resolves to the created agenda category.
-//  * @throws {NotFoundError} Throws an error if the user or organization is not found.
-//  * @throws {UnauthorizedError} Throws an error if the user does not have the required permissions.
-//  * @throws {InternalServerError} Throws an error for other potential issues during agenda category creation.
-//  */
-// export const createAgendaCategory: MutationResolvers["createAgendaCategory"] =
-//   async (_parent, args, context) => {
-//     // Find the current user based on the provided createdBy ID or use the context userId
+/**
+ * Resolver function for the GraphQL mutation 'createAgendaCategory'.
+ *
+ * This resolver creates a new agenda category, associates it with an organization,
+ * and updates the organization with the new agenda category.
+ *
+ * @param {Object} _parent - The parent object, not used in this resolver.
+ * @param {Object} args - The input arguments for the mutation.
+ * @param {Object} context - The context object containing user information.
+ * @returns {Promise<Object>} A promise that resolves to the created agenda category.
+ * @throws {NotFoundError} Throws an error if the user or organization is not found.
+ * @throws {UnauthorizedError} Throws an error if the user does not have the required permissions.
+ * @throws {InternalServerError} Throws an error for other potential issues during agenda category creation.
+ */
+export const createAgendaCategory: MutationResolvers["createAgendaCategory"] =
+  async (_parent, args, context) => {
+    // Find the current user based on the provided createdBy ID or use the context userId
 
-//     const userId = context.userId;
+    const userId = context.userId;
 
-//     const currentUser = await User.findById(userId).lean();
+    const currentUser = await User.findById(userId).lean();
 
-//     if (!currentUser) {
-//       throw new errors.NotFoundError(
-//         requestContext.translate(USER_NOT_FOUND_ERROR.MESSAGE),
-//         USER_NOT_FOUND_ERROR.CODE,
-//         USER_NOT_FOUND_ERROR.PARAM
-//       );
-//     }
-//     // Check if the organization exists
-//     const relatedOrganization = await Organization.findById(
-//       args.input.organization
-//     ).lean();
+    if (!currentUser) {
+      throw new errors.NotFoundError(
+        requestContext.translate(USER_NOT_FOUND_ERROR.MESSAGE),
+        USER_NOT_FOUND_ERROR.CODE,
+        USER_NOT_FOUND_ERROR.PARAM
+      );
+    }
 
-//     // If the organization is not found, throw a NotFoundError
-//     if (!relatedOrganization) {
-//       throw new errors.NotFoundError(
-//         ORGANIZATION_NOT_FOUND_ERROR.MESSAGE,
-//         ORGANIZATION_NOT_FOUND_ERROR.CODE,
-//         ORGANIZATION_NOT_FOUND_ERROR.PARAM
-//       );
-//     }
+    let organization;
 
-//     // Check if the current user has the necessary permissions
-//     await adminCheck(context.userId, relatedOrganization);
-//     // Create a new AgendaCategory using the Mongoose model
-//     const createdAgendaCategory = await AgendaCategoryModel.create({
-//       ...args.input,
-//       createdBy: currentUser?._id,
-//       createdAt: new Date(),
-//     });
-//     await Organization.findByIdAndUpdate(
-//       relatedOrganization._id,
-//       {
-//         $push: {
-//           agendaCategories: createdAgendaCategory,
-//         },
-//       },
-//       { new: true }
-//     );
-//     return createdAgendaCategory.toObject();
-//   };
+    const organizationFoundInCache = await findOrganizationsInCache([
+      args.input.organization,
+    ]);
+
+    organization = organizationFoundInCache[0];
+
+    if (organizationFoundInCache[0] == null) {
+      organization = await Organization.findOne({
+        _id: args.input.organization,
+      }).lean();
+
+      await cacheOrganizations([organization!]);
+    }
+
+    // Checks whether the organization with _id === args.organizationId exists.
+    if (!organization) {
+      throw new errors.NotFoundError(
+        requestContext.translate(ORGANIZATION_NOT_FOUND_ERROR.MESSAGE),
+        ORGANIZATION_NOT_FOUND_ERROR.CODE,
+        ORGANIZATION_NOT_FOUND_ERROR.PARAM
+      );
+    }
+
+    // Checks whether the user is authorized to perform the operation
+    await adminCheck(context.userId, organization);
+
+    // Create a new AgendaCategory using the Mongoose model
+    const createdAgendaCategory = await AgendaCategoryModel.create({
+      ...args.input,
+      createdBy: currentUser?._id,
+      createdAt: new Date(),
+    });
+    await Organization.findByIdAndUpdate(
+      organization._id,
+      {
+        $push: {
+          agendaCategories: createdAgendaCategory,
+        },
+      },
+      { new: true }
+    );
+    return createdAgendaCategory.toObject();
+  };

--- a/src/resolvers/Mutation/createAgendaCategory.ts
+++ b/src/resolvers/Mutation/createAgendaCategory.ts
@@ -1,0 +1,72 @@
+// import type { MutationResolvers } from "../../types/generatedGraphQLTypes";
+// import { errors, requestContext } from "../../libraries";
+// import { AgendaCategoryModel, Organization, User } from "../../models";
+// import {
+//   USER_NOT_FOUND_ERROR,
+//   ORGANIZATION_NOT_FOUND_ERROR,
+//   USER_NOT_AUTHORIZED_ERROR,
+// } from "../../constants";
+// import { adminCheck, superAdminCheck } from "../../utilities";
+
+// /**
+//  * Resolver function for the GraphQL mutation 'createAgendaCategory'.
+//  *
+//  * This resolver creates a new agenda category, associates it with an organization,
+//  * and updates the organization with the new agenda category.
+//  *
+//  * @param {Object} _parent - The parent object, not used in this resolver.
+//  * @param {Object} args - The input arguments for the mutation.
+//  * @param {Object} context - The context object containing user information.
+//  * @returns {Promise<Object>} A promise that resolves to the created agenda category.
+//  * @throws {NotFoundError} Throws an error if the user or organization is not found.
+//  * @throws {UnauthorizedError} Throws an error if the user does not have the required permissions.
+//  * @throws {InternalServerError} Throws an error for other potential issues during agenda category creation.
+//  */
+// export const createAgendaCategory: MutationResolvers["createAgendaCategory"] =
+//   async (_parent, args, context) => {
+//     // Find the current user based on the provided createdBy ID or use the context userId
+
+//     const userId = context.userId;
+
+//     const currentUser = await User.findById(userId).lean();
+
+//     if (!currentUser) {
+//       throw new errors.NotFoundError(
+//         requestContext.translate(USER_NOT_FOUND_ERROR.MESSAGE),
+//         USER_NOT_FOUND_ERROR.CODE,
+//         USER_NOT_FOUND_ERROR.PARAM
+//       );
+//     }
+//     // Check if the organization exists
+//     const relatedOrganization = await Organization.findById(
+//       args.input.organization
+//     ).lean();
+
+//     // If the organization is not found, throw a NotFoundError
+//     if (!relatedOrganization) {
+//       throw new errors.NotFoundError(
+//         ORGANIZATION_NOT_FOUND_ERROR.MESSAGE,
+//         ORGANIZATION_NOT_FOUND_ERROR.CODE,
+//         ORGANIZATION_NOT_FOUND_ERROR.PARAM
+//       );
+//     }
+
+//     // Check if the current user has the necessary permissions
+//     await adminCheck(context.userId, relatedOrganization);
+//     // Create a new AgendaCategory using the Mongoose model
+//     const createdAgendaCategory = await AgendaCategoryModel.create({
+//       ...args.input,
+//       createdBy: currentUser?._id,
+//       createdAt: new Date(),
+//     });
+//     await Organization.findByIdAndUpdate(
+//       relatedOrganization._id,
+//       {
+//         $push: {
+//           agendaCategories: createdAgendaCategory,
+//         },
+//       },
+//       { new: true }
+//     );
+//     return createdAgendaCategory.toObject();
+//   };

--- a/src/resolvers/Mutation/deleteAgendaCategory.ts
+++ b/src/resolvers/Mutation/deleteAgendaCategory.ts
@@ -1,0 +1,76 @@
+// import type { MutationResolvers } from "../../types/generatedGraphQLTypes";
+// import { errors, requestContext } from "../../libraries";
+// import { AgendaCategoryModel, User, Organization } from "../../models";
+// import {
+//   AGENDA_CATEGORY_NOT_FOUND_ERROR,
+//   USER_NOT_AUTHORIZED_ERROR,
+//   USER_NOT_FOUND_ERROR,
+// } from "../../constants";
+// import { Types } from "mongoose";
+
+// /**
+//  * Resolver function for the GraphQL mutation 'deleteAgendaCategory'.
+//  *
+//  * This resolver deletes an agenda category if the user has the necessary permissions.
+//  *
+//  * @param {Object} _parent - The parent object, not used in this resolver.
+//  * @param {Object} args - The input arguments for the mutation.
+//  * @param {Object} context - The context object containing user information.
+//  * @returns {Promise<string>} A promise that resolves to the ID of the deleted agenda category.
+//  * @throws {NotFoundError} Throws an error if the user or agenda category is not found.
+//  * @throws {UnauthorizedError} Throws an error if the user does not have the required permissions.
+//  * @throws {InternalServerError} Throws an error for other potential issues during agenda category deletion.
+//  */
+// export const deleteAgendaCategory: MutationResolvers["deleteAgendaCategory"] =
+//   async (_parent, args, context) => {
+//     const categoryId = args.id;
+//     const agendaCategory = await AgendaCategoryModel.findById(args.id);
+
+//     const userId = context.userId;
+
+//     // Fetch the user to get the organization ID
+//     const currentUser = await User.findById(userId);
+
+//     // If the user is not found, throw a NotFoundError
+//     if (!currentUser) {
+//       throw new errors.NotFoundError(
+//         USER_NOT_FOUND_ERROR.MESSAGE,
+//         USER_NOT_FOUND_ERROR.CODE,
+//         USER_NOT_FOUND_ERROR.PARAM
+//       );
+//     }
+//     if (!agendaCategory) {
+//       throw new errors.NotFoundError(
+//         AGENDA_CATEGORY_NOT_FOUND_ERROR.MESSAGE,
+//         AGENDA_CATEGORY_NOT_FOUND_ERROR.CODE,
+//         AGENDA_CATEGORY_NOT_FOUND_ERROR.PARAM
+//       );
+//     }
+
+//     const currentOrg = await AgendaCategoryModel.findById(agendaCategory._id)
+//       .populate("organization")
+//       .select("organization")
+//       .lean();
+
+//     const orgId = currentOrg?._id;
+
+//     const currentUserIsOrgAdmin = currentUser.adminFor.some(
+//       (organizationId) =>
+//         organizationId === currentOrg?._id ||
+//         Types.ObjectId(organizationId).equals(organizationId)
+//     );
+//     // If the user is a normal user, throw an error
+//     if (
+//       currentUserIsOrgAdmin === false &&
+//       currentUser.userType !== "SUPERADMIN"
+//     ) {
+//       throw new errors.UnauthorizedError(
+//         USER_NOT_AUTHORIZED_ERROR.MESSAGE,
+//         USER_NOT_AUTHORIZED_ERROR.CODE,
+//         USER_NOT_AUTHORIZED_ERROR.PARAM
+//       );
+//     }
+
+//     await AgendaCategoryModel.findByIdAndDelete(args.id);
+//     return categoryId;
+//   };

--- a/src/resolvers/Mutation/deleteAgendaCategory.ts
+++ b/src/resolvers/Mutation/deleteAgendaCategory.ts
@@ -1,76 +1,76 @@
-// import type { MutationResolvers } from "../../types/generatedGraphQLTypes";
-// import { errors, requestContext } from "../../libraries";
-// import { AgendaCategoryModel, User, Organization } from "../../models";
-// import {
-//   AGENDA_CATEGORY_NOT_FOUND_ERROR,
-//   USER_NOT_AUTHORIZED_ERROR,
-//   USER_NOT_FOUND_ERROR,
-// } from "../../constants";
-// import { Types } from "mongoose";
+import type { MutationResolvers } from "../../types/generatedGraphQLTypes";
+import { errors, requestContext } from "../../libraries";
+import { AgendaCategoryModel, User, Organization } from "../../models";
+import {
+  AGENDA_CATEGORY_NOT_FOUND_ERROR,
+  USER_NOT_AUTHORIZED_ERROR,
+  USER_NOT_FOUND_ERROR,
+} from "../../constants";
+import { Types } from "mongoose";
 
-// /**
-//  * Resolver function for the GraphQL mutation 'deleteAgendaCategory'.
-//  *
-//  * This resolver deletes an agenda category if the user has the necessary permissions.
-//  *
-//  * @param {Object} _parent - The parent object, not used in this resolver.
-//  * @param {Object} args - The input arguments for the mutation.
-//  * @param {Object} context - The context object containing user information.
-//  * @returns {Promise<string>} A promise that resolves to the ID of the deleted agenda category.
-//  * @throws {NotFoundError} Throws an error if the user or agenda category is not found.
-//  * @throws {UnauthorizedError} Throws an error if the user does not have the required permissions.
-//  * @throws {InternalServerError} Throws an error for other potential issues during agenda category deletion.
-//  */
-// export const deleteAgendaCategory: MutationResolvers["deleteAgendaCategory"] =
-//   async (_parent, args, context) => {
-//     const categoryId = args.id;
-//     const agendaCategory = await AgendaCategoryModel.findById(args.id);
+/**
+ * Resolver function for the GraphQL mutation 'deleteAgendaCategory'.
+ *
+ * This resolver deletes an agenda category if the user has the necessary permissions.
+ *
+ * @param {Object} _parent - The parent object, not used in this resolver.
+ * @param {Object} args - The input arguments for the mutation.
+ * @param {Object} context - The context object containing user information.
+ * @returns {Promise<string>} A promise that resolves to the ID of the deleted agenda category.
+ * @throws {NotFoundError} Throws an error if the user or agenda category is not found.
+ * @throws {UnauthorizedError} Throws an error if the user does not have the required permissions.
+ * @throws {InternalServerError} Throws an error for other potential issues during agenda category deletion.
+ */
+export const deleteAgendaCategory: MutationResolvers["deleteAgendaCategory"] =
+  async (_parent, args, context) => {
+    const categoryId = args.id;
+    const agendaCategory = await AgendaCategoryModel.findById(args.id);
 
-//     const userId = context.userId;
+    const userId = context.userId;
 
-//     // Fetch the user to get the organization ID
-//     const currentUser = await User.findById(userId);
+    // Fetch the user to get the organization ID
+    const currentUser = await User.findById(userId);
 
-//     // If the user is not found, throw a NotFoundError
-//     if (!currentUser) {
-//       throw new errors.NotFoundError(
-//         USER_NOT_FOUND_ERROR.MESSAGE,
-//         USER_NOT_FOUND_ERROR.CODE,
-//         USER_NOT_FOUND_ERROR.PARAM
-//       );
-//     }
-//     if (!agendaCategory) {
-//       throw new errors.NotFoundError(
-//         AGENDA_CATEGORY_NOT_FOUND_ERROR.MESSAGE,
-//         AGENDA_CATEGORY_NOT_FOUND_ERROR.CODE,
-//         AGENDA_CATEGORY_NOT_FOUND_ERROR.PARAM
-//       );
-//     }
+    // If the user is not found, throw a NotFoundError
+    if (!currentUser) {
+      throw new errors.NotFoundError(
+        USER_NOT_FOUND_ERROR.MESSAGE,
+        USER_NOT_FOUND_ERROR.CODE,
+        USER_NOT_FOUND_ERROR.PARAM
+      );
+    }
+    if (!agendaCategory) {
+      throw new errors.NotFoundError(
+        AGENDA_CATEGORY_NOT_FOUND_ERROR.MESSAGE,
+        AGENDA_CATEGORY_NOT_FOUND_ERROR.CODE,
+        AGENDA_CATEGORY_NOT_FOUND_ERROR.PARAM
+      );
+    }
 
-//     const currentOrg = await AgendaCategoryModel.findById(agendaCategory._id)
-//       .populate("organization")
-//       .select("organization")
-//       .lean();
+    const currentOrg = await AgendaCategoryModel.findById(agendaCategory._id)
+      .populate("organization")
+      .select("organization")
+      .lean();
 
-//     const orgId = currentOrg?._id;
+    const orgId = currentOrg?._id;
 
-//     const currentUserIsOrgAdmin = currentUser.adminFor.some(
-//       (organizationId) =>
-//         organizationId === currentOrg?._id ||
-//         Types.ObjectId(organizationId).equals(organizationId)
-//     );
-//     // If the user is a normal user, throw an error
-//     if (
-//       currentUserIsOrgAdmin === false &&
-//       currentUser.userType !== "SUPERADMIN"
-//     ) {
-//       throw new errors.UnauthorizedError(
-//         USER_NOT_AUTHORIZED_ERROR.MESSAGE,
-//         USER_NOT_AUTHORIZED_ERROR.CODE,
-//         USER_NOT_AUTHORIZED_ERROR.PARAM
-//       );
-//     }
+    const currentUserIsOrgAdmin = currentUser.adminFor.some(
+      (organizationId) =>
+        organizationId === currentOrg?._id ||
+        Types.ObjectId(organizationId).equals(organizationId)
+    );
+    // If the user is a normal user, throw an error
+    if (
+      currentUserIsOrgAdmin === false &&
+      currentUser.userType !== "SUPERADMIN"
+    ) {
+      throw new errors.UnauthorizedError(
+        USER_NOT_AUTHORIZED_ERROR.MESSAGE,
+        USER_NOT_AUTHORIZED_ERROR.CODE,
+        USER_NOT_AUTHORIZED_ERROR.PARAM
+      );
+    }
 
-//     await AgendaCategoryModel.findByIdAndDelete(args.id);
-//     return categoryId;
-//   };
+    await AgendaCategoryModel.findByIdAndDelete(args.id);
+    return categoryId;
+  };

--- a/src/resolvers/Mutation/index.ts
+++ b/src/resolvers/Mutation/index.ts
@@ -91,7 +91,9 @@ import { updateUserPassword } from "./updateUserPassword";
 import { updateUserTag } from "./updateUserTag";
 import { updateUserType } from "./updateUserType";
 import { deleteAdvertisementById } from "./deleteAdvertisementById";
-// import { createAgendaCategory } from "./createAgendaCategory";
+import { createAgendaCategory } from "./createAgendaCategory";
+import { updateAgendaCategory } from "./updateAgendaCategory";
+import { deleteAgendaCategory } from "./deleteAgendaCategory";
 
 export const Mutation: MutationResolvers = {
   acceptAdmin,
@@ -116,6 +118,7 @@ export const Mutation: MutationResolvers = {
   createAdmin,
   createComment,
   createAdvertisement,
+  createAgendaCategory,
   createDirectChat,
   createDonation,
   createEvent,
@@ -130,6 +133,7 @@ export const Mutation: MutationResolvers = {
   createUserTag,
   deleteDonationById,
   deleteAdvertisementById,
+  deleteAgendaCategory,
   forgotPassword,
   joinPublicOrganization,
   leaveOrganization,
@@ -179,6 +183,7 @@ export const Mutation: MutationResolvers = {
   updateEventProject,
   updateLanguage,
   updateOrganization,
+  updateAgendaCategory,
   updatePluginStatus,
   updateTask,
   updateUserProfile,

--- a/src/resolvers/Mutation/index.ts
+++ b/src/resolvers/Mutation/index.ts
@@ -91,6 +91,7 @@ import { updateUserPassword } from "./updateUserPassword";
 import { updateUserTag } from "./updateUserTag";
 import { updateUserType } from "./updateUserType";
 import { deleteAdvertisementById } from "./deleteAdvertisementById";
+// import { createAgendaCategory } from "./createAgendaCategory";
 
 export const Mutation: MutationResolvers = {
   acceptAdmin,

--- a/src/resolvers/Mutation/updateAgendaCategory.ts
+++ b/src/resolvers/Mutation/updateAgendaCategory.ts
@@ -1,95 +1,95 @@
-// import type { MutationResolvers } from "../../types/generatedGraphQLTypes";
-// import { errors, requestContext } from "../../libraries";
-// import { AgendaCategoryModel, User } from "../../models";
-// import {
-//   AGENDA_CATEGORY_NOT_FOUND_ERROR,
-//   USER_NOT_FOUND_ERROR,
-//   USER_NOT_AUTHORIZED_ERROR,
-// } from "../../constants";
-// import { adminCheck } from "../../utilities";
-// import { Types } from "mongoose";
+import type { MutationResolvers } from "../../types/generatedGraphQLTypes";
+import { errors, requestContext } from "../../libraries";
+import { AgendaCategoryModel, User } from "../../models";
+import {
+  AGENDA_CATEGORY_NOT_FOUND_ERROR,
+  USER_NOT_FOUND_ERROR,
+  USER_NOT_AUTHORIZED_ERROR,
+} from "../../constants";
+import { adminCheck } from "../../utilities";
+import { Types } from "mongoose";
 
-// /**
-//  * Resolver function for the GraphQL mutation 'updateAgendaCategory'.
-//  *
-//  * This resolver updates an existing agenda category based on the provided ID.
-//  * It checks if the user has the necessary permissions to update the agenda category.
-//  *
-//  * @param {Object} _parent - The parent object, not used in this resolver.
-//  * @param {Object} args - The input arguments for the mutation.
-//  * @param {Object} context - The context object containing user information.
-//  * @returns {Promise<Object>} A promise that resolves to the updated agenda category.
-//  * @throws {NotFoundError} Throws an error if the agenda category or user is not found.
-//  * @throws {UnauthorizedError} Throws an error if the user does not have the required permissions.
-//  * @throws {InternalServerError} Throws an error for other potential issues during agenda category update.
-//  */
+/**
+ * Resolver function for the GraphQL mutation 'updateAgendaCategory'.
+ *
+ * This resolver updates an existing agenda category based on the provided ID.
+ * It checks if the user has the necessary permissions to update the agenda category.
+ *
+ * @param {Object} _parent - The parent object, not used in this resolver.
+ * @param {Object} args - The input arguments for the mutation.
+ * @param {Object} context - The context object containing user information.
+ * @returns {Promise<Object>} A promise that resolves to the updated agenda category.
+ * @throws {NotFoundError} Throws an error if the agenda category or user is not found.
+ * @throws {UnauthorizedError} Throws an error if the user does not have the required permissions.
+ * @throws {InternalServerError} Throws an error for other potential issues during agenda category update.
+ */
 
-// export const updateAgendaCategory: MutationResolvers["updateAgendaCategory"] =
-//   async (_parent, args, context) => {
-//     // Check if the AgendaCategory exists
-//     // Fetch the user to get the organization ID
+export const updateAgendaCategory: MutationResolvers["updateAgendaCategory"] =
+  async (_parent, args, context) => {
+    // Check if the AgendaCategory exists
+    // Fetch the user to get the organization ID
 
-//     const userId = context.userId;
-//     const currentUser = await User.findById(userId);
+    const userId = context.userId;
+    const currentUser = await User.findById(userId);
 
-//     // If the user is not found, throw a NotFoundError
-//     if (!currentUser) {
-//       throw new errors.NotFoundError(
-//         requestContext.translate(USER_NOT_FOUND_ERROR.MESSAGE),
-//         USER_NOT_FOUND_ERROR.CODE,
-//         USER_NOT_FOUND_ERROR.PARAM
-//       );
-//     }
-//     const existingAgendaCategory = await AgendaCategoryModel.findById(
-//       args.id
-//     ).lean();
+    // If the user is not found, throw a NotFoundError
+    if (!currentUser) {
+      throw new errors.NotFoundError(
+        requestContext.translate(USER_NOT_FOUND_ERROR.MESSAGE),
+        USER_NOT_FOUND_ERROR.CODE,
+        USER_NOT_FOUND_ERROR.PARAM
+      );
+    }
+    const existingAgendaCategory = await AgendaCategoryModel.findById(
+      args.id
+    ).lean();
 
-//     // If the AgendaCategory is not found, throw a NotFoundError
-//     if (!existingAgendaCategory) {
-//       throw new errors.NotFoundError(
-//         requestContext.translate(AGENDA_CATEGORY_NOT_FOUND_ERROR.MESSAGE),
-//         AGENDA_CATEGORY_NOT_FOUND_ERROR.CODE,
-//         AGENDA_CATEGORY_NOT_FOUND_ERROR.PARAM
-//       );
-//     }
-//     const currentOrg = await AgendaCategoryModel.findById(
-//       existingAgendaCategory._id
-//     )
-//       .populate("organization")
-//       .select("organization")
-//       .lean();
+    // If the AgendaCategory is not found, throw a NotFoundError
+    if (!existingAgendaCategory) {
+      throw new errors.NotFoundError(
+        requestContext.translate(AGENDA_CATEGORY_NOT_FOUND_ERROR.MESSAGE),
+        AGENDA_CATEGORY_NOT_FOUND_ERROR.CODE,
+        AGENDA_CATEGORY_NOT_FOUND_ERROR.PARAM
+      );
+    }
+    const currentOrg = await AgendaCategoryModel.findById(
+      existingAgendaCategory._id
+    )
+      .populate("organization")
+      .select("organization")
+      .lean();
 
-//     const orgId = currentOrg?._id;
+    const orgId = currentOrg?._id;
 
-//     const currentUserIsOrgAdmin = currentUser.adminFor.some(
-//       (organizationId) =>
-//         organizationId === currentOrg?._id ||
-//         Types.ObjectId(organizationId).equals(organizationId)
-//     );
-//     // If the user is a normal user, throw an error
-//     if (
-//       currentUserIsOrgAdmin === false &&
-//       currentUser.userType !== "SUPERADMIN"
-//     ) {
-//       throw new errors.UnauthorizedError(
-//         USER_NOT_AUTHORIZED_ERROR.MESSAGE,
-//         USER_NOT_AUTHORIZED_ERROR.CODE,
-//         USER_NOT_AUTHORIZED_ERROR.PARAM
-//       );
-//     }
+    const currentUserIsOrgAdmin = currentUser.adminFor.some(
+      (organizationId) =>
+        organizationId === currentOrg?._id ||
+        Types.ObjectId(organizationId).equals(organizationId)
+    );
+    // If the user is a normal user, throw an error
+    if (
+      currentUserIsOrgAdmin === false &&
+      currentUser.userType !== "SUPERADMIN"
+    ) {
+      throw new errors.UnauthorizedError(
+        USER_NOT_AUTHORIZED_ERROR.MESSAGE,
+        USER_NOT_AUTHORIZED_ERROR.CODE,
+        USER_NOT_AUTHORIZED_ERROR.PARAM
+      );
+    }
 
-//     // Update the AgendaCategory
-//     const updatedAgendaCategory = await AgendaCategoryModel.findByIdAndUpdate(
-//       args.id,
-//       {
-//         $set: {
-//           updatedBy: context.userId,
-//           ...(args.input as any),
-//         },
-//       },
-//       {
-//         new: true,
-//       }
-//     ).lean();
-//     return updatedAgendaCategory!;
-//   };
+    // Update the AgendaCategory
+    const updatedAgendaCategory = await AgendaCategoryModel.findByIdAndUpdate(
+      args.id,
+      {
+        $set: {
+          updatedBy: context.userId,
+          ...(args.input as any),
+        },
+      },
+      {
+        new: true,
+      }
+    ).lean();
+    return updatedAgendaCategory!;
+  };

--- a/src/resolvers/Mutation/updateAgendaCategory.ts
+++ b/src/resolvers/Mutation/updateAgendaCategory.ts
@@ -1,0 +1,95 @@
+// import type { MutationResolvers } from "../../types/generatedGraphQLTypes";
+// import { errors, requestContext } from "../../libraries";
+// import { AgendaCategoryModel, User } from "../../models";
+// import {
+//   AGENDA_CATEGORY_NOT_FOUND_ERROR,
+//   USER_NOT_FOUND_ERROR,
+//   USER_NOT_AUTHORIZED_ERROR,
+// } from "../../constants";
+// import { adminCheck } from "../../utilities";
+// import { Types } from "mongoose";
+
+// /**
+//  * Resolver function for the GraphQL mutation 'updateAgendaCategory'.
+//  *
+//  * This resolver updates an existing agenda category based on the provided ID.
+//  * It checks if the user has the necessary permissions to update the agenda category.
+//  *
+//  * @param {Object} _parent - The parent object, not used in this resolver.
+//  * @param {Object} args - The input arguments for the mutation.
+//  * @param {Object} context - The context object containing user information.
+//  * @returns {Promise<Object>} A promise that resolves to the updated agenda category.
+//  * @throws {NotFoundError} Throws an error if the agenda category or user is not found.
+//  * @throws {UnauthorizedError} Throws an error if the user does not have the required permissions.
+//  * @throws {InternalServerError} Throws an error for other potential issues during agenda category update.
+//  */
+
+// export const updateAgendaCategory: MutationResolvers["updateAgendaCategory"] =
+//   async (_parent, args, context) => {
+//     // Check if the AgendaCategory exists
+//     // Fetch the user to get the organization ID
+
+//     const userId = context.userId;
+//     const currentUser = await User.findById(userId);
+
+//     // If the user is not found, throw a NotFoundError
+//     if (!currentUser) {
+//       throw new errors.NotFoundError(
+//         requestContext.translate(USER_NOT_FOUND_ERROR.MESSAGE),
+//         USER_NOT_FOUND_ERROR.CODE,
+//         USER_NOT_FOUND_ERROR.PARAM
+//       );
+//     }
+//     const existingAgendaCategory = await AgendaCategoryModel.findById(
+//       args.id
+//     ).lean();
+
+//     // If the AgendaCategory is not found, throw a NotFoundError
+//     if (!existingAgendaCategory) {
+//       throw new errors.NotFoundError(
+//         requestContext.translate(AGENDA_CATEGORY_NOT_FOUND_ERROR.MESSAGE),
+//         AGENDA_CATEGORY_NOT_FOUND_ERROR.CODE,
+//         AGENDA_CATEGORY_NOT_FOUND_ERROR.PARAM
+//       );
+//     }
+//     const currentOrg = await AgendaCategoryModel.findById(
+//       existingAgendaCategory._id
+//     )
+//       .populate("organization")
+//       .select("organization")
+//       .lean();
+
+//     const orgId = currentOrg?._id;
+
+//     const currentUserIsOrgAdmin = currentUser.adminFor.some(
+//       (organizationId) =>
+//         organizationId === currentOrg?._id ||
+//         Types.ObjectId(organizationId).equals(organizationId)
+//     );
+//     // If the user is a normal user, throw an error
+//     if (
+//       currentUserIsOrgAdmin === false &&
+//       currentUser.userType !== "SUPERADMIN"
+//     ) {
+//       throw new errors.UnauthorizedError(
+//         USER_NOT_AUTHORIZED_ERROR.MESSAGE,
+//         USER_NOT_AUTHORIZED_ERROR.CODE,
+//         USER_NOT_AUTHORIZED_ERROR.PARAM
+//       );
+//     }
+
+//     // Update the AgendaCategory
+//     const updatedAgendaCategory = await AgendaCategoryModel.findByIdAndUpdate(
+//       args.id,
+//       {
+//         $set: {
+//           updatedBy: context.userId,
+//           ...(args.input as any),
+//         },
+//       },
+//       {
+//         new: true,
+//       }
+//     ).lean();
+//     return updatedAgendaCategory!;
+//   };

--- a/src/resolvers/Query/getAgendaCategoryById.ts
+++ b/src/resolvers/Query/getAgendaCategoryById.ts
@@ -1,0 +1,37 @@
+import type { QueryResolvers } from "../../types/generatedGraphQLTypes";
+import { AgendaCategoryModel } from "../../models";
+import { errors, requestContext } from "../../libraries";
+import { AGENDA_CATEGORY_NOT_FOUND_ERROR } from "../../constants";
+
+/**
+ * Resolver function for the GraphQL query 'agendaCategory'.
+ *
+ * This resolver fetches an agenda category by its ID.
+ *
+ * @param {Object} _parent - The parent object, not used in this resolver.
+ * @param {Object} args - The input arguments for the query.
+ * @param {Object} _context - The context object (not used in this resolver).
+ * @returns {Promise<Object>} A promise that resolves to the fetched agenda category.
+ * @throws {NotFoundError} Throws an error if the agenda category is not found.
+ * @throws {InternalServerError} Throws an error for other potential issues during agenda category fetching.
+ */
+export const agendaCategory: QueryResolvers["agendaCategory"] = async (
+  _parent,
+  args,
+  _context
+) => {
+  // Find the AgendaCategory by ID
+  const foundAgendaCategory = await AgendaCategoryModel.findById(
+    args.id
+  ).lean();
+
+  // If the AgendaCategory is not found, throw a NotFoundError
+  if (!foundAgendaCategory) {
+    throw new errors.NotFoundError(
+      AGENDA_CATEGORY_NOT_FOUND_ERROR.MESSAGE,
+      AGENDA_CATEGORY_NOT_FOUND_ERROR.CODE,
+      AGENDA_CATEGORY_NOT_FOUND_ERROR.PARAM
+    );
+  }
+  return foundAgendaCategory;
+};

--- a/src/resolvers/Query/getAllAgendaCategories.ts
+++ b/src/resolvers/Query/getAllAgendaCategories.ts
@@ -1,0 +1,22 @@
+import type {
+  QueryResolvers,
+  AgendaCategory,
+} from "../../types/generatedGraphQLTypes";
+import { AgendaCategoryModel } from "../../models";
+import { errors, requestContext } from "../../libraries";
+import { AGENDA_CATEGORY_NOT_FOUND_ERROR } from "../../constants";
+
+/**
+ * Resolver function for the GraphQL query 'agendaCategories'.
+ *
+ * This resolver fetches all agenda categories from the database.
+ *
+ * @returns {Promise<Array<AgendaCategory>>} A promise that resolves to an array of agenda categories.
+ * @throws {InternalServerError} Throws an error for potential issues during agenda categories fetching.
+ */
+export const agendaCategories: QueryResolvers["agendaCategories"] =
+  async () => {
+    const allAgendaCategories = await AgendaCategoryModel.find().lean().exec();
+
+    return allAgendaCategories;
+  };

--- a/src/resolvers/Query/index.ts
+++ b/src/resolvers/Query/index.ts
@@ -27,8 +27,11 @@ import { userLanguage } from "./userLanguage";
 import { users } from "./users";
 import { getAdvertisements } from "./getAdvertisements";
 import { usersConnection } from "./usersConnection";
-
+import { agendaCategory } from "./getAgendaCategoryById";
+import { agendaCategories } from "./getAllAgendaCategories";
 export const Query: QueryResolvers = {
+  agendaCategories,
+  agendaCategory,
   checkAuth,
   customFieldsByOrganization,
   customDataByOrganization,

--- a/src/typeDefs/inputs.ts
+++ b/src/typeDefs/inputs.ts
@@ -408,4 +408,16 @@ export const inputs = gql`
     imageUrl: String
     videoUrl: String
   }
+
+  input CreateAgendaCategoryInput {
+    name: String!
+    description: String
+    organization: ID!
+  }
+
+  input UpdateAgendaCategoryInput {
+    name: String
+    description: String
+    organizationId: ID
+  }
 `;

--- a/src/typeDefs/mutations.ts
+++ b/src/typeDefs/mutations.ts
@@ -97,6 +97,8 @@ export const mutations = gql`
       endDate: Date!
     ): Advertisement!
 
+    createAgendaCategory(input: CreateAgendaCategoryInput!): AgendaCategory!
+
     createPost(data: PostInput!, file: String): Post @auth
 
     createUserTag(input: CreateUserTagInput!): UserTag @auth
@@ -106,6 +108,8 @@ export const mutations = gql`
     createTask(data: TaskInput!, eventProjectId: ID!): Task! @auth
 
     deleteAdvertisementById(id: ID!): DeletePayload!
+
+    deleteAgendaCategory(id: ID!): ID!
 
     deleteDonationById(id: ID!): DeletePayload!
 
@@ -224,6 +228,11 @@ export const mutations = gql`
       data: UpdateOrganizationInput
       file: String
     ): Organization! @auth
+
+    updateAgendaCategory(
+      id: ID!
+      input: UpdateAgendaCategoryInput!
+    ): AgendaCategory!
 
     updatePluginStatus(id: ID!, orgId: ID!): Plugin!
 

--- a/src/typeDefs/queries.ts
+++ b/src/typeDefs/queries.ts
@@ -107,5 +107,9 @@ export const queries = gql`
       skip: Int
       orderBy: UserOrderByInput
     ): [User]! @auth
+
+    agendaCategories: [AgendaCategory]
+
+    agendaCategory(id: ID!): AgendaCategory
   }
 `;

--- a/src/typeDefs/types.ts
+++ b/src/typeDefs/types.ts
@@ -73,6 +73,7 @@ export const types = gql`
     messages: [DirectChatMessage]
     creator: User!
     organization: Organization!
+    agendacategories: [AgendaCategory]
   }
 
   type DirectChatMessage {

--- a/src/typeDefs/types.ts
+++ b/src/typeDefs/types.ts
@@ -10,6 +10,17 @@ export const types = gql`
     count: Int!
   }
 
+  type AgendaCategory {
+    _id: ID!
+    name: String!
+    description: String
+    organization: Organization
+    createdBy: User!
+    updatedBy: User
+    createdAt: Date!
+    updatedAt: Date
+  }
+
   type AuthData {
     user: User!
     accessToken: String!

--- a/src/typeDefs/types.ts
+++ b/src/typeDefs/types.ts
@@ -73,7 +73,7 @@ export const types = gql`
     messages: [DirectChatMessage]
     creator: User!
     organization: Organization!
-    agendacategories: [AgendaCategory]
+    agendaCategories: [AgendaCategory]
   }
 
   type DirectChatMessage {

--- a/src/types/generatedGraphQLTypes.ts
+++ b/src/types/generatedGraphQLTypes.ts
@@ -191,7 +191,7 @@ export type DeletePayload = {
 export type DirectChat = {
   __typename?: 'DirectChat';
   _id: Scalars['ID'];
-  agendacategories?: Maybe<Array<Maybe<AgendaCategory>>>;
+  agendaCategories?: Maybe<Array<Maybe<AgendaCategory>>>;
   creator: User;
   messages?: Maybe<Array<Maybe<DirectChatMessage>>>;
   organization: Organization;
@@ -2424,7 +2424,7 @@ export type DeletePayloadResolvers<ContextType = any, ParentType extends Resolve
 
 export type DirectChatResolvers<ContextType = any, ParentType extends ResolversParentTypes['DirectChat'] = ResolversParentTypes['DirectChat']> = {
   _id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  agendacategories?: Resolver<Maybe<Array<Maybe<ResolversTypes['AgendaCategory']>>>, ParentType, ContextType>;
+  agendaCategories?: Resolver<Maybe<Array<Maybe<ResolversTypes['AgendaCategory']>>>, ParentType, ContextType>;
   creator?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   messages?: Resolver<Maybe<Array<Maybe<ResolversTypes['DirectChatMessage']>>>, ParentType, ContextType>;
   organization?: Resolver<ResolversTypes['Organization'], ParentType, ContextType>;

--- a/src/types/generatedGraphQLTypes.ts
+++ b/src/types/generatedGraphQLTypes.ts
@@ -191,6 +191,7 @@ export type DeletePayload = {
 export type DirectChat = {
   __typename?: 'DirectChat';
   _id: Scalars['ID'];
+  agendacategories?: Maybe<Array<Maybe<AgendaCategory>>>;
   creator: User;
   messages?: Maybe<Array<Maybe<DirectChatMessage>>>;
   organization: Organization;
@@ -2423,6 +2424,7 @@ export type DeletePayloadResolvers<ContextType = any, ParentType extends Resolve
 
 export type DirectChatResolvers<ContextType = any, ParentType extends ResolversParentTypes['DirectChat'] = ResolversParentTypes['DirectChat']> = {
   _id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  agendacategories?: Resolver<Maybe<Array<Maybe<ResolversTypes['AgendaCategory']>>>, ParentType, ContextType>;
   creator?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   messages?: Resolver<Maybe<Array<Maybe<ResolversTypes['DirectChatMessage']>>>, ParentType, ContextType>;
   organization?: Resolver<ResolversTypes['Organization'], ParentType, ContextType>;

--- a/src/types/generatedGraphQLTypes.ts
+++ b/src/types/generatedGraphQLTypes.ts
@@ -15,6 +15,7 @@ import type { InterfaceGroupChatMessage as InterfaceGroupChatMessageModel } from
 import type { InterfaceLanguage as InterfaceLanguageModel } from '../models/Language';
 import type { InterfaceMembershipRequest as InterfaceMembershipRequestModel } from '../models/MembershipRequest';
 import type { InterfaceMessage as InterfaceMessageModel } from '../models/Message';
+import type { InterfaceAgendaCategory as InterfaceAgendaCategoryModel } from '../models/AgendaCategory';
 import type { InterfaceOrganization as InterfaceOrganizationModel } from '../models/Organization';
 import type { InterfacePlugin as InterfacePluginModel } from '../models/Plugin';
 import type { InterfacePluginField as InterfacePluginFieldModel } from '../models/PluginField';
@@ -2033,7 +2034,7 @@ export type ResolversTypes = {
   Address: ResolverTypeWrapper<Address>;
   AddressInput: AddressInput;
   Advertisement: ResolverTypeWrapper<Advertisement>;
-  AgendaCategory: ResolverTypeWrapper<Omit<AgendaCategory, 'createdBy' | 'organization' | 'updatedBy'> & { createdBy: ResolversTypes['User'], organization?: Maybe<ResolversTypes['Organization']>, updatedBy?: Maybe<ResolversTypes['User']> }>;
+  AgendaCategory: ResolverTypeWrapper<InterfaceAgendaCategoryModel>;
   AggregatePost: ResolverTypeWrapper<AggregatePost>;
   AggregateUser: ResolverTypeWrapper<AggregateUser>;
   Any: ResolverTypeWrapper<Scalars['Any']>;
@@ -2174,7 +2175,7 @@ export type ResolversParentTypes = {
   Address: Address;
   AddressInput: AddressInput;
   Advertisement: Advertisement;
-  AgendaCategory: Omit<AgendaCategory, 'createdBy' | 'organization' | 'updatedBy'> & { createdBy: ResolversParentTypes['User'], organization?: Maybe<ResolversParentTypes['Organization']>, updatedBy?: Maybe<ResolversParentTypes['User']> };
+  AgendaCategory: InterfaceAgendaCategoryModel;
   AggregatePost: AggregatePost;
   AggregateUser: AggregateUser;
   Any: Scalars['Any'];

--- a/src/types/generatedGraphQLTypes.ts
+++ b/src/types/generatedGraphQLTypes.ts
@@ -85,6 +85,18 @@ export type Advertisement = {
   type: Scalars['String'];
 };
 
+export type AgendaCategory = {
+  __typename?: 'AgendaCategory';
+  _id: Scalars['ID'];
+  createdAt: Scalars['Date'];
+  createdBy: User;
+  description?: Maybe<Scalars['String']>;
+  name: Scalars['String'];
+  organization?: Maybe<Organization>;
+  updatedAt?: Maybe<Scalars['Date']>;
+  updatedBy?: Maybe<User>;
+};
+
 export type AggregatePost = {
   __typename?: 'AggregatePost';
   count: Scalars['Int'];
@@ -150,6 +162,12 @@ export type ConnectionPageInfo = {
   hasNextPage: Scalars['Boolean'];
   hasPreviousPage: Scalars['Boolean'];
   startCursor?: Maybe<Scalars['String']>;
+};
+
+export type CreateAgendaCategoryInput = {
+  description?: InputMaybe<Scalars['String']>;
+  name: Scalars['String'];
+  organization: Scalars['ID'];
 };
 
 export type CreateUserTagInput = {
@@ -547,6 +565,7 @@ export type Mutation = {
   checkIn: CheckIn;
   createAdmin: User;
   createAdvertisement: Advertisement;
+  createAgendaCategory: AgendaCategory;
   createComment?: Maybe<Comment>;
   createDirectChat: DirectChat;
   createDonation: Donation;
@@ -562,6 +581,7 @@ export type Mutation = {
   createTask: Task;
   createUserTag?: Maybe<UserTag>;
   deleteAdvertisementById: DeletePayload;
+  deleteAgendaCategory: Scalars['ID'];
   deleteDonationById: DeletePayload;
   forgotPassword: Scalars['Boolean'];
   joinPublicOrganization: User;
@@ -608,6 +628,7 @@ export type Mutation = {
   unlikeComment?: Maybe<Comment>;
   unlikePost?: Maybe<Post>;
   unregisterForEventByUser: Event;
+  updateAgendaCategory: AgendaCategory;
   updateEvent: Event;
   updateEventProject: EventProject;
   updateLanguage: User;
@@ -731,6 +752,11 @@ export type MutationCreateAdvertisementArgs = {
 };
 
 
+export type MutationCreateAgendaCategoryArgs = {
+  input: CreateAgendaCategoryInput;
+};
+
+
 export type MutationCreateCommentArgs = {
   data: CommentInput;
   postId: Scalars['ID'];
@@ -809,6 +835,11 @@ export type MutationCreateUserTagArgs = {
 
 
 export type MutationDeleteAdvertisementByIdArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type MutationDeleteAgendaCategoryArgs = {
   id: Scalars['ID'];
 };
 
@@ -1028,6 +1059,12 @@ export type MutationUnlikePostArgs = {
 
 export type MutationUnregisterForEventByUserArgs = {
   id: Scalars['ID'];
+};
+
+
+export type MutationUpdateAgendaCategoryArgs = {
+  id: Scalars['ID'];
+  input: UpdateAgendaCategoryInput;
 };
 
 
@@ -1348,6 +1385,8 @@ export type PostWhereInput = {
 export type Query = {
   __typename?: 'Query';
   adminPlugin?: Maybe<Array<Maybe<Plugin>>>;
+  agendaCategories?: Maybe<Array<Maybe<AgendaCategory>>>;
+  agendaCategory?: Maybe<AgendaCategory>;
   checkAuth: User;
   customDataByOrganization: Array<UserCustomData>;
   customFieldsByOrganization?: Maybe<Array<Maybe<OrganizationCustomField>>>;
@@ -1385,6 +1424,11 @@ export type Query = {
 
 export type QueryAdminPluginArgs = {
   orgId: Scalars['ID'];
+};
+
+
+export type QueryAgendaCategoryArgs = {
+  id: Scalars['ID'];
 };
 
 
@@ -1632,6 +1676,12 @@ export type UnauthenticatedError = Error & {
 export type UnauthorizedError = Error & {
   __typename?: 'UnauthorizedError';
   message: Scalars['String'];
+};
+
+export type UpdateAgendaCategoryInput = {
+  description?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']>;
+  organizationId?: InputMaybe<Scalars['ID']>;
 };
 
 export type UpdateEventInput = {
@@ -1983,6 +2033,7 @@ export type ResolversTypes = {
   Address: ResolverTypeWrapper<Address>;
   AddressInput: AddressInput;
   Advertisement: ResolverTypeWrapper<Advertisement>;
+  AgendaCategory: ResolverTypeWrapper<Omit<AgendaCategory, 'createdBy' | 'organization' | 'updatedBy'> & { createdBy: ResolversTypes['User'], organization?: Maybe<ResolversTypes['Organization']>, updatedBy?: Maybe<ResolversTypes['User']> }>;
   AggregatePost: ResolverTypeWrapper<AggregatePost>;
   AggregateUser: ResolverTypeWrapper<AggregateUser>;
   Any: ResolverTypeWrapper<Scalars['Any']>;
@@ -1996,6 +2047,7 @@ export type ResolversTypes = {
   ConnectionError: ResolversTypes['InvalidCursor'] | ResolversTypes['MaximumValueError'];
   ConnectionPageInfo: ResolverTypeWrapper<ConnectionPageInfo>;
   CountryCode: ResolverTypeWrapper<Scalars['CountryCode']>;
+  CreateAgendaCategoryInput: CreateAgendaCategoryInput;
   CreateUserTagInput: CreateUserTagInput;
   CursorPaginationInput: CursorPaginationInput;
   Date: ResolverTypeWrapper<Scalars['Date']>;
@@ -2084,6 +2136,7 @@ export type ResolversTypes = {
   URL: ResolverTypeWrapper<Scalars['URL']>;
   UnauthenticatedError: ResolverTypeWrapper<UnauthenticatedError>;
   UnauthorizedError: ResolverTypeWrapper<UnauthorizedError>;
+  UpdateAgendaCategoryInput: UpdateAgendaCategoryInput;
   UpdateEventInput: UpdateEventInput;
   UpdateEventProjectInput: UpdateEventProjectInput;
   UpdateOrganizationInput: UpdateOrganizationInput;
@@ -2121,6 +2174,7 @@ export type ResolversParentTypes = {
   Address: Address;
   AddressInput: AddressInput;
   Advertisement: Advertisement;
+  AgendaCategory: Omit<AgendaCategory, 'createdBy' | 'organization' | 'updatedBy'> & { createdBy: ResolversParentTypes['User'], organization?: Maybe<ResolversParentTypes['Organization']>, updatedBy?: Maybe<ResolversParentTypes['User']> };
   AggregatePost: AggregatePost;
   AggregateUser: AggregateUser;
   Any: Scalars['Any'];
@@ -2134,6 +2188,7 @@ export type ResolversParentTypes = {
   ConnectionError: ResolversParentTypes['InvalidCursor'] | ResolversParentTypes['MaximumValueError'];
   ConnectionPageInfo: ConnectionPageInfo;
   CountryCode: Scalars['CountryCode'];
+  CreateAgendaCategoryInput: CreateAgendaCategoryInput;
   CreateUserTagInput: CreateUserTagInput;
   CursorPaginationInput: CursorPaginationInput;
   Date: Scalars['Date'];
@@ -2210,6 +2265,7 @@ export type ResolversParentTypes = {
   URL: Scalars['URL'];
   UnauthenticatedError: UnauthenticatedError;
   UnauthorizedError: UnauthorizedError;
+  UpdateAgendaCategoryInput: UpdateAgendaCategoryInput;
   UpdateEventInput: UpdateEventInput;
   UpdateEventProjectInput: UpdateEventProjectInput;
   UpdateOrganizationInput: UpdateOrganizationInput;
@@ -2270,6 +2326,18 @@ export type AdvertisementResolvers<ContextType = any, ParentType extends Resolve
   orgId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   startDate?: Resolver<ResolversTypes['Date'], ParentType, ContextType>;
   type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type AgendaCategoryResolvers<ContextType = any, ParentType extends ResolversParentTypes['AgendaCategory'] = ResolversParentTypes['AgendaCategory']> = {
+  _id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes['Date'], ParentType, ContextType>;
+  createdBy?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  organization?: Resolver<Maybe<ResolversTypes['Organization']>, ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<ResolversTypes['Date']>, ParentType, ContextType>;
+  updatedBy?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2584,6 +2652,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   checkIn?: Resolver<ResolversTypes['CheckIn'], ParentType, ContextType, RequireFields<MutationCheckInArgs, 'data'>>;
   createAdmin?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationCreateAdminArgs, 'data'>>;
   createAdvertisement?: Resolver<ResolversTypes['Advertisement'], ParentType, ContextType, RequireFields<MutationCreateAdvertisementArgs, 'endDate' | 'link' | 'name' | 'orgId' | 'startDate' | 'type'>>;
+  createAgendaCategory?: Resolver<ResolversTypes['AgendaCategory'], ParentType, ContextType, RequireFields<MutationCreateAgendaCategoryArgs, 'input'>>;
   createComment?: Resolver<Maybe<ResolversTypes['Comment']>, ParentType, ContextType, RequireFields<MutationCreateCommentArgs, 'data' | 'postId'>>;
   createDirectChat?: Resolver<ResolversTypes['DirectChat'], ParentType, ContextType, RequireFields<MutationCreateDirectChatArgs, 'data'>>;
   createDonation?: Resolver<ResolversTypes['Donation'], ParentType, ContextType, RequireFields<MutationCreateDonationArgs, 'amount' | 'nameOfOrg' | 'nameOfUser' | 'orgId' | 'payPalId' | 'userId'>>;
@@ -2599,6 +2668,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   createTask?: Resolver<ResolversTypes['Task'], ParentType, ContextType, RequireFields<MutationCreateTaskArgs, 'data' | 'eventProjectId'>>;
   createUserTag?: Resolver<Maybe<ResolversTypes['UserTag']>, ParentType, ContextType, RequireFields<MutationCreateUserTagArgs, 'input'>>;
   deleteAdvertisementById?: Resolver<ResolversTypes['DeletePayload'], ParentType, ContextType, RequireFields<MutationDeleteAdvertisementByIdArgs, 'id'>>;
+  deleteAgendaCategory?: Resolver<ResolversTypes['ID'], ParentType, ContextType, RequireFields<MutationDeleteAgendaCategoryArgs, 'id'>>;
   deleteDonationById?: Resolver<ResolversTypes['DeletePayload'], ParentType, ContextType, RequireFields<MutationDeleteDonationByIdArgs, 'id'>>;
   forgotPassword?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationForgotPasswordArgs, 'data'>>;
   joinPublicOrganization?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationJoinPublicOrganizationArgs, 'organizationId'>>;
@@ -2645,6 +2715,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   unlikeComment?: Resolver<Maybe<ResolversTypes['Comment']>, ParentType, ContextType, RequireFields<MutationUnlikeCommentArgs, 'id'>>;
   unlikePost?: Resolver<Maybe<ResolversTypes['Post']>, ParentType, ContextType, RequireFields<MutationUnlikePostArgs, 'id'>>;
   unregisterForEventByUser?: Resolver<ResolversTypes['Event'], ParentType, ContextType, RequireFields<MutationUnregisterForEventByUserArgs, 'id'>>;
+  updateAgendaCategory?: Resolver<ResolversTypes['AgendaCategory'], ParentType, ContextType, RequireFields<MutationUpdateAgendaCategoryArgs, 'id' | 'input'>>;
   updateEvent?: Resolver<ResolversTypes['Event'], ParentType, ContextType, RequireFields<MutationUpdateEventArgs, 'id'>>;
   updateEventProject?: Resolver<ResolversTypes['EventProject'], ParentType, ContextType, RequireFields<MutationUpdateEventProjectArgs, 'data' | 'id'>>;
   updateLanguage?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationUpdateLanguageArgs, 'languageCode'>>;
@@ -2766,6 +2837,8 @@ export type PostConnectionResolvers<ContextType = any, ParentType extends Resolv
 
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
   adminPlugin?: Resolver<Maybe<Array<Maybe<ResolversTypes['Plugin']>>>, ParentType, ContextType, RequireFields<QueryAdminPluginArgs, 'orgId'>>;
+  agendaCategories?: Resolver<Maybe<Array<Maybe<ResolversTypes['AgendaCategory']>>>, ParentType, ContextType>;
+  agendaCategory?: Resolver<Maybe<ResolversTypes['AgendaCategory']>, ParentType, ContextType, RequireFields<QueryAgendaCategoryArgs, 'id'>>;
   checkAuth?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   customDataByOrganization?: Resolver<Array<ResolversTypes['UserCustomData']>, ParentType, ContextType, RequireFields<QueryCustomDataByOrganizationArgs, 'organizationId'>>;
   customFieldsByOrganization?: Resolver<Maybe<Array<Maybe<ResolversTypes['OrganizationCustomField']>>>, ParentType, ContextType, RequireFields<QueryCustomFieldsByOrganizationArgs, 'id'>>;
@@ -2954,6 +3027,7 @@ export type UsersConnectionResultResolvers<ContextType = any, ParentType extends
 export type Resolvers<ContextType = any> = {
   Address?: AddressResolvers<ContextType>;
   Advertisement?: AdvertisementResolvers<ContextType>;
+  AgendaCategory?: AgendaCategoryResolvers<ContextType>;
   AggregatePost?: AggregatePostResolvers<ContextType>;
   AggregateUser?: AggregateUserResolvers<ContextType>;
   Any?: GraphQLScalarType;

--- a/tests/resolvers/Mutation/createAgendaCategory.spec.ts
+++ b/tests/resolvers/Mutation/createAgendaCategory.spec.ts
@@ -1,0 +1,205 @@
+import {
+  AGENDA_CATEGORY_NOT_FOUND_ERROR,
+  LENGTH_VALIDATION_ERROR,
+  ORGANIZATION_NOT_FOUND_ERROR,
+  USER_NOT_AUTHORIZED_ERROR,
+  USER_NOT_FOUND_ERROR,
+} from "../../../src/constants";
+import { expect, vi, beforeAll, afterAll, describe, it } from "vitest";
+import type { MutationCreateAgendaCategoryArgs } from "../../../src/types/generatedGraphQLTypes";
+import { createAgendaCategory } from "../../../src/resolvers/Mutation/createAgendaCategory";
+import { connect, disconnect } from "../../helpers/db";
+import { createTestUser } from "../../helpers/userAndOrg";
+import type {
+  TestUserType,
+  TestOrganizationType,
+} from "../../helpers/userAndOrg";
+import { Organization, User } from "../../../src/models";
+import type mongoose from "mongoose";
+import { Types } from "mongoose";
+import { errors } from "../../../src/libraries";
+
+let testUser: TestUserType;
+let testAdminUser: TestUserType;
+let testOrganization: TestOrganizationType;
+let MONGOOSE_INSTANCE: typeof mongoose;
+let testUserSuperAdmin: TestUserType;
+let testUser2: TestUserType;
+
+beforeAll(async () => {
+  MONGOOSE_INSTANCE = await connect();
+  testUser = await createTestUser();
+  testAdminUser = await createTestUser();
+  testUser2 = await createTestUser();
+  testUserSuperAdmin = await createTestUser();
+  testOrganization = await Organization.create({
+    name: "name",
+    description: "description",
+    isPublic: true,
+    creator: testUser?._id,
+    admins: [testAdminUser?._id],
+    members: [testUser?._id, testAdminUser?._id],
+  });
+
+  await User.updateOne(
+    {
+      _id: testUser?._id,
+    },
+    {
+      $push: {
+        adminFor: testOrganization?._id,
+      },
+    }
+  );
+
+  const { requestContext } = await import("../../../src/libraries");
+  vi.spyOn(requestContext, "translate").mockImplementation(
+    (message) => message
+  );
+});
+
+afterAll(async () => {
+  await disconnect(MONGOOSE_INSTANCE);
+});
+
+describe("resolvers -> Mutation -> createAgendaCategory", () => {
+  it(`creates an agenda category successfully`, async () => {
+    try {
+      const args: MutationCreateAgendaCategoryArgs = {
+        input: {
+          name: "Agenda Category",
+          description: "Description for the agenda category",
+          organization: testOrganization?._id,
+        },
+      };
+
+      const context = {
+        userId: testAdminUser?._id,
+      };
+
+      const { createAgendaCategory: createAgendaCategoryResolver } =
+        await import("../../../src/resolvers/Mutation/createAgendaCategory");
+
+      const createdAgendaCategory = await createAgendaCategoryResolver?.(
+        {},
+        args,
+        context
+      );
+
+      expect(createdAgendaCategory).toBeDefined();
+
+      // Verify that the agenda category is associated with the correct user and organization
+      expect(createdAgendaCategory?.createdBy).toBe(testAdminUser?._id);
+      expect(createdAgendaCategory?.organization).toBe(testOrganization?._id);
+      // Verify that the organization's list is updated correctly
+      const updatedOrganization = await Organization.findById(
+        testOrganization?._id
+      ).lean();
+      expect(updatedOrganization?.agendaCategories).toContain(
+        createdAgendaCategory?._id.toString()
+      );
+      // Verify that the properties of the returned agenda category match the expected values
+      expect(createdAgendaCategory?.name).toEqual(args.input.name);
+      expect(createdAgendaCategory?.description).toEqual(
+        args.input.description
+      );
+      expect(createdAgendaCategory?._id).toBeUndefined();
+    } catch (error) {
+      expect(error);
+    }
+  });
+
+  it(`throws an error if the user is not found`, async () => {
+    try {
+      const args: MutationCreateAgendaCategoryArgs = {
+        input: {
+          name: "Agenda Category",
+          description: "Description for the agenda category",
+          organization: testOrganization?.id,
+        },
+      };
+
+      const context = {
+        userId: Types.ObjectId().toString(), // A random ID that does not exist in the database
+      };
+
+      const { createAgendaCategory: createAgendaCategoryResolver } =
+        await import("../../../src/resolvers/Mutation/createAgendaCategory");
+
+      const createdAgendaCategory = await createAgendaCategoryResolver?.(
+        {},
+        args,
+        context
+      );
+
+      expect(createdAgendaCategory).toBeUndefined(); // The resolver should not return anything
+    } catch (error: any) {
+      // The resolver should throw a NotFoundError with the appropriate message, code, and parameter
+
+      expect(error.message).toEqual(USER_NOT_FOUND_ERROR.MESSAGE);
+    }
+  });
+
+  it(`throws an error if the organization is not found`, async () => {
+    try {
+      const args: MutationCreateAgendaCategoryArgs = {
+        input: {
+          name: "Agenda Category",
+          description: "Description for the agenda category",
+          organization: Types.ObjectId().toString(), // A random ID that does not exist in the database
+        },
+      };
+
+      const context = {
+        userId: testUser?.id,
+      };
+
+      const { createAgendaCategory: createAgendaCategoryResolver } =
+        await import("../../../src/resolvers/Mutation/createAgendaCategory");
+
+      const createdAgendaCategory = await createAgendaCategoryResolver?.(
+        {},
+        args,
+        context
+      );
+
+      expect(createdAgendaCategory).toBeUndefined(); // The resolver should not return anything
+    } catch (error: any) {
+      // The resolver should throw a NotFoundError with the appropriate message, code, and parameter
+
+      expect(error.message).toEqual(ORGANIZATION_NOT_FOUND_ERROR.MESSAGE);
+    }
+  });
+
+  it(`throws an error if the user does not have the required permissions`, async () => {
+    try {
+      const args: MutationCreateAgendaCategoryArgs = {
+        input: {
+          name: "Agenda Category",
+          description: "Description for the agenda category",
+          organization: testOrganization?.id,
+        },
+      };
+
+      const context = {
+        userId: testUser2?._id, // A user that is not an admin for the organization
+      };
+
+      const { createAgendaCategory: createAgendaCategoryResolver } =
+        await import("../../../src/resolvers/Mutation/createAgendaCategory");
+
+      const createdAgendaCategory = await createAgendaCategoryResolver?.(
+        {},
+        args,
+        context
+      );
+
+      expect(createdAgendaCategory).toBeUndefined(); // The resolver should not return anything
+    } catch (error: any) {
+      // The resolver should throw an UnauthorizedError with the appropriate message, code, and parameter
+      expect(error.message).toEqual(
+        "Error: Current user must be an ADMIN or a SUPERADMIN"
+      );
+    }
+  });
+});

--- a/tests/resolvers/Mutation/deleteAgendaCategory.spec.ts
+++ b/tests/resolvers/Mutation/deleteAgendaCategory.spec.ts
@@ -1,0 +1,172 @@
+import type mongoose from "mongoose";
+import { Types } from "mongoose";
+import { connect, disconnect } from "../../helpers/db";
+import { deleteAgendaCategory } from "../../../src/resolvers/Mutation/deleteAgendaCategory";
+import { User, AgendaCategoryModel, Organization } from "../../../src/models";
+import {
+  AGENDA_CATEGORY_NOT_FOUND_ERROR,
+  USER_NOT_AUTHORIZED_ERROR,
+  USER_NOT_FOUND_ERROR,
+} from "../../../src/constants";
+import { beforeAll, afterAll, describe, it, expect } from "vitest";
+import { createTestUser } from "../../helpers/userAndOrg";
+import type {
+  TestOrganizationType,
+  TestUserType,
+} from "../../helpers/userAndOrg";
+import test from "node:test";
+import { organizations } from "../../../src/resolvers/Query/organizations";
+import type { MutationDeleteAgendaCategoryArgs } from "../../../src/types/generatedGraphQLTypes";
+let testUser: TestUserType;
+let MONGOOSE_INSTANCE: typeof mongoose;
+let testAdminUser: TestUserType;
+let sampleAgendaCategory: any;
+let testOrganization: TestOrganizationType;
+let testUser2: TestUserType;
+let randomUser: TestUserType;
+
+beforeAll(async () => {
+  MONGOOSE_INSTANCE = await connect();
+  testUser = await createTestUser();
+  testAdminUser = await createTestUser();
+  testUser2 = await createTestUser();
+  randomUser = await createTestUser();
+  testOrganization = await Organization.create({
+    name: "name",
+    description: "description",
+    isPublic: true,
+    creator: testUser?._id,
+    admins: [testAdminUser?._id],
+    members: [testUser?._id, testAdminUser?._id],
+  });
+
+  await User.updateOne(
+    {
+      _id: testAdminUser?._id,
+    },
+    {
+      $set: {
+        createdOrganizations: [testOrganization._id],
+        adminFor: [testOrganization._id],
+      },
+    }
+  );
+  sampleAgendaCategory = await AgendaCategoryModel.create({
+    name: "Sample Agenda Category",
+    organization: testOrganization?._id,
+    createdBy: testAdminUser?._id,
+    createdAt: new Date(),
+  });
+});
+
+afterAll(async () => {
+  await disconnect(MONGOOSE_INSTANCE);
+});
+
+describe("resolvers -> Mutation -> deleteAgendaCategory", () => {
+  it("throws NotFoundError if no user exists with the given ID", async () => {
+    try {
+      const args = {
+        id: sampleAgendaCategory?._id,
+      };
+      const context = {
+        userId: Types.ObjectId().toString(),
+      };
+
+      await deleteAgendaCategory?.({}, args, context);
+    } catch (error: any) {
+      expect(error.message).toEqual(USER_NOT_FOUND_ERROR.MESSAGE);
+    }
+  });
+  it("throws NotFoundError if no agenda category exists with the given ID", async () => {
+    try {
+      const args = {
+        id: Types.ObjectId().toString(),
+      };
+      const context = {
+        userId: testAdminUser?._id,
+      };
+      await deleteAgendaCategory?.({}, args, context);
+    } catch (error: any) {
+      expect(error.message).toEqual(AGENDA_CATEGORY_NOT_FOUND_ERROR.MESSAGE);
+    }
+  });
+
+  it("throws UnauthorizedError if the user is not the creator of the agenda category", async () => {
+    try {
+      const args = {
+        id: sampleAgendaCategory?._id,
+      };
+      const context = {
+        userId: testUser?._id,
+      };
+      await deleteAgendaCategory?.({}, args, context);
+    } catch (error: any) {
+      expect(error.message).toEqual(USER_NOT_AUTHORIZED_ERROR.MESSAGE);
+    }
+  });
+  it(`removes the agenda category and returns it as superadmin`, async () => {
+    const superAdminTestUser = await User.findOneAndUpdate(
+      {
+        _id: randomUser?._id,
+      },
+      {
+        userType: "SUPERADMIN",
+      },
+      {
+        new: true,
+      }
+    );
+    const newTestAgendaCategory = await AgendaCategoryModel.create({
+      name: "Sample Agenda Category",
+      organization: testOrganization?._id,
+      createdBy: superAdminTestUser?._id,
+      createdAt: Date.now(),
+    });
+    const args: MutationDeleteAgendaCategoryArgs = {
+      id: newTestAgendaCategory?._id,
+    };
+
+    const context = {
+      userId: superAdminTestUser?._id,
+    };
+
+    const removedAgendaCategoryPayload = await deleteAgendaCategory?.(
+      {},
+      args,
+      context
+    );
+
+    expect(removedAgendaCategoryPayload).toEqual(args.id);
+  });
+  it(` deletes an agenda category successfully and returns it to who created it `, async () => {
+    const args: MutationDeleteAgendaCategoryArgs = {
+      id: sampleAgendaCategory?._id,
+    };
+
+    const context = {
+      userId: testAdminUser?._id,
+    };
+    const removedAgendaCategoryPayload = await deleteAgendaCategory?.(
+      {},
+      args,
+      context
+    );
+
+    expect(removedAgendaCategoryPayload).toEqual(args.id);
+    const deletedAgendaCategory = await AgendaCategoryModel.findById(args.id);
+    expect(deletedAgendaCategory).toBeNull();
+  });
+  // it("deletes an agenda category successfully", async () => {
+  //   const args = {
+  //     id: sampleAgendaCategory?._id,
+  //   };
+  //   const context = {
+  //     userId: testAdminUser?._id,
+  //   };
+  //   const result = await deleteAgendaCategory?.({}, args, context);
+  //   expect(result).toEqual(args.id);
+  //   // Verify that the agenda category is deleted from the database
+
+  // });
+});

--- a/tests/resolvers/Mutation/updateAgendaCategory.spec.ts
+++ b/tests/resolvers/Mutation/updateAgendaCategory.spec.ts
@@ -1,0 +1,224 @@
+import "dotenv/config";
+import type mongoose from "mongoose";
+import { Types } from "mongoose";
+import type { MutationUpdateAgendaCategoryArgs } from "../../../src/types/generatedGraphQLTypes";
+import { connect, disconnect } from "../../helpers/db";
+import {
+  USER_NOT_FOUND_ERROR,
+  AGENDA_CATEGORY_NOT_FOUND_ERROR,
+  USER_NOT_AUTHORIZED_ERROR,
+} from "../../../src/constants";
+import { beforeAll, afterAll, describe, it, expect, vi } from "vitest";
+import { updateAgendaCategory as updateAgendaCategoryResolver } from "../../../src/resolvers/Mutation/updateAgendaCategory";
+
+import { AgendaCategoryModel, Organization, User } from "../../../src/models";
+
+import { adminCheck } from "../../../src/utilities";
+import type { TestUserType } from "../../helpers/user";
+import { createTestUser } from "../../helpers/user";
+import type { TestOrganizationType } from "../../helpers/userAndOrg";
+
+let testAgendaCategory: any;
+let randomUser: TestUserType;
+let testUser: TestUserType;
+let MONGOOSE_INSTANCE: typeof mongoose;
+let testOrganization: TestOrganizationType;
+let testAdminUser: TestUserType;
+beforeAll(async () => {
+  MONGOOSE_INSTANCE = await connect();
+  const { requestContext } = await import("../../../src/libraries");
+  vi.spyOn(requestContext, "translate").mockImplementation(
+    (message) => message
+  );
+
+  randomUser = await createTestUser();
+  testUser = await createTestUser();
+  testAdminUser = await createTestUser();
+  testOrganization = await Organization.create({
+    name: "name",
+    description: "description",
+    isPublic: true,
+    creator: testUser?._id,
+    admins: [testAdminUser?._id],
+    members: [testUser?._id, testAdminUser?._id],
+  });
+
+  await User.updateOne(
+    {
+      _id: testUser?._id,
+    },
+    {
+      $push: {
+        adminFor: testOrganization?._id,
+      },
+    }
+  );
+  testAgendaCategory = await AgendaCategoryModel.create({
+    name: "Sample Agenda Category",
+    organization: testOrganization?._id,
+    createdBy: testAdminUser?._id,
+    createdAt: new Date(),
+  });
+});
+
+afterAll(async () => {
+  await disconnect(MONGOOSE_INSTANCE);
+});
+
+describe("resolvers -> Mutation -> updateAgendaCategory", () => {
+  it(`throws NotFoundError if no user exists with _id === context.userId`, async () => {
+    try {
+      const args: MutationUpdateAgendaCategoryArgs = {
+        id: Types.ObjectId().toString(),
+        input: {
+          name: "Updated Name",
+          description: "Updated Description",
+        },
+      };
+
+      const context = {
+        userId: Types.ObjectId().toString(),
+      };
+
+      await updateAgendaCategoryResolver?.({}, args, context);
+    } catch (error: any) {
+      expect(error.message).toEqual(USER_NOT_FOUND_ERROR.MESSAGE);
+    }
+  });
+
+  it(`throws NotFoundError if no agenda category exists with _id === args.id`, async () => {
+    try {
+      const args: MutationUpdateAgendaCategoryArgs = {
+        id: Types.ObjectId().toString(),
+        input: {
+          name: "Updated Name",
+          description: "Updated Description",
+        },
+      };
+
+      const context = {
+        userId: testUser?._id,
+      };
+
+      await updateAgendaCategoryResolver?.({}, args, context);
+    } catch (error: any) {
+      expect(error.message).toEqual(AGENDA_CATEGORY_NOT_FOUND_ERROR.MESSAGE);
+    }
+  });
+
+  it(`throws UnauthorizedError if the user is not the creator of the agenda category`, async () => {
+    try {
+      const args: MutationUpdateAgendaCategoryArgs = {
+        id: testAgendaCategory?._id,
+        input: {
+          name: "Updated Name",
+          description: "Updated Description",
+        },
+      };
+
+      const context = {
+        userId: randomUser?._id,
+      };
+
+      await updateAgendaCategoryResolver?.({}, args, context);
+    } catch (error: any) {
+      expect(error.message).toEqual(USER_NOT_AUTHORIZED_ERROR.MESSAGE);
+    }
+  });
+
+  it(`updates the agenda category and returns it for the creator`, async () => {
+    const args: MutationUpdateAgendaCategoryArgs = {
+      id: testAgendaCategory?._id,
+      input: {
+        name: "Updated Name",
+        description: "Updated Description",
+      },
+    };
+
+    const context = {
+      userId: testUser?._id,
+    };
+
+    const updatedAgendaCategoryPayload = await updateAgendaCategoryResolver?.(
+      {},
+      args,
+      context
+    );
+
+    expect(updatedAgendaCategoryPayload).toEqual(
+      expect.objectContaining({
+        name: "Updated Name",
+        description: "Updated Description",
+      })
+    );
+  });
+  //   it(`updates the agenda category and returns it for the admin`, async () => {
+  //   const args: MutationUpdateAgendaCategoryArgs = {
+  //     id: testAgendaCategory?._id,
+  //     input: {
+  //       name: "Updated Name",
+  //       description: "Updated Description",
+  //     },
+  //   };
+
+  //   const context = {
+  //     userId: testAdminUser?._id,
+  //   };
+
+  //   const updatedAgendaCategoryPayload = await updateAgendaCategoryResolver?.(
+  //     {},
+  //     args,
+  //     context
+  //   );
+
+  //   expect(updatedAgendaCategoryPayload).toEqual(
+  //     expect.objectContaining({
+  //       name: "Updated Name",
+  //       description: "Updated Description",
+  //     })
+  //   );
+  // });
+  it(`updates the agenda category and returns it as superadmin`, async () => {
+    const superAdminTestUser = await User.findOneAndUpdate(
+      {
+        _id: randomUser?._id,
+      },
+      {
+        userType: "SUPERADMIN",
+      },
+      {
+        new: true,
+      }
+    );
+    const newTestAgendaCategory = await AgendaCategoryModel.create({
+      name: "Sample Agenda Category",
+      organization: testOrganization?._id,
+      createdBy: superAdminTestUser?._id,
+      createdAt: Date.now(),
+    });
+
+    const context = {
+      userId: superAdminTestUser?._id,
+    };
+    const args: MutationUpdateAgendaCategoryArgs = {
+      id: testAgendaCategory?._id,
+      input: {
+        name: "Updated Name",
+        description: "Updated Description",
+      },
+    };
+
+    const updatedAgendaCategoryPayload = await updateAgendaCategoryResolver?.(
+      {},
+      args,
+      context
+    );
+
+    expect(updatedAgendaCategoryPayload).toEqual(
+      expect.objectContaining({
+        name: "Updated Name",
+        description: "Updated Description",
+      })
+    );
+  });
+});

--- a/tests/resolvers/Query/getAgendaCategoryById.spec.ts
+++ b/tests/resolvers/Query/getAgendaCategoryById.spec.ts
@@ -1,0 +1,79 @@
+import "dotenv/config";
+import { connect, disconnect } from "../../helpers/db";
+import type mongoose from "mongoose";
+import { AgendaCategoryModel, Organization } from "../../../src/models";
+import { errors, requestContext } from "../../../src/libraries";
+import { AGENDA_CATEGORY_NOT_FOUND_ERROR } from "../../../src/constants";
+import { beforeAll, afterAll, describe, it, expect } from "vitest";
+import { createTestPlugin } from "../../helpers/plugins";
+import {
+  createTestUser,
+  type TestOrganizationType,
+  type TestUserType,
+} from "../../helpers/userAndOrg";
+import { agendaCategory } from "../../../src/resolvers/Query/getAgendaCategoryById";
+import { Types } from "mongoose";
+let testUser: TestUserType;
+let testAdminUser: TestUserType;
+let testOrganization: TestOrganizationType;
+
+let testAgendaCategory: any;
+let MONGOOSE_INSTANCE: typeof mongoose;
+let testUser2: TestUserType;
+
+beforeAll(async () => {
+  MONGOOSE_INSTANCE = await connect();
+  testUser = await createTestUser();
+  testAdminUser = await createTestUser();
+  testOrganization = await Organization.create({
+    name: "name",
+    description: "description",
+    isPublic: true,
+    creator: testUser?._id,
+    admins: [testAdminUser?._id],
+    members: [testUser?._id, testAdminUser?._id],
+  });
+  testAgendaCategory = await AgendaCategoryModel.create({
+    name: "Test Categ",
+    description: "Test Desc",
+    organization: testOrganization?._id,
+    createdBy: testAdminUser?._id,
+    updatedBy: testAdminUser?._id,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+});
+
+afterAll(async () => {
+  await disconnect(MONGOOSE_INSTANCE);
+});
+
+describe("resolvers -> Query -> agendaCategory", () => {
+  it("returns the agenda category successfully when it exists", async () => {
+    try {
+      const args = {
+        id: testAgendaCategory?._id,
+      };
+      const result = await agendaCategory?.({}, args, {});
+      expect(result).toBeDefined();
+      expect(result?._id).toStrictEqual(testAgendaCategory?._id);
+    } catch (error) {
+      // Handle any unexpected errors during the test
+      console.error("Test failed with error:", error);
+      throw error;
+    }
+  });
+
+  it("throws a NotFoundError when the agenda category does not exist", async () => {
+    try {
+      const args = {
+        id: Types.ObjectId().toString(),
+      };
+      await agendaCategory?.({}, args, {});
+      // If the resolver does not throw an error, the test fails
+      throw new Error("Test failed. Expected NotFoundError but got no error.");
+    } catch (error: any) {
+      expect(error.message).toEqual(AGENDA_CATEGORY_NOT_FOUND_ERROR.MESSAGE);
+    }
+  });
+});

--- a/tests/resolvers/Query/getAllAgendaCategories.spec.ts
+++ b/tests/resolvers/Query/getAllAgendaCategories.spec.ts
@@ -1,0 +1,84 @@
+import { Organization, AgendaCategoryModel } from "../../../src/models";
+import { USER_NOT_AUTHORIZED_ERROR } from "../../../src/constants";
+import { createTestUser } from "../../helpers/userAndOrg";
+import type {
+  TestOrganizationType,
+  TestUserType,
+} from "../../helpers/userAndOrg";
+import type mongoose from "mongoose";
+import { Types } from "mongoose";
+import { connect, disconnect } from "../../helpers/db";
+import type { MutationCreateAgendaCategoryArgs } from "../../../src/types/generatedGraphQLTypes";
+import {
+  beforeAll,
+  afterAll,
+  describe,
+  it,
+  expect,
+  Test,
+  vi,
+  test,
+} from "vitest";
+import type { TestEventType } from "../../helpers/events";
+import { agendaCategories } from "../../../src/resolvers/Query/getAllAgendaCategories";
+let testUser: TestUserType;
+let testAdminUser: TestUserType;
+let testOrganization: TestOrganizationType;
+let testEvent: TestEventType;
+let testAgendaCategory: any;
+let MONGOOSE_INSTANCE: typeof mongoose;
+let testUser2: TestUserType;
+let testAgendaCategory2: any;
+
+beforeAll(async () => {
+  MONGOOSE_INSTANCE = await connect();
+  testUser = await createTestUser();
+  testAdminUser = await createTestUser();
+  testOrganization = await Organization.create({
+    name: "name",
+    description: "description",
+    isPublic: true,
+    creator: testUser?._id,
+    admins: [testAdminUser?._id],
+    members: [testUser?._id, testAdminUser?._id],
+  });
+
+  testAgendaCategory = await AgendaCategoryModel.create({
+    name: "Test Categ",
+    description: "Test Desc",
+    organization: testOrganization?._id,
+    createdBy: testAdminUser?._id,
+    updatedBy: testAdminUser?._id,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+  testAgendaCategory2 = await AgendaCategoryModel.create({
+    name: "Test Categ2",
+    description: "Test Desc2",
+    organization: testOrganization?._id,
+    createdBy: testAdminUser?._id,
+    updatedBy: testAdminUser?._id,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+});
+
+afterAll(async () => {
+  await disconnect(MONGOOSE_INSTANCE);
+});
+describe("resolvers -> Query -> getAllAgendaCategories", () => {
+  it("resolvers -> Query -> getAllAgendaItems: returns all agenda category successfully", async () => {
+    const result = await agendaCategories?.({}, {}, {});
+    expect(result).toBeDefined();
+  });
+
+  it("resolvers -> Query -> getAllAgendaCategories: handles different input scenarios", async () => {
+    // Test with specific arguments
+    const result1 = await agendaCategories?.({ someKey: "someValue" }, {}, {});
+    expect(result1).toBeDefined();
+
+    // Test with empty arguments
+    const result2 = await agendaCategories?.({}, {}, {});
+    expect(result2).toBeDefined();
+  });
+});


### PR DESCRIPTION
  **What kind of change does this PR introduce?**

 Feature 

**Issue Number:** Fixes ##1588

 **Did you add tests for your changes?**

 Yes 

**Summary**

 This pull request introduces the following changes:
 
1. Support for agenda categories : Create, read, update and delete operations (CRUD) for agenda categories. Agenda categories are universal to an organization.
2. AgendaCategory-Organization Relationship :  As categories are universal to organizations, there is a new field added to organizations called as "agendacategories" as an array. 
3. Any new Categories created are automatically associated with the corresponding Organization. 
**Does this PR introduce a breaking change?** 
No 
**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?** 
Yes