### PR TITLE
Added tests for file src/resolvers/Mutation/createPost.ts

### DIFF
--- a/tests/resolvers/Mutation/createPost.spec.ts
+++ b/tests/resolvers/Mutation/createPost.spec.ts
@@ -273,7 +273,6 @@ describe("resolvers -> Mutation -> createPost", () => {
     expect(createPostPayload?.pinned).toBe(true);
 
     const testCreatePostPayload = await Post.findOne({
-      organization: testOrganization?.id,
       _id: createPostPayload?._id,
       imageUrl: { $ne: null },
     }).lean();
@@ -312,7 +311,6 @@ describe("resolvers -> Mutation -> createPost", () => {
     expect(createPostPayload?.pinned).toBe(true);
 
     const testCreatePostPayload = await Post.findOne({
-      organization: testOrganization?.id,
       _id: createPostPayload?._id,
       videoUrl: { $ne: null },
     }).lean();

--- a/tests/resolvers/Mutation/createPost.spec.ts
+++ b/tests/resolvers/Mutation/createPost.spec.ts
@@ -431,7 +431,7 @@ describe("resolvers -> Mutation -> createPost", () => {
     }
   });
 
-  it('throws an error if the user tries to create a post but post is not pinned', async () => {
+  it("throws an error if the user tries to create a post but post is not pinned", async () => {
     const { requestContext } = await import("../../../src/libraries");
     vi.spyOn(requestContext, "translate").mockImplementationOnce(
       (message) => message

--- a/tests/resolvers/Mutation/createPost.spec.ts
+++ b/tests/resolvers/Mutation/createPost.spec.ts
@@ -431,6 +431,39 @@ describe("resolvers -> Mutation -> createPost", () => {
     }
   });
 
+  it('throws an error if the user tries to create a post but post is not pinned', async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    vi.spyOn(requestContext, "translate").mockImplementationOnce(
+      (message) => message
+    );
+    try {
+      const args: MutationCreatePostArgs = {
+        data: {
+          organizationId: testOrganization?._id,
+          text: "text",
+          pinned: false,
+        },
+      };
+
+      const context = {
+        userId: testUser?.id,
+      };
+
+      expect(args.data.pinned).toBe(false);
+      const { createPost: createPostResolver } = await import(
+        "../../../src/resolvers/Mutation/createPost"
+      );
+      const createdPost = await createPostResolver?.({}, args, context);
+      expect(createdPost?.pinned).toBe(false);
+    } catch (error) {
+      if (error instanceof Error) {
+        expect(error.message).toEqual(
+          `Cannot create post when pinned is false`
+        );
+      }
+    }
+  });
+
   it("throws error if title is provided and post is not pinned", async () => {
     const { requestContext } = await import("../../../src/libraries");
     vi.spyOn(requestContext, "translate").mockImplementationOnce(

--- a/tests/resolvers/Mutation/createPost.spec.ts
+++ b/tests/resolvers/Mutation/createPost.spec.ts
@@ -85,11 +85,13 @@ describe("resolvers -> Mutation -> createPost", () => {
       );
 
       await createPostResolver?.({}, args, context);
-    } catch (error: any) {
-      expect(spy).toBeCalledWith(USER_NOT_FOUND_ERROR.MESSAGE);
-      expect(error.message).toEqual(
-        `Translated ${USER_NOT_FOUND_ERROR.MESSAGE}`
-      );
+    } catch (error) {
+      if (error instanceof Error) {
+        expect(spy).toBeCalledWith(USER_NOT_FOUND_ERROR.MESSAGE);
+        expect(error.message).toEqual(
+          `Translated ${USER_NOT_FOUND_ERROR.MESSAGE}`
+        );
+      }
     }
   });
 
@@ -118,11 +120,13 @@ describe("resolvers -> Mutation -> createPost", () => {
       );
 
       await createPostResolver?.({}, args, context);
-    } catch (error: any) {
-      expect(spy).toBeCalledWith(ORGANIZATION_NOT_FOUND_ERROR.MESSAGE);
-      expect(error.message).toEqual(
-        `Translated ${ORGANIZATION_NOT_FOUND_ERROR.MESSAGE}`
-      );
+    } catch (error) {
+      if (error instanceof Error) {
+        expect(spy).toBeCalledWith(ORGANIZATION_NOT_FOUND_ERROR.MESSAGE);
+        expect(error.message).toEqual(
+          `Translated ${ORGANIZATION_NOT_FOUND_ERROR.MESSAGE}`
+        );
+      }
     }
   });
 
@@ -154,11 +158,13 @@ describe("resolvers -> Mutation -> createPost", () => {
 
       const createPost = await createPostResolver?.({}, args, context);
       expect(createPost?.pinned).toBe(true);
-    } catch (error: any) {
-      expect(spy).toBeCalledWith(USER_NOT_AUTHORIZED_TO_PIN.MESSAGE);
-      expect(error.message).toEqual(
-        `Translated ${USER_NOT_AUTHORIZED_TO_PIN.MESSAGE}`
-      );
+    } catch (error) {
+      if (error instanceof Error) {
+        expect(spy).toBeCalledWith(USER_NOT_AUTHORIZED_TO_PIN.MESSAGE);
+        expect(error.message).toEqual(
+          `Translated ${USER_NOT_AUTHORIZED_TO_PIN.MESSAGE}`
+        );
+      }
     }
   });
 
@@ -379,10 +385,12 @@ describe("resolvers -> Mutation -> createPost", () => {
 
       const createdPost = await createPostResolver?.({}, args, context);
       expect(createdPost?.pinned).toBe(true);
-    } catch (error: any) {
-      expect(error.message).toEqual(
-        `${LENGTH_VALIDATION_ERROR.MESSAGE} 256 characters in title`
-      );
+    } catch (error) {
+      if (error instanceof Error) {
+        expect(error.message).toEqual(
+          `${LENGTH_VALIDATION_ERROR.MESSAGE} 256 characters in title`
+        );
+      }
     }
   });
   it(`throws String Length Validation error if text is greater than 500 characters`, async () => {
@@ -414,10 +422,12 @@ describe("resolvers -> Mutation -> createPost", () => {
 
       const createdPost = await createPostResolver?.({}, args, context);
       expect(createdPost?.pinned).toBe(true);
-    } catch (error: any) {
-      expect(error.message).toEqual(
-        `${LENGTH_VALIDATION_ERROR.MESSAGE} 500 characters in information`
-      );
+    } catch (error) {
+      if (error instanceof Error) {
+        expect(error.message).toEqual(
+          `${LENGTH_VALIDATION_ERROR.MESSAGE} 500 characters in information`
+        );
+      }
     }
   });
 
@@ -446,10 +456,12 @@ describe("resolvers -> Mutation -> createPost", () => {
       );
       const createdPost = await createPostResolver?.({}, args, context);
       expect(createdPost?.pinned).toBe(false);
-    } catch (error: any) {
-      expect(error.message).toEqual(
-        `Post needs to be pinned inorder to add a title`
-      );
+    } catch (error) {
+      if (error instanceof Error) {
+        expect(error.message).toEqual(
+          `Post needs to be pinned inorder to add a title`
+        );
+      }
     }
   });
 
@@ -478,8 +490,10 @@ describe("resolvers -> Mutation -> createPost", () => {
       );
       const createPost = await createPostResolver?.({}, args, context);
       expect(createPost?.pinned).toBe(true);
-    } catch (error: any) {
-      expect(error.message).toEqual(`Please provide a title to pin post`);
+    } catch (error) {
+      if (error instanceof Error) {
+        expect(error.message).toEqual(`Please provide a title to pin post`);
+      }
     }
   });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Tests added for increasing the code coverage of the file src/resolvers/Mutation/createPost.ts.

**Issue Number:**

Fixes #1826 

**Did you add tests for your changes?**
N/A

**Snapshots/Videos:**
All tests:
![image](https://github.com/PalisadoesFoundation/talawa-api/assets/78889572/2ec38b51-ead9-4a2f-ab1c-a07533125eed)

Code coverage of file src/resolvers/Mutation/createPost.ts after adding tests
![Screenshot from 2024-02-11 15-38-49](https://github.com/PalisadoesFoundation/talawa-api/assets/78889572/23d025fa-0781-4b66-b3f5-41de410e6e38)



**If relevant, did you update the documentation?**
N/A

**Does this PR introduce a breaking change?**
No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes