### PR TITLE
changed eslint typescript no explicit any rule to warn

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -65,13 +65,12 @@
 
     // Typescript Rules
     "@typescript-eslint/ban-ts-comment": "error",
-    "@typescript-eslint/no-explicit-any": "error",
-    "@typescript-eslint/no-inferrable-types": "error",
+    "@typescript-eslint/ban-types": "error",
+    "@typescript-eslint/no-duplicate-enum-values": "error",
+    "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/no-non-null-asserted-optional-chain": "error",
     "@typescript-eslint/no-non-null-assertion": "error",
     "@typescript-eslint/no-var-requires": "error",
-    "@typescript-eslint/ban-types": "error",
-    "@typescript-eslint/no-duplicate-enum-values": "error",
 
     // Typescript rule to enforce PascalCase naming convention for types and interfaces
     "@typescript-eslint/naming-convention": [


### PR DESCRIPTION
**What kind of change does this PR introduce?**

refactor

**Issue Number:**

Fixes #1944

**Did you add tests for your changes?**

Not required

**Snapshots/Videos:**

-

**If relevant, did you update the documentation?**

-

**Summary**

Explained in the issue #1944

`"@typescript-eslint/no-inferrable-types"` rule is deleted, because explicit typing increases the performance of typescript language server and reduces the time it takes to type check the codebase.

**Does this PR introduce a breaking change?**

-

**Other information**

-

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes
