### PR TITLE
feat: delete recurring events

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -935,7 +935,7 @@ type Mutation {
   removeAdmin(data: UserAndOrganizationInput!): User!
   removeComment(id: ID!): Comment
   removeDirectChat(chatId: ID!, organizationId: ID!): DirectChat!
-  removeEvent(id: ID!): Event!
+  removeEvent(id: ID!, recurringEventDeleteType: RecurringEventMutationType): Event!
   removeEventAttendee(data: EventAttendeeInput!): User!
   removeEventVolunteer(id: ID!): EventVolunteer!
   removeFund(id: ID!): Fund!
@@ -970,7 +970,7 @@ type Mutation {
   updateActionItemCategory(data: UpdateActionItemCategoryInput!, id: ID!): ActionItemCategory
   updateAdvertisement(input: UpdateAdvertisementInput!): UpdateAdvertisementPayload
   updateAgendaCategory(id: ID!, input: UpdateAgendaCategoryInput!): AgendaCategory
-  updateEvent(data: UpdateEventInput, id: ID!, recurrenceRuleData: RecurrenceRuleInput, recurringEventUpdateType: RecurringEventUpdateType): Event!
+  updateEvent(data: UpdateEventInput, id: ID!, recurrenceRuleData: RecurrenceRuleInput, recurringEventUpdateType: RecurringEventMutationType): Event!
   updateEventVolunteer(data: UpdateEventVolunteerInput, id: ID!): EventVolunteer!
   updateFund(data: UpdateFundInput!, id: ID!): Fund!
   updateFundraisingCampaign(data: UpdateFundCampaignInput!, id: ID!): FundraisingCampaign!
@@ -1291,7 +1291,7 @@ input RecurrenceRuleInput {
   weekDays: [WeekDays]
 }
 
-enum RecurringEventUpdateType {
+enum RecurringEventMutationType {
   AllInstances
   ThisAndFollowingInstances
   ThisInstance

--- a/src/helpers/event/deleteEventHelpers/deleteRecurringEvent.ts
+++ b/src/helpers/event/deleteEventHelpers/deleteRecurringEvent.ts
@@ -5,6 +5,16 @@ import type { InterfaceEvent } from "../../../models";
 import { Event } from "../../../models";
 import { deleteSingleEvent, deleteRecurringEventInstances } from "./index";
 
+/**
+ * This function deletes thisInstance / allInstances / thisAndFollowingInstances of a recurring event.
+ * @param args - removeEventArgs
+ * @param event - an instance of the recurring event to be deleted.
+ * @remarks The following steps are followed:
+ * 1. get the recurrence rule and the base recurring event.
+ * 2. if the instance is an exception instance or if we're deleting thisInstance only, just delete that single instance.
+ * 3. if it's a bulk delete operation, handle it accordingly.
+ */
+
 export const deleteRecurringEvent = async (
   args: MutationRemoveEventArgs,
   event: InterfaceEvent,
@@ -31,7 +41,7 @@ export const deleteRecurringEvent = async (
     // delete all the instances
     // and update the recurrenceRule and baseRecurringEvent accordingly
     await deleteRecurringEventInstances(
-      null,
+      null, // because we're going to delete all the instances, which we could get from the recurrence rule
       recurrenceRule[0],
       baseRecurringEvent[0],
       session,
@@ -40,7 +50,7 @@ export const deleteRecurringEvent = async (
     // delete this and following the instances
     // and update the recurrenceRule and baseRecurringEvent accordingly
     await deleteRecurringEventInstances(
-      event,
+      event, // we'll find all the instances after(and including) this one and delete them
       recurrenceRule[0],
       baseRecurringEvent[0],
       session,

--- a/src/helpers/event/deleteEventHelpers/deleteRecurringEvent.ts
+++ b/src/helpers/event/deleteEventHelpers/deleteRecurringEvent.ts
@@ -1,0 +1,46 @@
+import type mongoose from "mongoose";
+import { MutationRemoveEventArgs } from "../../../types/generatedGraphQLTypes";
+import { RecurrenceRule } from "../../../models/RecurrenceRule";
+import { Event, InterfaceEvent } from "../../../models";
+import { deleteSingleEvent, deleteRecurringEventInstances } from "./index";
+
+export const deleteRecurringEvent = async (
+  args: MutationRemoveEventArgs,
+  event: InterfaceEvent,
+  session: mongoose.ClientSession,
+): Promise<void> => {
+  // get the recurrenceRule
+  const recurrenceRule = await RecurrenceRule.find({
+    _id: event.recurrenceRuleId,
+  });
+
+  // get the baseRecurringEvent
+  const baseRecurringEvent = await Event.find({
+    _id: event.baseRecurringEventId,
+  });
+
+  if (
+    event.isRecurringEventException ||
+    args.recurringEventDeleteType === "ThisInstance"
+  ) {
+    // if the event is an exception or if it's deleting thisInstance only,
+    // just delete this single instance
+    await deleteSingleEvent(event._id.toString(), session);
+  } else if (args.recurringEventDeleteType === "AllInstances") {
+    // perform a regular bulk delete on all the instances
+    await deleteRecurringEventInstances(
+      null,
+      recurrenceRule[0],
+      baseRecurringEvent[0],
+      session,
+    );
+  } else {
+    // update current and following events
+    await deleteRecurringEventInstances(
+      event,
+      recurrenceRule[0],
+      baseRecurringEvent[0],
+      session,
+    );
+  }
+};

--- a/src/helpers/event/deleteEventHelpers/deleteRecurringEvent.ts
+++ b/src/helpers/event/deleteEventHelpers/deleteRecurringEvent.ts
@@ -1,7 +1,8 @@
 import type mongoose from "mongoose";
-import { MutationRemoveEventArgs } from "../../../types/generatedGraphQLTypes";
+import type { MutationRemoveEventArgs } from "../../../types/generatedGraphQLTypes";
 import { RecurrenceRule } from "../../../models/RecurrenceRule";
-import { Event, InterfaceEvent } from "../../../models";
+import type { InterfaceEvent } from "../../../models";
+import { Event } from "../../../models";
 import { deleteSingleEvent, deleteRecurringEventInstances } from "./index";
 
 export const deleteRecurringEvent = async (
@@ -27,7 +28,8 @@ export const deleteRecurringEvent = async (
     // just delete this single instance
     await deleteSingleEvent(event._id.toString(), session);
   } else if (args.recurringEventDeleteType === "AllInstances") {
-    // perform a regular bulk delete on all the instances
+    // delete all the instances
+    // and update the recurrenceRule and baseRecurringEvent accordingly
     await deleteRecurringEventInstances(
       null,
       recurrenceRule[0],
@@ -35,7 +37,8 @@ export const deleteRecurringEvent = async (
       session,
     );
   } else {
-    // update current and following events
+    // delete this and following the instances
+    // and update the recurrenceRule and baseRecurringEvent accordingly
     await deleteRecurringEventInstances(
       event,
       recurrenceRule[0],

--- a/src/helpers/event/deleteEventHelpers/deleteRecurringEventInstances.ts
+++ b/src/helpers/event/deleteEventHelpers/deleteRecurringEventInstances.ts
@@ -1,0 +1,160 @@
+import type mongoose from "mongoose";
+import {
+  InterfaceRecurrenceRule,
+  RecurrenceRule,
+} from "../../../models/RecurrenceRule";
+import {
+  ActionItem,
+  Event,
+  EventAttendee,
+  InterfaceEvent,
+  User,
+} from "../../../models";
+import { cacheEvents } from "../../../services/EventCache/cacheEvents";
+import { shouldUpdateBaseRecurringEvent } from "../updateEventHelpers";
+
+export const deleteRecurringEventInstances = async (
+  event: InterfaceEvent | null,
+  recurrenceRule: InterfaceRecurrenceRule,
+  baseRecurringEvent: InterfaceEvent,
+  session: mongoose.ClientSession,
+): Promise<void> => {
+  const recurringEventInstances = await Event.find({
+    recurrenceRuleId: recurrenceRule._id,
+    startDate: { $gte: event?.startDate },
+  });
+
+  const recurringEventInstancesIds = recurringEventInstances.map(
+    (recurringEventInstance) => recurringEventInstance._id,
+  );
+
+  await Promise.all([
+    EventAttendee.deleteMany(
+      { eventId: { $in: recurringEventInstancesIds } },
+      { session },
+    ),
+    User.updateMany(
+      {
+        $or: [
+          { createdEvents: { $in: recurringEventInstancesIds } },
+          { eventAdmin: { $in: recurringEventInstancesIds } },
+          { registeredEvents: { $in: recurringEventInstancesIds } },
+        ],
+      },
+      {
+        $pull: {
+          createdEvents: { $in: recurringEventInstancesIds },
+          eventAdmin: { $in: recurringEventInstancesIds },
+          registeredEvents: { $in: recurringEventInstancesIds },
+        },
+      },
+      { session },
+    ),
+    ActionItem.deleteMany(
+      { eventId: { $in: recurringEventInstancesIds } },
+      { session },
+    ),
+  ]);
+
+  await Event.updateMany(
+    {
+      _id: { $in: recurringEventInstancesIds },
+    },
+    {
+      status: "DELETED",
+    },
+    {
+      session,
+    },
+  );
+
+  const updatedRecurringEventInstances = await Event.find(
+    {
+      _id: { $in: recurringEventInstancesIds },
+    },
+    null,
+    { session },
+  );
+
+  await Promise.all(
+    updatedRecurringEventInstances.map((updatedEvent) =>
+      cacheEvents([updatedEvent]),
+    ),
+  );
+
+  // get the instances following the current recurrence rule
+  const eventsFollowingCurrentRecurrence = await Event.find(
+    {
+      recurrenceRuleId: recurrenceRule._id,
+      isRecurringEventException: false,
+    },
+    null,
+    { session },
+  ).sort({ startDate: -1 });
+
+  const moreInstancesExist =
+    eventsFollowingCurrentRecurrence && eventsFollowingCurrentRecurrence.length;
+
+  if (moreInstancesExist) {
+    // get the latest instance following the old recurrence rule
+    const updatedEndDateString = eventsFollowingCurrentRecurrence[0].startDate;
+    const updatedEndDate = new Date(updatedEndDateString);
+
+    // update the latestInstanceDate and endDate of the current recurrenceRule
+    await RecurrenceRule.findOneAndUpdate(
+      {
+        _id: recurrenceRule._id,
+      },
+      {
+        latestInstanceDate: updatedEndDate,
+        endDate: updatedEndDate,
+      },
+      { session },
+    ).lean();
+
+    // update the baseRecurringEvent if it is the latest recurrence rule that the instances are following
+    if (
+      shouldUpdateBaseRecurringEvent(
+        recurrenceRule.endDate?.toString(),
+        baseRecurringEvent.endDate?.toString(),
+      )
+    ) {
+      await Event.updateOne(
+        {
+          _id: baseRecurringEvent._id,
+        },
+        {
+          endDate: updatedEndDateString,
+        },
+        {
+          session,
+        },
+      );
+    }
+  } else {
+    const previousRecurrenceRules = await RecurrenceRule.find(
+      { baseRecurringEventId: baseRecurringEvent._id },
+      null,
+      { session },
+    ).sort({ endDate: -1 });
+
+    const previousRecurrenceRulesExist =
+      previousRecurrenceRules && previousRecurrenceRules.length;
+    if (previousRecurrenceRulesExist) {
+      if (
+        shouldUpdateBaseRecurringEvent(
+          recurrenceRule.endDate.toISOString(),
+          baseRecurringEvent.endDate,
+        )
+      ) {
+        await Event.updateOne(
+          {
+            _id: baseRecurringEvent._id,
+          },
+          { endDate: previousRecurrenceRules[0]._id },
+          { session },
+        );
+      }
+    }
+  }
+};

--- a/src/helpers/event/deleteEventHelpers/deleteRecurringEventInstances.ts
+++ b/src/helpers/event/deleteEventHelpers/deleteRecurringEventInstances.ts
@@ -1,17 +1,8 @@
 import type mongoose from "mongoose";
-import type {
-  InterfaceRecurrenceRule} from "../../../models/RecurrenceRule";
-import {
-  RecurrenceRule,
-} from "../../../models/RecurrenceRule";
-import type {
-  InterfaceEvent} from "../../../models";
-import {
-  ActionItem,
-  Event,
-  EventAttendee,
-  User,
-} from "../../../models";
+import type { InterfaceRecurrenceRule } from "../../../models/RecurrenceRule";
+import { RecurrenceRule } from "../../../models/RecurrenceRule";
+import type { InterfaceEvent } from "../../../models";
+import { ActionItem, Event, EventAttendee, User } from "../../../models";
 import { cacheEvents } from "../../../services/EventCache/cacheEvents";
 import { shouldUpdateBaseRecurringEvent } from "../updateEventHelpers";
 import type { Types } from "mongoose";
@@ -155,7 +146,9 @@ export const deleteRecurringEventInstances = async (
       },
       null,
       { session },
-    ).sort({ endDate: -1 });
+    )
+      .sort({ endDate: -1 })
+      .lean();
 
     const previousRecurrenceRulesExist =
       previousRecurrenceRules && previousRecurrenceRules.length;
@@ -170,7 +163,7 @@ export const deleteRecurringEventInstances = async (
           {
             _id: baseRecurringEvent._id,
           },
-          { endDate: previousRecurrenceRules[0]._id },
+          { endDate: previousRecurrenceRules[0].endDate.toISOString() },
           { session },
         );
       }

--- a/src/helpers/event/deleteEventHelpers/deleteSingleEvent.ts
+++ b/src/helpers/event/deleteEventHelpers/deleteSingleEvent.ts
@@ -1,0 +1,52 @@
+import type mongoose from "mongoose";
+import { ActionItem, Event, EventAttendee, User } from "../../../models";
+import { cacheEvents } from "../../../services/EventCache/cacheEvents";
+
+export const deleteSingleEvent = async (
+  eventId: string,
+  session: mongoose.ClientSession,
+): Promise<void> => {
+  await Promise.all([
+    EventAttendee.deleteMany(
+      {
+        eventId,
+      },
+      { session },
+    ),
+    User.updateMany(
+      {
+        $or: [
+          { createdEvents: eventId },
+          { eventAdmin: eventId },
+          { registeredEvents: eventId },
+        ],
+      },
+      {
+        $pull: {
+          createdEvents: eventId,
+          eventAdmin: eventId,
+          registeredEvents: eventId,
+        },
+      },
+      { session },
+    ),
+    ActionItem.deleteMany({ eventId }, { session }),
+  ]);
+
+  const updatedEvent = await Event.findOneAndUpdate(
+    {
+      _id: eventId,
+    },
+    {
+      status: "DELETED",
+    },
+    {
+      new: true,
+      session,
+    },
+  );
+
+  if (updatedEvent !== null) {
+    await cacheEvents([updatedEvent]);
+  }
+};

--- a/src/helpers/event/deleteEventHelpers/deleteSingleEvent.ts
+++ b/src/helpers/event/deleteEventHelpers/deleteSingleEvent.ts
@@ -1,11 +1,19 @@
 import type mongoose from "mongoose";
 import { ActionItem, Event, EventAttendee, User } from "../../../models";
-import { cacheEvents } from "../../../services/EventCache/cacheEvents";
+
+/**
+ * This function deletes a single event.
+ * @param event - the event to be deleted:
+ * @remarks The following steps are followed:
+ * 1. remove the associations of the event.
+ * 2. delete the event.
+ */
 
 export const deleteSingleEvent = async (
   eventId: string,
   session: mongoose.ClientSession,
 ): Promise<void> => {
+  // remove the associations of the current event
   await Promise.all([
     EventAttendee.deleteMany(
       {
@@ -33,20 +41,13 @@ export const deleteSingleEvent = async (
     ActionItem.deleteMany({ eventId }, { session }),
   ]);
 
-  const updatedEvent = await Event.findOneAndUpdate(
+  // delete the event
+  await Event.deleteOne(
     {
       _id: eventId,
     },
     {
-      status: "DELETED",
-    },
-    {
-      new: true,
       session,
     },
   );
-
-  if (updatedEvent !== null) {
-    await cacheEvents([updatedEvent]);
-  }
 };

--- a/src/helpers/event/deleteEventHelpers/index.ts
+++ b/src/helpers/event/deleteEventHelpers/index.ts
@@ -1,0 +1,3 @@
+export { deleteSingleEvent } from "./deleteSingleEvent";
+export { deleteRecurringEvent } from "./deleteRecurringEvent";
+export { deleteRecurringEventInstances } from "./deleteRecurringEventInstances";

--- a/src/helpers/event/updateEventHelpers/index.ts
+++ b/src/helpers/event/updateEventHelpers/index.ts
@@ -1,2 +1,4 @@
+export { getEventData } from "./getEventData";
 export { updateSingleEvent } from "./updateSingleEvent";
 export { updateRecurringEvent } from "./updateRecurringEvent";
+export { shouldUpdateBaseRecurringEvent } from "./shouldUpdateBaseRecurringEvent";

--- a/src/helpers/event/updateEventHelpers/shouldUpdateBaseRecurringEvent.ts
+++ b/src/helpers/event/updateEventHelpers/shouldUpdateBaseRecurringEvent.ts
@@ -1,7 +1,15 @@
+/**
+ * This function checks whether the baseRecurringEvent should be updated.
+ * @param recurrenceRuleEndDate - the end date of the recurrence rule.
+ * @param baseRecurringEventEndDate - the end date of the base recurring event.
+ * @returns true if the recurrence rule is the latest rule that the instances were following, false otherwise.
+ */
+
 export const shouldUpdateBaseRecurringEvent = (
   recurrenceRuleEndDate: string | null | undefined,
   baseRecurringEventEndDate: string | null | undefined,
-): Boolean => {
+): boolean => {
+  // if the endDate matches then return true, otherwise false
   return (!recurrenceRuleEndDate && !baseRecurringEventEndDate) ||
     (recurrenceRuleEndDate &&
       baseRecurringEventEndDate &&

--- a/src/helpers/event/updateEventHelpers/shouldUpdateBaseRecurringEvent.ts
+++ b/src/helpers/event/updateEventHelpers/shouldUpdateBaseRecurringEvent.ts
@@ -1,0 +1,11 @@
+export const shouldUpdateBaseRecurringEvent = (
+  recurrenceRuleEndDate: string | null | undefined,
+  baseRecurringEventEndDate: string | null | undefined,
+): Boolean => {
+  return (!recurrenceRuleEndDate && !baseRecurringEventEndDate) ||
+    (recurrenceRuleEndDate &&
+      baseRecurringEventEndDate &&
+      recurrenceRuleEndDate === baseRecurringEventEndDate)
+    ? true
+    : false;
+};

--- a/src/helpers/event/updateEventHelpers/updateAllInstances.ts
+++ b/src/helpers/event/updateEventHelpers/updateAllInstances.ts
@@ -3,6 +3,7 @@ import type { InterfaceEvent } from "../../../models";
 import { Event } from "../../../models";
 import type { MutationUpdateEventArgs } from "../../../types/generatedGraphQLTypes";
 import type { InterfaceRecurrenceRule } from "../../../models/RecurrenceRule";
+import { shouldUpdateBaseRecurringEvent } from "./index";
 
 /**
  * This function updates all instances of the recurring event following the given recurrenceRule.
@@ -24,11 +25,10 @@ export const updateAllInstances = async (
   session: mongoose.ClientSession,
 ): Promise<InterfaceEvent> => {
   if (
-    (!recurrenceRule.endDate && !baseRecurringEvent.endDate) ||
-    (recurrenceRule.endDate &&
-      baseRecurringEvent.endDate &&
-      recurrenceRule.endDate.toString() ===
-        baseRecurringEvent.endDate.toString())
+    shouldUpdateBaseRecurringEvent(
+      recurrenceRule?.endDate?.toString(),
+      baseRecurringEvent?.endDate?.toString(),
+    )
   ) {
     // if this was the latest recurrence rule, then update the baseRecurringEvent
     // because new instances following this recurrence rule would be generated based on baseRecurringEvent

--- a/src/helpers/event/updateEventHelpers/updateThisAndFollowingInstances.ts
+++ b/src/helpers/event/updateEventHelpers/updateThisAndFollowingInstances.ts
@@ -10,7 +10,7 @@ import {
   generateRecurringEventInstances,
   getRecurringInstanceDates,
 } from "../recurringEventHelpers";
-import { getEventData } from "./getEventData";
+import { getEventData, shouldUpdateBaseRecurringEvent } from "./index";
 
 /**
  * This function updates this and the following instances of a recurring event.
@@ -198,12 +198,10 @@ export const updateThisAndFollowingInstances = async (
 
   // update the baseRecurringEvent if it is the latest recurrence rule that the instances are following
   if (
-    recurrenceRule &&
-    ((!recurrenceRule.endDate && !baseRecurringEvent.endDate) ||
-      (recurrenceRule.endDate &&
-        baseRecurringEvent.endDate &&
-        recurrenceRule.endDate.toString() ===
-          baseRecurringEvent.endDate.toString()))
+    shouldUpdateBaseRecurringEvent(
+      recurrenceRule?.endDate?.toString(),
+      baseRecurringEvent?.endDate?.toString(),
+    )
   ) {
     await Event.updateOne(
       {

--- a/src/resolvers/Mutation/removeEvent.ts
+++ b/src/resolvers/Mutation/removeEvent.ts
@@ -1,7 +1,7 @@
 import type { MutationResolvers } from "../../types/generatedGraphQLTypes";
 import { errors, requestContext } from "../../libraries";
 import type { InterfaceEvent } from "../../models";
-import { User, Event, ActionItem } from "../../models";
+import { User, Event } from "../../models";
 import {
   USER_NOT_FOUND_ERROR,
   EVENT_NOT_FOUND_ERROR,
@@ -9,6 +9,11 @@ import {
 } from "../../constants";
 import { findEventsInCache } from "../../services/EventCache/findEventInCache";
 import { cacheEvents } from "../../services/EventCache/cacheEvents";
+import {
+  deleteRecurringEvent,
+  deleteSingleEvent,
+} from "../../helpers/event/deleteEventHelpers";
+import { session } from "../../db";
 /**
  * This function enables to remove an event.
  * @param _parent - parent of current request
@@ -89,45 +94,72 @@ export const removeEvent: MutationResolvers["removeEvent"] = async (
     );
   }
 
-  await User.updateMany(
-    {
-      createdEvents: event._id,
-    },
-    {
-      $pull: {
-        createdEvents: event._id,
-      },
-    },
-  );
-
-  await User.updateMany(
-    {
-      eventAdmin: event._id,
-    },
-    {
-      $pull: {
-        eventAdmin: event._id,
-      },
-    },
-  );
-
-  const updatedEvent = await Event.findOneAndUpdate(
-    {
-      _id: event._id,
-    },
-    {
-      status: "DELETED",
-    },
-    {
-      new: true,
-    },
-  );
-
-  if (updatedEvent !== null) {
-    await cacheEvents([updatedEvent]);
+  /* c8 ignore start */
+  if (session) {
+    // start a transaction
+    session.startTransaction();
   }
 
-  await ActionItem.deleteMany({ eventId: event?._id });
+  /* c8 ignore stop */
+
+  try {
+    if (event.recurring) {
+      await deleteRecurringEvent(args, event, session);
+    } else {
+      await deleteSingleEvent(event._id.toString(), session);
+    }
+
+    /* c8 ignore start */
+  } catch (error) {
+    if (session) {
+      // abort transaction if something fails
+      await session.abortTransaction();
+    }
+
+    throw error;
+  }
+
+  /* c8 ignore stop */
+
+  // await User.updateMany(
+  //   {
+  //     createdEvents: event._id,
+  //   },
+  //   {
+  //     $pull: {
+  //       createdEvents: event._id,
+  //     },
+  //   },
+  // );
+
+  // await User.updateMany(
+  //   {
+  //     eventAdmin: event._id,
+  //   },
+  //   {
+  //     $pull: {
+  //       eventAdmin: event._id,
+  //     },
+  //   },
+  // );
+
+  // const updatedEvent = await Event.findOneAndUpdate(
+  //   {
+  //     _id: event._id,
+  //   },
+  //   {
+  //     status: "DELETED",
+  //   },
+  //   {
+  //     new: true,
+  //   },
+  // );
+
+  // if (updatedEvent !== null) {
+  //   await cacheEvents([updatedEvent]);
+  // }
+
+  // await ActionItem.deleteMany({ eventId: event?._id });
 
   return event;
 };

--- a/src/resolvers/Mutation/removeEvent.ts
+++ b/src/resolvers/Mutation/removeEvent.ts
@@ -101,7 +101,6 @@ export const removeEvent: MutationResolvers["removeEvent"] = async (
   }
 
   /* c8 ignore stop */
-
   try {
     if (event.recurring) {
       // if the event is recurring
@@ -126,6 +125,5 @@ export const removeEvent: MutationResolvers["removeEvent"] = async (
   }
 
   /* c8 ignore stop */
-
   return event;
 };

--- a/src/resolvers/Mutation/removeEvent.ts
+++ b/src/resolvers/Mutation/removeEvent.ts
@@ -104,12 +104,18 @@ export const removeEvent: MutationResolvers["removeEvent"] = async (
 
   try {
     if (event.recurring) {
+      // if the event is recurring
       await deleteRecurringEvent(args, event, session);
     } else {
+      // if the event is non-recurring
       await deleteSingleEvent(event._id.toString(), session);
     }
 
     /* c8 ignore start */
+    if (session) {
+      // commit transaction if everything's successful
+      await session.commitTransaction();
+    }
   } catch (error) {
     if (session) {
       // abort transaction if something fails
@@ -120,46 +126,6 @@ export const removeEvent: MutationResolvers["removeEvent"] = async (
   }
 
   /* c8 ignore stop */
-
-  // await User.updateMany(
-  //   {
-  //     createdEvents: event._id,
-  //   },
-  //   {
-  //     $pull: {
-  //       createdEvents: event._id,
-  //     },
-  //   },
-  // );
-
-  // await User.updateMany(
-  //   {
-  //     eventAdmin: event._id,
-  //   },
-  //   {
-  //     $pull: {
-  //       eventAdmin: event._id,
-  //     },
-  //   },
-  // );
-
-  // const updatedEvent = await Event.findOneAndUpdate(
-  //   {
-  //     _id: event._id,
-  //   },
-  //   {
-  //     status: "DELETED",
-  //   },
-  //   {
-  //     new: true,
-  //   },
-  // );
-
-  // if (updatedEvent !== null) {
-  //   await cacheEvents([updatedEvent]);
-  // }
-
-  // await ActionItem.deleteMany({ eventId: event?._id });
 
   return event;
 };

--- a/src/typeDefs/enums.ts
+++ b/src/typeDefs/enums.ts
@@ -30,7 +30,7 @@ export const enums = gql`
     location_DESC
   }
 
-  enum RecurringEventUpdateType {
+  enum RecurringEventMutationType {
     AllInstances
     ThisInstance
     ThisAndFollowingInstances

--- a/src/typeDefs/mutations.ts
+++ b/src/typeDefs/mutations.ts
@@ -185,7 +185,10 @@ export const mutations = gql`
 
     removeDirectChat(chatId: ID!, organizationId: ID!): DirectChat! @auth
 
-    removeEvent(id: ID!): Event! @auth
+    removeEvent(
+      id: ID!
+      recurringEventDeleteType: RecurringEventMutationType
+    ): Event! @auth
 
     removeEventAttendee(data: EventAttendeeInput!): User! @auth
 
@@ -264,7 +267,7 @@ export const mutations = gql`
       id: ID!
       data: UpdateEventInput
       recurrenceRuleData: RecurrenceRuleInput
-      recurringEventUpdateType: RecurringEventUpdateType
+      recurringEventUpdateType: RecurringEventMutationType
     ): Event! @auth
 
     updateEventVolunteer(

--- a/src/types/generatedGraphQLTypes.ts
+++ b/src/types/generatedGraphQLTypes.ts
@@ -1405,6 +1405,7 @@ export type MutationRemoveDirectChatArgs = {
 
 export type MutationRemoveEventArgs = {
   id: Scalars['ID']['input'];
+  recurringEventDeleteType?: InputMaybe<RecurringEventMutationType>;
 };
 
 
@@ -1578,7 +1579,7 @@ export type MutationUpdateEventArgs = {
   data?: InputMaybe<UpdateEventInput>;
   id: Scalars['ID']['input'];
   recurrenceRuleData?: InputMaybe<RecurrenceRuleInput>;
-  recurringEventUpdateType?: InputMaybe<RecurringEventUpdateType>;
+  recurringEventUpdateType?: InputMaybe<RecurringEventMutationType>;
 };
 
 
@@ -2210,7 +2211,7 @@ export type RecurrenceRuleInput = {
   weekDays?: InputMaybe<Array<InputMaybe<WeekDays>>>;
 };
 
-export type RecurringEventUpdateType =
+export type RecurringEventMutationType =
   | 'AllInstances'
   | 'ThisAndFollowingInstances'
   | 'ThisInstance';
@@ -2827,7 +2828,7 @@ export type ResolversTypes = {
   RecaptchaVerification: RecaptchaVerification;
   Recurrance: Recurrance;
   RecurrenceRuleInput: RecurrenceRuleInput;
-  RecurringEventUpdateType: RecurringEventUpdateType;
+  RecurringEventMutationType: RecurringEventMutationType;
   SortedByOrder: SortedByOrder;
   Status: Status;
   String: ResolverTypeWrapper<Scalars['String']['output']>;

--- a/tests/helpers/events.ts
+++ b/tests/helpers/events.ts
@@ -25,7 +25,7 @@ export const createTestEvent = async (): Promise<
       description: `description${nanoid().toLowerCase()}`,
       allDay: true,
       startDate: new Date(),
-      recurring: true,
+      recurring: false,
       isPublic: true,
       isRegisterable: true,
       creatorId: testUser._id,

--- a/tests/resolvers/Mutation/removeEvent.spec.ts
+++ b/tests/resolvers/Mutation/removeEvent.spec.ts
@@ -1,9 +1,24 @@
 import "dotenv/config";
 import type mongoose from "mongoose";
 import { Types } from "mongoose";
-import { User, Event, ActionItem } from "../../../src/models";
-import type { MutationRemoveEventArgs } from "../../../src/types/generatedGraphQLTypes";
-import { connect, disconnect } from "../../helpers/db";
+import type {
+  InterfaceEvent} from "../../../src/models";
+import {
+  User,
+  Event,
+  ActionItem,
+  EventAttendee,
+} from "../../../src/models";
+import type {
+  MutationCreateEventArgs,
+  MutationRemoveEventArgs,
+  MutationUpdateEventArgs,
+} from "../../../src/types/generatedGraphQLTypes";
+import {
+  connect,
+  disconnect,
+  dropAllCollectionsFromDatabase,
+} from "../../helpers/db";
 
 import { removeEvent as removeEventResolver } from "../../../src/resolvers/Mutation/removeEvent";
 import {
@@ -20,16 +35,23 @@ import type { TestEventType } from "../../helpers/events";
 import { createTestEvent } from "../../helpers/events";
 import { cacheEvents } from "../../../src/services/EventCache/cacheEvents";
 import { createTestActionItems } from "../../helpers/actionItem";
+import { convertToUTCDate } from "../../../src/utilities/recurrenceDatesUtil";
+import { addMonths } from "date-fns";
+import { Frequency, RecurrenceRule } from "../../../src/models/RecurrenceRule";
+import { fail } from "assert";
 
 let MONGOOSE_INSTANCE: typeof mongoose;
 let testUser: TestUserType;
 let newTestUser: TestUserType;
 let testOrganization: TestOrganizationType;
 let testEvent: TestEventType;
+let testRecurringEvent: InterfaceEvent;
 let newTestEvent: TestEventType;
 
 beforeAll(async () => {
   MONGOOSE_INSTANCE = await connect();
+  await dropAllCollectionsFromDatabase(MONGOOSE_INSTANCE);
+
   const temp = await createTestEvent();
   testUser = temp[0];
   testOrganization = temp[1];
@@ -37,6 +59,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  await dropAllCollectionsFromDatabase(MONGOOSE_INSTANCE);
   await disconnect(MONGOOSE_INSTANCE);
 });
 
@@ -60,9 +83,13 @@ describe("resolvers -> Mutation -> removeEvent", () => {
       );
 
       await removeEventResolver?.({}, args, context);
-    } catch (error: any) {
+    } catch (error: unknown) {
       expect(spy).toBeCalledWith(USER_NOT_FOUND_ERROR.MESSAGE);
-      expect(error.message).toEqual(USER_NOT_FOUND_ERROR.MESSAGE);
+      if (error instanceof Error) {
+        expect(error.message).toEqual(USER_NOT_FOUND_ERROR.MESSAGE);
+      } else {
+        fail(`Expected NotDoundError, but got ${error}`);
+      }
     }
   });
 
@@ -85,9 +112,13 @@ describe("resolvers -> Mutation -> removeEvent", () => {
       );
 
       await removeEventResolver?.({}, args, context);
-    } catch (error: any) {
+    } catch (error: unknown) {
       expect(spy).toBeCalledWith(EVENT_NOT_FOUND_ERROR.MESSAGE);
-      expect(error.message).toEqual(EVENT_NOT_FOUND_ERROR.MESSAGE);
+      if (error instanceof Error) {
+        EVENT_NOT_FOUND_ERROR.MESSAGE;
+      } else {
+        fail(`Expected NotDoundError, but got ${error}`);
+      }
     }
   });
 
@@ -134,13 +165,17 @@ describe("resolvers -> Mutation -> removeEvent", () => {
       );
 
       await removeEventResolver?.({}, args, context);
-    } catch (error: any) {
+    } catch (error: unknown) {
       expect(spy).toBeCalledWith(USER_NOT_AUTHORIZED_ERROR.MESSAGE);
-      expect(error.message).toEqual(USER_NOT_AUTHORIZED_ERROR.MESSAGE);
+      if (error instanceof Error) {
+        USER_NOT_AUTHORIZED_ERROR.MESSAGE;
+      } else {
+        fail(`Expected UnauthorizedError, but got ${error}`);
+      }
     }
   });
 
-  it(`removes event with _id === args.id and returns it`, async () => {
+  it(`removes the single(non-recurring) event with _id === args.id and returns it`, async () => {
     await User.updateOne(
       {
         _id: testUser?._id,
@@ -223,5 +258,470 @@ describe("resolvers -> Mutation -> removeEvent", () => {
     });
 
     expect(deletedActionItems).toEqual([]);
+  });
+
+  it(`removes a single instance of a recurring event`, async () => {
+    let startDate = new Date();
+    startDate = convertToUTCDate(startDate);
+
+    const endDate = addMonths(startDate, 6);
+
+    const createEventArgs: MutationCreateEventArgs = {
+      data: {
+        organizationId: testOrganization?.id,
+        allDay: true,
+        description: "newDescription",
+        endDate,
+        isPublic: false,
+        isRegisterable: false,
+        latitude: 1,
+        longitude: 1,
+        location: "newLocation",
+        recurring: true,
+        startDate,
+        title: "newTitle",
+        recurrance: "WEEKLY",
+      },
+    };
+
+    const createEventContext = {
+      userId: testUser?.id,
+    };
+
+    const { createEvent: createEventResolver } = await import(
+      "../../../src/resolvers/Mutation/createEvent"
+    );
+
+    testRecurringEvent = (await createEventResolver?.(
+      {},
+      createEventArgs,
+      createEventContext,
+    )) as InterfaceEvent;
+
+    const recurrenceRule = await RecurrenceRule.findOne({
+      startDate,
+      endDate,
+      frequency: Frequency.WEEKLY,
+    });
+
+    const baseRecurringEvent = await Event.findOne({
+      isBaseRecurringEvent: true,
+      startDate: startDate.toUTCString(),
+    });
+
+    // find an event one week ahead of the testRecurringEvent and delete it
+    const recurringInstances = await Event.find({
+      recurrenceRuleId: testRecurringEvent?.recurrenceRuleId,
+    });
+
+    const recurringEventInstance = recurringInstances[1];
+
+    let attendeeExists = await EventAttendee.exists({
+      userId: testUser?._id,
+      eventId: recurringEventInstance?._id,
+    });
+
+    expect(attendeeExists).toBeTruthy();
+
+    let updatedTestUser = await User.findOne({
+      _id: testUser?._id,
+    })
+      .select(["eventAdmin", "createdEvents", "registeredEvents"])
+      .lean();
+
+    expect(updatedTestUser).toEqual(
+      expect.objectContaining({
+        eventAdmin: expect.arrayContaining([recurringEventInstance?._id]),
+        createdEvents: expect.arrayContaining([recurringEventInstance?._id]),
+        registeredEvents: expect.arrayContaining([recurringEventInstance?._id]),
+      }),
+    );
+
+    const args: MutationRemoveEventArgs = {
+      id: recurringEventInstance?._id.toString(),
+      recurringEventDeleteType: "ThisInstance",
+    };
+
+    const context = {
+      userId: testUser?.id,
+    };
+
+    const removeEventPayload = await removeEventResolver?.({}, args, context);
+
+    expect(removeEventPayload).toEqual(
+      expect.objectContaining({
+        allDay: true,
+        description: "newDescription",
+        isPublic: false,
+        recurrenceRuleId: recurrenceRule?._id.toString(),
+        baseRecurringEventId: baseRecurringEvent?._id.toString(),
+        startDate: recurringEventInstance.startDate,
+        isRegisterable: false,
+        latitude: 1,
+        longitude: 1,
+        location: "newLocation",
+        recurring: true,
+        title: "newTitle",
+        creatorId: testUser?._id,
+        admins: expect.arrayContaining([testUser?._id]),
+        organization: testOrganization?._id,
+      }),
+    );
+
+    attendeeExists = await EventAttendee.exists({
+      userId: testUser?._id,
+      eventId: recurringEventInstance?._id,
+    });
+
+    expect(attendeeExists).toBeFalsy();
+
+    updatedTestUser = await User.findOne({
+      _id: testUser?._id,
+    })
+      .select(["eventAdmin", "createdEvents", "registeredEvents"])
+      .lean();
+
+    expect(updatedTestUser).toEqual(
+      expect.objectContaining({
+        eventAdmin: expect.not.arrayContaining([recurringEventInstance?._id]),
+        createdEvents: expect.not.arrayContaining([
+          recurringEventInstance?._id,
+        ]),
+        registeredEvents: expect.not.arrayContaining([
+          recurringEventInstance?._id,
+        ]),
+      }),
+    );
+  });
+
+  it(`removes this and following instances of the recurring event`, async () => {
+    // find an event 10 weeks ahead of the testRecurringEvent
+    const recurringInstances = await Event.find({
+      recurrenceRuleId: testRecurringEvent?.recurrenceRuleId,
+    });
+
+    const recurringEventInstance = recurringInstances[10];
+
+    let attendeeExists = await EventAttendee.exists({
+      userId: testUser?._id,
+      eventId: recurringEventInstance?._id,
+    });
+
+    expect(attendeeExists).toBeTruthy();
+
+    let updatedTestUser = await User.findOne({
+      _id: testUser?._id,
+    })
+      .select(["eventAdmin", "createdEvents", "registeredEvents"])
+      .lean();
+
+    expect(updatedTestUser).toEqual(
+      expect.objectContaining({
+        eventAdmin: expect.arrayContaining([recurringEventInstance?._id]),
+        createdEvents: expect.arrayContaining([recurringEventInstance?._id]),
+        registeredEvents: expect.arrayContaining([recurringEventInstance?._id]),
+      }),
+    );
+
+    const args: MutationRemoveEventArgs = {
+      id: recurringEventInstance?._id.toString(),
+      recurringEventDeleteType: "ThisAndFollowingInstances",
+    };
+
+    const context = {
+      userId: testUser?.id,
+    };
+
+    const removeEventPayload = await removeEventResolver?.({}, args, context);
+
+    expect(removeEventPayload).toEqual(
+      expect.objectContaining({
+        allDay: true,
+        description: "newDescription",
+        isPublic: false,
+        recurrenceRuleId: recurringEventInstance.recurrenceRuleId.toString(),
+        baseRecurringEventId:
+          recurringEventInstance.baseRecurringEventId.toString(),
+        startDate: recurringEventInstance.startDate,
+        isRegisterable: false,
+        latitude: 1,
+        longitude: 1,
+        location: "newLocation",
+        recurring: true,
+        title: "newTitle",
+        creatorId: testUser?._id,
+        admins: expect.arrayContaining([testUser?._id]),
+        organization: testOrganization?._id,
+      }),
+    );
+
+    attendeeExists = await EventAttendee.exists({
+      userId: testUser?._id,
+      eventId: recurringEventInstance?._id,
+    });
+
+    expect(attendeeExists).toBeFalsy();
+
+    updatedTestUser = await User.findOne({
+      _id: testUser?._id,
+    })
+      .select(["eventAdmin", "createdEvents", "registeredEvents"])
+      .lean();
+
+    expect(updatedTestUser).toEqual(
+      expect.objectContaining({
+        eventAdmin: expect.not.arrayContaining([recurringEventInstance?._id]),
+        createdEvents: expect.not.arrayContaining([
+          recurringEventInstance?._id,
+        ]),
+        registeredEvents: expect.not.arrayContaining([
+          recurringEventInstance?._id,
+        ]),
+      }),
+    );
+  });
+
+  it(`changes the recurrencerule and deletes the new series`, async () => {
+    // find an event 7 weeks ahead of the testRecurringEvent
+    // and update it to follow a new recurrence series
+    const recurringInstances = await Event.find({
+      recurrenceRuleId: testRecurringEvent?.recurrenceRuleId,
+    });
+
+    let recurringEventInstance = recurringInstances[7] as InterfaceEvent;
+
+    let attendeeExists = await EventAttendee.exists({
+      userId: testUser?._id,
+      eventId: recurringEventInstance?._id,
+    });
+
+    expect(attendeeExists).toBeTruthy();
+
+    let updatedTestUser = await User.findOne({
+      _id: testUser?._id,
+    })
+      .select(["eventAdmin", "createdEvents", "registeredEvents"])
+      .lean();
+
+    expect(updatedTestUser).toEqual(
+      expect.objectContaining({
+        eventAdmin: expect.arrayContaining([recurringEventInstance?._id]),
+        createdEvents: expect.arrayContaining([recurringEventInstance?._id]),
+        registeredEvents: expect.arrayContaining([recurringEventInstance?._id]),
+      }),
+    );
+
+    const updateEventArgs: MutationUpdateEventArgs = {
+      id: recurringEventInstance?._id.toString(),
+      data: {
+        title: "update the recurrence rule of this and following instances",
+      },
+      recurrenceRuleData: {
+        frequency: "DAILY",
+      },
+      recurringEventUpdateType: "ThisAndFollowingInstances",
+    };
+
+    const updateEventContext = {
+      userId: testUser?._id,
+    };
+
+    const { updateEvent: updateEventResolver } = await import(
+      "../../../src/resolvers/Mutation/updateEvent"
+    );
+
+    recurringEventInstance = (await updateEventResolver?.(
+      {},
+      updateEventArgs,
+      updateEventContext,
+    )) as InterfaceEvent;
+
+    const args: MutationRemoveEventArgs = {
+      id: recurringEventInstance?._id.toString(),
+      recurringEventDeleteType: "ThisAndFollowingInstances",
+    };
+
+    const context = {
+      userId: testUser?.id,
+    };
+
+    const removeEventPayload = await removeEventResolver?.({}, args, context);
+
+    expect(removeEventPayload).toEqual(
+      expect.objectContaining({
+        allDay: true,
+        description: "newDescription",
+        isPublic: false,
+        recurrenceRuleId: recurringEventInstance.recurrenceRuleId.toString(),
+        baseRecurringEventId:
+          recurringEventInstance.baseRecurringEventId.toString(),
+        startDate: recurringEventInstance.startDate,
+        isRegisterable: false,
+        latitude: 1,
+        longitude: 1,
+        location: "newLocation",
+        recurring: true,
+        title: "update the recurrence rule of this and following instances",
+        creatorId: testUser?._id,
+        admins: expect.arrayContaining([testUser?._id]),
+        organization: testOrganization?._id,
+      }),
+    );
+
+    attendeeExists = await EventAttendee.exists({
+      userId: testUser?._id,
+      eventId: recurringEventInstance?._id,
+    });
+
+    expect(attendeeExists).toBeFalsy();
+
+    updatedTestUser = await User.findOne({
+      _id: testUser?._id,
+    })
+      .select(["eventAdmin", "createdEvents", "registeredEvents"])
+      .lean();
+
+    expect(updatedTestUser).toEqual(
+      expect.objectContaining({
+        eventAdmin: expect.not.arrayContaining([recurringEventInstance?._id]),
+        createdEvents: expect.not.arrayContaining([
+          recurringEventInstance?._id,
+        ]),
+        registeredEvents: expect.not.arrayContaining([
+          recurringEventInstance?._id,
+        ]),
+      }),
+    );
+  });
+
+  it(`removes all the instances of a recurring event except the exception instance`, async () => {
+    // find an event 6 weeks ahead of the testRecurringEvent
+    // and make it an exception
+    const recurringInstances = await Event.find({
+      recurrenceRuleId: testRecurringEvent?.recurrenceRuleId,
+    });
+
+    const recurringEventExceptionInstance =
+      recurringInstances[6] as InterfaceEvent;
+
+    const exceptionInstanceAttendeeExists = await EventAttendee.exists({
+      userId: testUser?._id,
+      eventId: recurringEventExceptionInstance?._id,
+    });
+
+    expect(exceptionInstanceAttendeeExists).toBeTruthy();
+
+    let attendeeExists = await EventAttendee.exists({
+      userId: testUser?._id,
+      eventId: testRecurringEvent?._id,
+    });
+
+    expect(attendeeExists).toBeTruthy();
+
+    let updatedTestUser = await User.findOne({
+      _id: testUser?._id,
+    })
+      .select(["eventAdmin", "createdEvents", "registeredEvents"])
+      .lean();
+
+    expect(updatedTestUser).toEqual(
+      expect.objectContaining({
+        eventAdmin: expect.arrayContaining([
+          testRecurringEvent?._id,
+          recurringEventExceptionInstance?._id,
+        ]),
+        createdEvents: expect.arrayContaining([
+          testRecurringEvent?._id,
+          recurringEventExceptionInstance?._id,
+        ]),
+        registeredEvents: expect.arrayContaining([
+          testRecurringEvent?._id,
+          recurringEventExceptionInstance?._id,
+        ]),
+      }),
+    );
+
+    await Event.updateOne(
+      {
+        _id: recurringEventExceptionInstance?._id,
+      },
+      {
+        isRecurringEventException: true,
+      },
+    );
+
+    const args: MutationRemoveEventArgs = {
+      id: testRecurringEvent?._id.toString(),
+      recurringEventDeleteType: "AllInstances",
+    };
+
+    const context = {
+      userId: testUser?.id,
+    };
+
+    const removeEventPayload = await removeEventResolver?.({}, args, context);
+
+    expect(removeEventPayload).toEqual(
+      expect.objectContaining({
+        allDay: true,
+        description: "newDescription",
+        isPublic: false,
+        recurrenceRuleId: testRecurringEvent.recurrenceRuleId.toString(),
+        baseRecurringEventId:
+          testRecurringEvent.baseRecurringEventId.toString(),
+        startDate: testRecurringEvent.startDate,
+        isRegisterable: false,
+        latitude: 1,
+        longitude: 1,
+        location: "newLocation",
+        recurring: true,
+        title: "newTitle",
+        creatorId: testUser?._id,
+        admins: expect.arrayContaining([testUser?._id]),
+        organization: testOrganization?._id,
+      }),
+    );
+
+    attendeeExists = await EventAttendee.exists({
+      userId: testUser?._id,
+      eventId: testRecurringEvent?._id,
+    });
+
+    expect(attendeeExists).toBeFalsy();
+
+    attendeeExists = await EventAttendee.exists({
+      userId: testUser?._id,
+      eventId: recurringEventExceptionInstance?._id,
+    });
+
+    expect(attendeeExists).toBeTruthy();
+
+    updatedTestUser = await User.findOne({
+      _id: testUser?._id,
+    })
+      .select(["eventAdmin", "createdEvents", "registeredEvents"])
+      .lean();
+
+    expect(updatedTestUser).toEqual(
+      expect.objectContaining({
+        eventAdmin: expect.not.arrayContaining([testRecurringEvent?._id]),
+        createdEvents: expect.not.arrayContaining([testRecurringEvent?._id]),
+        registeredEvents: expect.not.arrayContaining([testRecurringEvent?._id]),
+      }),
+    );
+
+    expect(updatedTestUser).toEqual(
+      expect.objectContaining({
+        eventAdmin: expect.arrayContaining([
+          recurringEventExceptionInstance?._id,
+        ]),
+        createdEvents: expect.arrayContaining([
+          recurringEventExceptionInstance?._id,
+        ]),
+        registeredEvents: expect.arrayContaining([
+          recurringEventExceptionInstance?._id,
+        ]),
+      }),
+    );
   });
 });

--- a/tests/resolvers/Mutation/removeEvent.spec.ts
+++ b/tests/resolvers/Mutation/removeEvent.spec.ts
@@ -1,14 +1,8 @@
 import "dotenv/config";
 import type mongoose from "mongoose";
 import { Types } from "mongoose";
-import type {
-  InterfaceEvent} from "../../../src/models";
-import {
-  User,
-  Event,
-  ActionItem,
-  EventAttendee,
-} from "../../../src/models";
+import type { InterfaceEvent } from "../../../src/models";
+import { User, Event, ActionItem, EventAttendee } from "../../../src/models";
 import type {
   MutationCreateEventArgs,
   MutationRemoveEventArgs,
@@ -229,13 +223,11 @@ describe("resolvers -> Mutation -> removeEvent", () => {
     expect(updatedTestUser?.createdEvents).toEqual([]);
     expect(updatedTestUser?.eventAdmin).toEqual([]);
 
-    const updatedTestEvent = await Event.findOne({
+    const testEventExists = await Event.exists({
       _id: testEvent?._id,
-    })
-      .select(["status"])
-      .lean();
+    });
 
-    expect(updatedTestEvent?.status).toEqual("DELETED");
+    expect(testEventExists).toBeFalsy();
   });
 
   it(`removes the events and all action items assiciated with it`, async () => {


### PR DESCRIPTION
### What kind of change does this PR introduce?

It implements the functionality for deleting recurring events: this instance, this and following instances, and all instances.

### Issue Number:

Fixes #1583 

### Did you add tests for your changes?

Yes

### Snapshots/Videos:

1. **Deleting this instance only**:

https://github.com/PalisadoesFoundation/talawa-api/assets/55585268/6b9abf95-8481-4a57-8be6-d02cee998a4e

2. **Deleting this and the following instances**:

https://github.com/PalisadoesFoundation/talawa-api/assets/55585268/a4e2404d-d5a7-45a6-96d7-8e84a92abdd7

3. **Deleting all the instances (except the exception instance)**:

https://github.com/PalisadoesFoundation/talawa-api/assets/55585268/f611805a-d87c-494a-b79c-975da20a66b5


### Additional Context

> **For creation and management of recurring events, we're following [this](https://meetulr.github.io/Recurrence-Plan/) approach. Please refer to the corresponding section in there for a refresher.**

This is the 4th and final PR in the series for this issue, implementing delete functionality for recurring events.
With this, CRUD for recurring events would be complete.

**Previous PR**: #1884 (updating single and recurring events)