### PR TITLE
Fixed continuous loading in 'Users' tab

### DIFF
--- a/sample_data/appUserProfiles.json
+++ b/sample_data/appUserProfiles.json
@@ -177,7 +177,7 @@
   },
   {
     "_id": "64378abd85308f171cf2993d",
-    "userId": "6589389a2caa9d8d69087487",
+    "userId": "6589389d2caa9d8d69087487",
     "adminFor": [],
     "appLanguageCode": "en",
     "createdEvents": [],
@@ -193,7 +193,7 @@
   },
   {
     "_id": "64378abd85408f171cf2993d",
-    "userId": "658938aa2caa9d8d69087488",
+    "userId": "658938a62caa9d8d69087488",
     "adminFor": [],
     "appLanguageCode": "en",
     "createdEvents": [],
@@ -209,7 +209,7 @@
   },
   {
     "_id": "64378abd85508f171cf2993d",
-    "userId": "658938b92caa9d8d69087489",
+    "userId": "658938b02caa9d8d69087489",
     "adminFor": [],
     "appLanguageCode": "en",
     "createdEvents": [],

--- a/src/resolvers/Query/users.ts
+++ b/src/resolvers/Query/users.ts
@@ -92,7 +92,15 @@ export const users: QueryResolvers["users"] = async (
               ? user.organizationsBlockedBy
               : [],
         },
-        appUserProfile: appUserProfile as InterfaceAppUserProfile,
+        appUserProfile: (appUserProfile as InterfaceAppUserProfile) || {
+          _id: "",
+          adminApproved: false,
+          adminFor: [],
+          isSuperAdmin: false,
+          createdOrganizations: [],
+          createdEvents: [],
+          eventAdmin: [],
+        },
       };
     }),
   );

--- a/tests/resolvers/Query/users.spec.ts
+++ b/tests/resolvers/Query/users.spec.ts
@@ -206,6 +206,17 @@ describe("resolvers -> Query -> users", () => {
           },
         },
       );
+
+      await User.updateOne(
+        {
+          userId: testUsers[4]._id,
+        },
+        {
+          $set: { appUserProfileId: null },
+        },
+      );
+
+      await AppUserProfile.deleteOne({ userId: testUsers[4]._id });
     });
 
     it(`returns empty array for organizationsBlockedBy fields when the client is a normal user`, async () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
A bugfix.

**Issue Number:**

Fixes #2047 

**Did you add tests for your changes?**
No.

**Snapshots/Videos:**
![image](https://github.com/PalisadoesFoundation/talawa-api/assets/135227614/c7133b6b-e43e-4530-9a78-b9590d41ea7c)
It's loading now.

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**
In the follwoing PR, I corrected some appUserProfiles which had incorrect userId and made the users resolver return a default value for appUserProfile when appUserProfile was `null`.

**Does this PR introduce a breaking change?**
No.

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes.
