### PR TITLE
feat: Add `recurrenceRule` field resolver, and more recurrence properties

### DIFF
--- a/codegen.ts
+++ b/codegen.ts
@@ -93,6 +93,8 @@ const config: CodegenConfig = {
 
           Post: "../models/Post#InterfacePost",
 
+          RecurrenceRule: "../models/RecurrenceRule#InterfaceRecurrenceRule",
+
           UserTag: "../models/OrganizationTagUser#InterfaceOrganizationTagUser",
 
           User: "../models/User#InterfaceUser",

--- a/schema.graphql
+++ b/schema.graphql
@@ -604,6 +604,7 @@ type Event {
   longitude: Longitude
   organization: Organization
   recurrance: Recurrance
+  recurrenceRule: RecurrenceRule
   recurring: Boolean!
   startDate: Date!
   startTime: Time
@@ -1404,9 +1405,17 @@ enum Recurrance {
   YEARLY
 }
 
+type RecurrenceRule {
+  count: Int
+  frequency: Frequency
+  interval: Int
+  weekDays: [WeekDays]
+}
+
 input RecurrenceRuleInput {
   count: Int
   frequency: Frequency
+  interval: Int
   weekDays: [WeekDays]
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1406,16 +1406,18 @@ enum Recurrance {
 }
 
 type RecurrenceRule {
-  count: Int
+  count: PositiveInt
   frequency: Frequency
-  interval: Int
+  interval: PositiveInt
+  weekDayOccurenceInMonth: Int
   weekDays: [WeekDays]
 }
 
 input RecurrenceRuleInput {
-  count: Int
+  count: PositiveInt
   frequency: Frequency
-  interval: Int
+  interval: PositiveInt
+  weekDayOccurenceInMonth: Int
   weekDays: [WeekDays]
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1850,13 +1850,13 @@ input VenueInput {
 }
 
 enum WeekDays {
-  FR
-  MO
-  SA
-  SU
-  TH
-  TU
-  WE
+  FRIDAY
+  MONDAY
+  SATURDAY
+  SUNDAY
+  THURSDAY
+  TUESDAY
+  WEDNESDAY
 }
 
 input createChatInput {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -703,6 +703,16 @@ export const RECURRENCE_WEEKDAYS = [
   "SUNDAY",
 ];
 
+export const RECURRENCE_WEEKDAYS_MAPPING = {
+  MONDAY: "MO",
+  TUESDAY: "TU",
+  WEDNESDAY: "WE",
+  THURSDAY: "TH",
+  FRIDAY: "FR",
+  SATURDAY: "SA",
+  SUNDAY: "SU",
+};
+
 export const key = ENV.ENCRYPTION_KEY as string;
 export const iv = crypto.randomBytes(16).toString("hex");
 

--- a/src/helpers/event/recurringEventHelpers/createRecurrenceRule.ts
+++ b/src/helpers/event/recurringEventHelpers/createRecurrenceRule.ts
@@ -33,7 +33,7 @@ export const createRecurrenceRule = async (
 ): Promise<InterfaceRecurrenceRule> => {
   const recurrenceRuleObject = rrulestr(recurrenceRuleString);
 
-  const { freq, byweekday } = recurrenceRuleObject.options;
+  const { freq, byweekday, interval, count } = recurrenceRuleObject.options;
 
   const weekDays: string[] = [];
   if (byweekday) {
@@ -53,8 +53,9 @@ export const createRecurrenceRule = async (
         startDate: recurrenceStartDate,
         endDate: recurrenceEndDate,
         frequency,
-        count: recurrenceRuleObject.options.count,
         weekDays,
+        interval,
+        count,
         latestInstanceDate,
       },
     ],

--- a/src/helpers/event/recurringEventHelpers/createRecurrenceRule.ts
+++ b/src/helpers/event/recurringEventHelpers/createRecurrenceRule.ts
@@ -33,7 +33,10 @@ export const createRecurrenceRule = async (
 ): Promise<InterfaceRecurrenceRule> => {
   const recurrenceRuleObject = rrulestr(recurrenceRuleString);
 
-  const { freq, byweekday, interval, count } = recurrenceRuleObject.options;
+  const { freq, byweekday, interval, count, bysetpos } =
+    recurrenceRuleObject.options;
+
+  const frequency = RECURRENCE_FREQUENCIES[freq];
 
   const weekDays: string[] = [];
   if (byweekday) {
@@ -42,7 +45,10 @@ export const createRecurrenceRule = async (
     }
   }
 
-  const frequency = RECURRENCE_FREQUENCIES[freq];
+  let weekDayOccurenceInMonth = undefined;
+  if (bysetpos?.length) {
+    weekDayOccurenceInMonth = bysetpos[0];
+  }
 
   const recurrenceRule = await RecurrenceRule.create(
     [
@@ -56,6 +62,7 @@ export const createRecurrenceRule = async (
         weekDays,
         interval,
         count,
+        weekDayOccurenceInMonth,
         latestInstanceDate,
       },
     ],

--- a/src/helpers/event/recurringEventHelpers/generateRecurrenceRuleString.ts
+++ b/src/helpers/event/recurringEventHelpers/generateRecurrenceRuleString.ts
@@ -28,7 +28,7 @@ export const generateRecurrenceRuleString = (
   }
 
   // destructure the recurrence rules
-  const { frequency, count, weekDays } = recurrenceRuleData;
+  const { frequency, weekDays, interval, count } = recurrenceRuleData;
 
   // string representing the days of the week the event would recur
   const weekDaysString = weekDays?.length ? weekDays.join(",") : "";
@@ -38,6 +38,11 @@ export const generateRecurrenceRuleString = (
 
   if (recurrenceEndDateString) {
     recurrenceRuleString += `;UNTIL=${recurrenceEndDateString}`;
+  }
+
+  if (interval) {
+    // interval of recurrence
+    recurrenceRuleString += `;INTERVAL=${interval}`;
   }
 
   if (count) {

--- a/src/helpers/event/recurringEventHelpers/generateRecurrenceRuleString.ts
+++ b/src/helpers/event/recurringEventHelpers/generateRecurrenceRuleString.ts
@@ -28,7 +28,8 @@ export const generateRecurrenceRuleString = (
   }
 
   // destructure the recurrence rules
-  const { frequency, weekDays, interval, count } = recurrenceRuleData;
+  const { frequency, weekDays, interval, count, weekDayOccurenceInMonth } =
+    recurrenceRuleData;
 
   // string representing the days of the week the event would recur
   const weekDaysString = weekDays?.length ? weekDays.join(",") : "";
@@ -48,6 +49,12 @@ export const generateRecurrenceRuleString = (
   if (count) {
     // maximum number of instances to generate
     recurrenceRuleString += `;COUNT=${count}`;
+  }
+
+  if (weekDayOccurenceInMonth) {
+    // occurence of week day in month
+    // i.e. 1 = first monday, 3 = third monday, -1 = last monday
+    recurrenceRuleString += `;BYSETPOS=${weekDayOccurenceInMonth}`;
   }
 
   if (weekDaysString) {

--- a/src/helpers/event/recurringEventHelpers/generateRecurrenceRuleString.ts
+++ b/src/helpers/event/recurringEventHelpers/generateRecurrenceRuleString.ts
@@ -1,3 +1,4 @@
+import { RECURRENCE_WEEKDAYS_MAPPING } from "../../../constants";
 import type { RecurrenceRuleInput } from "../../../types/generatedGraphQLTypes";
 import { convertToRRuleDateString } from "../../../utilities/recurrenceDatesUtil";
 
@@ -31,8 +32,17 @@ export const generateRecurrenceRuleString = (
   const { frequency, weekDays, interval, count, weekDayOccurenceInMonth } =
     recurrenceRuleData;
 
+  // get weekdays for recurrence rule string, i.e. "MO", "TU", etc.
+  const recurrenceWeekDays = weekDays?.map((weekDay) => {
+    if (weekDay) {
+      return RECURRENCE_WEEKDAYS_MAPPING[weekDay];
+    }
+  });
+
   // string representing the days of the week the event would recur
-  const weekDaysString = weekDays?.length ? weekDays.join(",") : "";
+  const weekDaysString = recurrenceWeekDays?.length
+    ? recurrenceWeekDays.join(",")
+    : "";
 
   // initiate recurrence rule string
   let recurrenceRuleString = `DTSTART:${recurrenceStartDateString}\nRRULE:FREQ=${frequency}`;

--- a/src/models/RecurrenceRule.ts
+++ b/src/models/RecurrenceRule.ts
@@ -34,6 +34,7 @@ export interface InterfaceRecurrenceRule {
   weekDays: WeekDays[];
   interval: number;
   count: number;
+  weekDayOccurenceInMonth: number;
   latestInstanceDate: Date;
 }
 
@@ -48,6 +49,7 @@ export interface InterfaceRecurrenceRule {
  * @param weekDays - Array containing the days of the week the recurring instance occurs
  * @param interval - Interval of recurrence (i.e. 1 = every week, 2 = every other week, etc.)
  * @param count - Number of recurring instances
+ * @param weekDayOccurenceInMonth - Occurence of week day in the month (i.e. 1 = first monday, 3 = third monday, -1 = last monday)
  * @param latestInstanceDate - The startDate of the last recurring instance generated using this recurrence rule
  */
 
@@ -91,6 +93,10 @@ const recurrenceRuleSchema = new Schema(
       default: 1,
     },
     count: {
+      type: Number,
+      required: false,
+    },
+    weekDayOccurenceInMonth: {
       type: Number,
       required: false,
     },

--- a/src/models/RecurrenceRule.ts
+++ b/src/models/RecurrenceRule.ts
@@ -31,8 +31,9 @@ export interface InterfaceRecurrenceRule {
   startDate: Date;
   endDate: Date;
   frequency: Frequency;
-  count: number;
   weekDays: WeekDays[];
+  interval: number;
+  count: number;
   latestInstanceDate: Date;
 }
 
@@ -44,8 +45,9 @@ export interface InterfaceRecurrenceRule {
  * @param startDate - Start date of the recurrence pattern (not necessarily the startDate of the first recurring instance)
  * @param endDate - Start date of the recurrence pattern (not necessarily the startDate of the last recurring instance)
  * @param frequency - Frequency of recurrence
- * @param count - Number of recurring instances
  * @param weekDays - Array containing the days of the week the recurring instance occurs
+ * @param interval - Interval of recurrence (i.e. 1 = every week, 2 = every other week, etc.)
+ * @param count - Number of recurring instances
  * @param latestInstanceDate - The startDate of the last recurring instance generated using this recurrence rule
  */
 
@@ -78,14 +80,19 @@ const recurrenceRuleSchema = new Schema(
       required: true,
       enum: Object.values(Frequency),
     },
-    count: {
-      type: Number,
-      required: false,
-    },
     weekDays: { type: [String], required: true, enum: Object.values(WeekDays) },
     latestInstanceDate: {
       type: Date,
       required: true,
+    },
+    interval: {
+      type: Number,
+      required: false,
+      default: 1,
+    },
+    count: {
+      type: Number,
+      required: false,
     },
   },
   {

--- a/src/resolvers/Event/index.ts
+++ b/src/resolvers/Event/index.ts
@@ -6,6 +6,7 @@ import { feedback } from "./feedback";
 import { organization } from "./organization";
 import { actionItems } from "./actionItems";
 import { creator } from "./creator";
+import { recurrenceRule } from "./recurrenceRule";
 
 export const Event: EventResolvers = {
   actionItems,
@@ -15,4 +16,5 @@ export const Event: EventResolvers = {
   feedback,
   organization,
   creator,
+  recurrenceRule,
 };

--- a/src/resolvers/Event/recurrenceRule.ts
+++ b/src/resolvers/Event/recurrenceRule.ts
@@ -1,0 +1,16 @@
+import type { EventResolvers } from "../../types/generatedGraphQLTypes";
+import { RecurrenceRule } from "../../models/RecurrenceRule";
+
+/**
+ * This resolver function will fetch and return the recurrenceRule that the event is following.
+ * @param parent - An object that is the return value of the resolver for this field's parent.
+ * @returns An object that contains the RecurrenceRule of the event.
+ */
+
+export const recurrenceRule: EventResolvers["recurrenceRule"] = async (
+  parent,
+) => {
+  return await RecurrenceRule.findOne({
+    _id: parent.recurrenceRuleId,
+  }).lean();
+};

--- a/src/typeDefs/enums.ts
+++ b/src/typeDefs/enums.ts
@@ -118,13 +118,13 @@ export const enums = gql`
   }
 
   enum WeekDays {
-    MO
-    TU
-    WE
-    TH
-    FR
-    SA
-    SU
+    MONDAY
+    TUESDAY
+    WEDNESDAY
+    THURSDAY
+    FRIDAY
+    SATURDAY
+    SUNDAY
   }
 
   enum EducationGrade {

--- a/src/typeDefs/inputs.ts
+++ b/src/typeDefs/inputs.ts
@@ -352,6 +352,7 @@ export const inputs = gql`
   input RecurrenceRuleInput {
     frequency: Frequency
     weekDays: [WeekDays]
+    interval: Int
     count: Int
   }
 

--- a/src/typeDefs/inputs.ts
+++ b/src/typeDefs/inputs.ts
@@ -352,8 +352,9 @@ export const inputs = gql`
   input RecurrenceRuleInput {
     frequency: Frequency
     weekDays: [WeekDays]
-    interval: Int
-    count: Int
+    interval: PositiveInt
+    count: PositiveInt
+    weekDayOccurenceInMonth: Int
   }
 
   input SocialMediaUrlsInput {

--- a/src/typeDefs/types.ts
+++ b/src/typeDefs/types.ts
@@ -523,8 +523,9 @@ export const types = gql`
   type RecurrenceRule {
     frequency: Frequency
     weekDays: [WeekDays]
-    interval: Int
-    count: Int
+    interval: PositiveInt
+    count: PositiveInt
+    weekDayOccurenceInMonth: Int
   }
 
   type SocialMediaUrls {

--- a/src/typeDefs/types.ts
+++ b/src/typeDefs/types.ts
@@ -230,6 +230,7 @@ export const types = gql`
     endTime: Time
     allDay: Boolean!
     recurring: Boolean!
+    recurrenceRule: RecurrenceRule
     recurrance: Recurrance
     isPublic: Boolean!
     isRegisterable: Boolean!
@@ -517,6 +518,13 @@ export const types = gql`
     likeCount: Int
     commentCount: Int
     pinned: Boolean
+  }
+
+  type RecurrenceRule {
+    frequency: Frequency
+    weekDays: [WeekDays]
+    interval: Int
+    count: Int
   }
 
   type SocialMediaUrls {

--- a/src/types/generatedGraphQLTypes.ts
+++ b/src/types/generatedGraphQLTypes.ts
@@ -674,6 +674,7 @@ export type Event = {
   longitude?: Maybe<Scalars['Longitude']['output']>;
   organization?: Maybe<Organization>;
   recurrance?: Maybe<Recurrance>;
+  recurrenceRule?: Maybe<RecurrenceRule>;
   recurring: Scalars['Boolean']['output'];
   startDate: Scalars['Date']['output'];
   startTime?: Maybe<Scalars['Time']['output']>;
@@ -2411,9 +2412,18 @@ export type Recurrance =
   | 'WEEKLY'
   | 'YEARLY';
 
+export type RecurrenceRule = {
+  __typename?: 'RecurrenceRule';
+  count?: Maybe<Scalars['Int']['output']>;
+  frequency?: Maybe<Frequency>;
+  interval?: Maybe<Scalars['Int']['output']>;
+  weekDays?: Maybe<Array<Maybe<WeekDays>>>;
+};
+
 export type RecurrenceRuleInput = {
   count?: InputMaybe<Scalars['Int']['input']>;
   frequency?: InputMaybe<Frequency>;
+  interval?: InputMaybe<Scalars['Int']['input']>;
   weekDays?: InputMaybe<Array<InputMaybe<WeekDays>>>;
 };
 
@@ -3105,6 +3115,7 @@ export type ResolversTypes = {
   Query: ResolverTypeWrapper<{}>;
   RecaptchaVerification: RecaptchaVerification;
   Recurrance: Recurrance;
+  RecurrenceRule: ResolverTypeWrapper<RecurrenceRule>;
   RecurrenceRuleInput: RecurrenceRuleInput;
   RecurringEventMutationType: RecurringEventMutationType;
   SocialMediaUrls: ResolverTypeWrapper<SocialMediaUrls>;
@@ -3276,6 +3287,7 @@ export type ResolversParentTypes = {
   PostsConnection: Omit<PostsConnection, 'edges'> & { edges: Array<ResolversParentTypes['PostEdge']> };
   Query: {};
   RecaptchaVerification: RecaptchaVerification;
+  RecurrenceRule: RecurrenceRule;
   RecurrenceRuleInput: RecurrenceRuleInput;
   SocialMediaUrls: SocialMediaUrls;
   SocialMediaUrlsInput: SocialMediaUrlsInput;
@@ -3641,6 +3653,7 @@ export type EventResolvers<ContextType = any, ParentType extends ResolversParent
   longitude?: Resolver<Maybe<ResolversTypes['Longitude']>, ParentType, ContextType>;
   organization?: Resolver<Maybe<ResolversTypes['Organization']>, ParentType, ContextType>;
   recurrance?: Resolver<Maybe<ResolversTypes['Recurrance']>, ParentType, ContextType>;
+  recurrenceRule?: Resolver<Maybe<ResolversTypes['RecurrenceRule']>, ParentType, ContextType>;
   recurring?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   startDate?: Resolver<ResolversTypes['Date'], ParentType, ContextType>;
   startTime?: Resolver<Maybe<ResolversTypes['Time']>, ParentType, ContextType>;
@@ -4157,6 +4170,14 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   venue?: Resolver<Maybe<ResolversTypes['Venue']>, ParentType, ContextType, RequireFields<QueryVenueArgs, 'id'>>;
 };
 
+export type RecurrenceRuleResolvers<ContextType = any, ParentType extends ResolversParentTypes['RecurrenceRule'] = ResolversParentTypes['RecurrenceRule']> = {
+  count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  frequency?: Resolver<Maybe<ResolversTypes['Frequency']>, ParentType, ContextType>;
+  interval?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  weekDays?: Resolver<Maybe<Array<Maybe<ResolversTypes['WeekDays']>>>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type SocialMediaUrlsResolvers<ContextType = any, ParentType extends ResolversParentTypes['SocialMediaUrls'] = ResolversParentTypes['SocialMediaUrls']> = {
   facebook?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   gitHub?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -4391,6 +4412,7 @@ export type Resolvers<ContextType = any> = {
   PostEdge?: PostEdgeResolvers<ContextType>;
   PostsConnection?: PostsConnectionResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
+  RecurrenceRule?: RecurrenceRuleResolvers<ContextType>;
   SocialMediaUrls?: SocialMediaUrlsResolvers<ContextType>;
   Subscription?: SubscriptionResolvers<ContextType>;
   Time?: GraphQLScalarType;

--- a/src/types/generatedGraphQLTypes.ts
+++ b/src/types/generatedGraphQLTypes.ts
@@ -2414,16 +2414,18 @@ export type Recurrance =
 
 export type RecurrenceRule = {
   __typename?: 'RecurrenceRule';
-  count?: Maybe<Scalars['Int']['output']>;
+  count?: Maybe<Scalars['PositiveInt']['output']>;
   frequency?: Maybe<Frequency>;
-  interval?: Maybe<Scalars['Int']['output']>;
+  interval?: Maybe<Scalars['PositiveInt']['output']>;
+  weekDayOccurenceInMonth?: Maybe<Scalars['Int']['output']>;
   weekDays?: Maybe<Array<Maybe<WeekDays>>>;
 };
 
 export type RecurrenceRuleInput = {
-  count?: InputMaybe<Scalars['Int']['input']>;
+  count?: InputMaybe<Scalars['PositiveInt']['input']>;
   frequency?: InputMaybe<Frequency>;
-  interval?: InputMaybe<Scalars['Int']['input']>;
+  interval?: InputMaybe<Scalars['PositiveInt']['input']>;
+  weekDayOccurenceInMonth?: InputMaybe<Scalars['Int']['input']>;
   weekDays?: InputMaybe<Array<InputMaybe<WeekDays>>>;
 };
 
@@ -4171,9 +4173,10 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
 };
 
 export type RecurrenceRuleResolvers<ContextType = any, ParentType extends ResolversParentTypes['RecurrenceRule'] = ResolversParentTypes['RecurrenceRule']> = {
-  count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  count?: Resolver<Maybe<ResolversTypes['PositiveInt']>, ParentType, ContextType>;
   frequency?: Resolver<Maybe<ResolversTypes['Frequency']>, ParentType, ContextType>;
-  interval?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  interval?: Resolver<Maybe<ResolversTypes['PositiveInt']>, ParentType, ContextType>;
+  weekDayOccurenceInMonth?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   weekDays?: Resolver<Maybe<Array<Maybe<ResolversTypes['WeekDays']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };

--- a/src/types/generatedGraphQLTypes.ts
+++ b/src/types/generatedGraphQLTypes.ts
@@ -31,6 +31,7 @@ import type { InterfaceOrganization as InterfaceOrganizationModel } from '../mod
 import type { InterfacePlugin as InterfacePluginModel } from '../models/Plugin';
 import type { InterfacePluginField as InterfacePluginFieldModel } from '../models/PluginField';
 import type { InterfacePost as InterfacePostModel } from '../models/Post';
+import type { InterfaceRecurrenceRule as InterfaceRecurrenceRuleModel } from '../models/RecurrenceRule';
 import type { InterfaceOrganizationTagUser as InterfaceOrganizationTagUserModel } from '../models/OrganizationTagUser';
 import type { InterfaceUser as InterfaceUserModel } from '../models/User';
 import type { InterfaceVenue as InterfaceVenueModel } from '../models/Venue';
@@ -2891,13 +2892,13 @@ export type VenueInput = {
 };
 
 export type WeekDays =
-  | 'FR'
-  | 'MO'
-  | 'SA'
-  | 'SU'
-  | 'TH'
-  | 'TU'
-  | 'WE';
+  | 'FRIDAY'
+  | 'MONDAY'
+  | 'SATURDAY'
+  | 'SUNDAY'
+  | 'THURSDAY'
+  | 'TUESDAY'
+  | 'WEDNESDAY';
 
 export type CreateChatInput = {
   organizationId: Scalars['ID']['input'];
@@ -3117,7 +3118,7 @@ export type ResolversTypes = {
   Query: ResolverTypeWrapper<{}>;
   RecaptchaVerification: RecaptchaVerification;
   Recurrance: Recurrance;
-  RecurrenceRule: ResolverTypeWrapper<RecurrenceRule>;
+  RecurrenceRule: ResolverTypeWrapper<InterfaceRecurrenceRuleModel>;
   RecurrenceRuleInput: RecurrenceRuleInput;
   RecurringEventMutationType: RecurringEventMutationType;
   SocialMediaUrls: ResolverTypeWrapper<SocialMediaUrls>;
@@ -3289,7 +3290,7 @@ export type ResolversParentTypes = {
   PostsConnection: Omit<PostsConnection, 'edges'> & { edges: Array<ResolversParentTypes['PostEdge']> };
   Query: {};
   RecaptchaVerification: RecaptchaVerification;
-  RecurrenceRule: RecurrenceRule;
+  RecurrenceRule: InterfaceRecurrenceRuleModel;
   RecurrenceRuleInput: RecurrenceRuleInput;
   SocialMediaUrls: SocialMediaUrls;
   SocialMediaUrlsInput: SocialMediaUrlsInput;

--- a/src/utilities/recurrenceDatesUtil.ts
+++ b/src/utilities/recurrenceDatesUtil.ts
@@ -30,3 +30,22 @@ export const convertToRRuleDateString = (date: Date): string => {
 
   return dateString;
 };
+
+/**
+ * This function counts the total number of mondays in a month.
+ * @param date - a date.
+ * @returns total number of mondays.
+ */
+
+export const countTotalMondaysInMonth = (date: Date): number => {
+  let count = 0;
+  const month = date.getMonth();
+
+  for (let i = 1; i <= 31; i++) {
+    const testDate = new Date(date.getFullYear(), month, i);
+    if (testDate.getMonth() !== month) break; // Month has ended
+    if (testDate.getDay() === 1) count++; // Monday
+  }
+
+  return count;
+};

--- a/tests/resolvers/Event/recurrenceRule.spec.ts
+++ b/tests/resolvers/Event/recurrenceRule.spec.ts
@@ -8,12 +8,9 @@ import {
 import type mongoose from "mongoose";
 import { beforeAll, afterAll, describe, it, expect } from "vitest";
 import type { InterfaceEvent } from "../../../src/models";
-import {
-  createTestUserAndOrganization} from "../../helpers/userAndOrg";
-import type {
-  TestOrganizationType,
-  type TestUserType,
-} from "../../helpers/userAndOrg";
+import { createTestUserAndOrganization } from "../../helpers/userAndOrg";
+import type { TestOrganizationType , TestUserType } from "../../helpers/userAndOrg";
+
 
 import { convertToUTCDate } from "../../../src/utilities/recurrenceDatesUtil";
 import type { MutationCreateEventArgs } from "../../../src/types/generatedGraphQLTypes";

--- a/tests/resolvers/Event/recurrenceRule.spec.ts
+++ b/tests/resolvers/Event/recurrenceRule.spec.ts
@@ -9,8 +9,10 @@ import type mongoose from "mongoose";
 import { beforeAll, afterAll, describe, it, expect } from "vitest";
 import type { InterfaceEvent } from "../../../src/models";
 import { createTestUserAndOrganization } from "../../helpers/userAndOrg";
-import type { TestOrganizationType , TestUserType } from "../../helpers/userAndOrg";
-
+import type {
+  TestOrganizationType,
+  TestUserType,
+} from "../../helpers/userAndOrg";
 
 import { convertToUTCDate } from "../../../src/utilities/recurrenceDatesUtil";
 import type { MutationCreateEventArgs } from "../../../src/types/generatedGraphQLTypes";

--- a/tests/resolvers/Event/recurrenceRule.spec.ts
+++ b/tests/resolvers/Event/recurrenceRule.spec.ts
@@ -1,0 +1,86 @@
+import "dotenv/config";
+import { recurrenceRule as recurrenceRuleResolver } from "../../../src/resolvers/Event/recurrenceRule";
+import {
+  connect,
+  disconnect,
+  dropAllCollectionsFromDatabase,
+} from "../../helpers/db";
+import type mongoose from "mongoose";
+import { beforeAll, afterAll, describe, it, expect } from "vitest";
+import type { InterfaceEvent } from "../../../src/models";
+import {
+  createTestUserAndOrganization} from "../../helpers/userAndOrg";
+import type {
+  TestOrganizationType,
+  type TestUserType,
+} from "../../helpers/userAndOrg";
+
+import { convertToUTCDate } from "../../../src/utilities/recurrenceDatesUtil";
+import type { MutationCreateEventArgs } from "../../../src/types/generatedGraphQLTypes";
+import { RecurrenceRule } from "../../../src/models/RecurrenceRule";
+
+let MONGOOSE_INSTANCE: typeof mongoose;
+let testOrganization: TestOrganizationType;
+let testUser: TestUserType;
+
+beforeAll(async () => {
+  MONGOOSE_INSTANCE = await connect();
+  await dropAllCollectionsFromDatabase(MONGOOSE_INSTANCE);
+
+  [testUser, testOrganization] = await createTestUserAndOrganization();
+});
+
+afterAll(async () => {
+  await dropAllCollectionsFromDatabase(MONGOOSE_INSTANCE);
+  await disconnect(MONGOOSE_INSTANCE);
+});
+
+describe("resolvers -> Event -> recurrenceRule", () => {
+  it(`returns the recurrence rule object for parent event`, async () => {
+    let startDate = new Date();
+    startDate = convertToUTCDate(startDate);
+
+    const args: MutationCreateEventArgs = {
+      data: {
+        organizationId: testOrganization?.id,
+        allDay: true,
+        description: "newDescription",
+        isPublic: false,
+        isRegisterable: false,
+        latitude: 1,
+        longitude: 1,
+        location: "newLocation",
+        recurring: true,
+        startDate,
+        title: "newTitle",
+      },
+      recurrenceRuleData: {
+        frequency: "WEEKLY",
+        weekDays: ["MONDAY", "TUESDAY", "WEDNESDAY"],
+        count: 10,
+      },
+    };
+
+    const context = {
+      userId: testUser?.id,
+    };
+    const { createEvent: createEventResolver } = await import(
+      "../../../src/resolvers/Mutation/createEvent"
+    );
+
+    const createEventPayload = await createEventResolver?.({}, args, context);
+
+    const recurrenceRule = await RecurrenceRule.findOne({
+      _id: createEventPayload?.recurrenceRuleId,
+    }).lean();
+
+    const parent = createEventPayload as InterfaceEvent;
+    const recurrenceRulePayload = await recurrenceRuleResolver?.(
+      parent,
+      {},
+      {},
+    );
+
+    expect(recurrenceRule).toEqual(recurrenceRulePayload);
+  });
+});

--- a/tests/resolvers/Mutation/createEvent.spec.ts
+++ b/tests/resolvers/Mutation/createEvent.spec.ts
@@ -31,7 +31,10 @@ import {
   UnauthorizedError,
 } from "../../../src/libraries/errors";
 import { Frequency, RecurrenceRule } from "../../../src/models/RecurrenceRule";
-import { convertToUTCDate } from "../../../src/utilities/recurrenceDatesUtil";
+import {
+  convertToUTCDate,
+  countTotalMondaysInMonth,
+} from "../../../src/utilities/recurrenceDatesUtil";
 import type {
   TestOrganizationType,
   TestUserType,
@@ -947,6 +950,253 @@ describe("resolvers -> Mutation -> createEvent", () => {
 
     expect(recurringEvents).toBeDefined();
     expect(recurringEvents).toHaveLength(10);
+
+    const attendeeExists = await EventAttendee.exists({
+      userId: testUser?._id,
+      eventId: createEventPayload?._id,
+    });
+
+    expect(attendeeExists).toBeTruthy();
+
+    const updatedTestUser = await User.findOne({
+      _id: testUser?._id,
+    })
+      .select(["registeredEvents"])
+      .lean();
+
+    expect(updatedTestUser).toEqual(
+      expect.objectContaining({
+        registeredEvents: expect.arrayContaining([createEventPayload?._id]),
+      }),
+    );
+  });
+
+  it(`creates a monthly recurring event that occurs on every first Monday of the month`, async () => {
+    let startDate = new Date();
+    startDate = addMonths(startDate, 7);
+    startDate = convertToUTCDate(startDate);
+
+    startDate.setDate(1);
+
+    // Turn into the first monday of the month
+    if (startDate.getDay() !== 1) {
+      startDate.setDate(
+        startDate.getDate() + ((1 + 7 - startDate.getDay()) % 7),
+      );
+    }
+
+    const args: MutationCreateEventArgs = {
+      data: {
+        organizationId: testOrganization?.id,
+        allDay: true,
+        description: "newDescription",
+        isPublic: false,
+        isRegisterable: false,
+        latitude: 1,
+        longitude: 1,
+        location: "newLocation",
+        recurring: true,
+        startDate,
+        startTime: startDate.toUTCString(),
+        title: "newTitle",
+        recurrance: "ONCE",
+      },
+      recurrenceRuleData: {
+        frequency: "MONTHLY",
+        weekDays: ["MO"],
+        count: 10,
+        weekDayOccurenceInMonth: 1,
+      },
+    };
+
+    const context = {
+      userId: testUser?.id,
+    };
+    const { createEvent: createEventResolver } = await import(
+      "../../../src/resolvers/Mutation/createEvent"
+    );
+
+    const createEventPayload = await createEventResolver?.({}, args, context);
+
+    expect(createEventPayload).toEqual(
+      expect.objectContaining({
+        allDay: true,
+        description: "newDescription",
+        isPublic: false,
+        isRegisterable: false,
+        latitude: 1,
+        longitude: 1,
+        location: "newLocation",
+        recurring: true,
+        title: "newTitle",
+        creatorId: testUser?._id,
+        admins: expect.arrayContaining([testUser?._id]),
+        organization: testOrganization?._id,
+      }),
+    );
+
+    const recurrenceRule = await RecurrenceRule.findOne({
+      frequency: Frequency.MONTHLY,
+      startDate,
+    });
+
+    const baseRecurringEvent = await Event.findOne({
+      isBaseRecurringEvent: true,
+      startDate: startDate.toUTCString(),
+    });
+
+    const recurringEvents = await Event.find({
+      recurring: true,
+      isBaseRecurringEvent: false,
+      recurrenceRuleId: recurrenceRule?._id,
+      baseRecurringEventId: baseRecurringEvent?._id,
+    }).lean();
+
+    expect(recurringEvents).toBeDefined();
+    expect(recurringEvents).toHaveLength(10);
+
+    for (const recurringEventInstance of recurringEvents) {
+      const recurringEventInstanceDate = new Date(
+        recurringEventInstance.startDate,
+      );
+
+      // get the day of the week
+      const dayOfWeek = recurringEventInstanceDate.getDay();
+
+      // get the current occurrence of week day in month
+      const dayOfMonth = recurringEventInstanceDate.getDate();
+      const occurrence = Math.ceil(dayOfMonth / 7);
+
+      expect(dayOfWeek).toEqual(1);
+      expect(occurrence).toEqual(1);
+    }
+
+    const attendeeExists = await EventAttendee.exists({
+      userId: testUser?._id,
+      eventId: createEventPayload?._id,
+    });
+
+    expect(attendeeExists).toBeTruthy();
+
+    const updatedTestUser = await User.findOne({
+      _id: testUser?._id,
+    })
+      .select(["registeredEvents"])
+      .lean();
+
+    expect(updatedTestUser).toEqual(
+      expect.objectContaining({
+        registeredEvents: expect.arrayContaining([createEventPayload?._id]),
+      }),
+    );
+  });
+
+  it(`creates a monthly recurring event that occurs on every last Monday of the month`, async () => {
+    let startDate = new Date();
+    startDate = addMonths(startDate, 9);
+    startDate = convertToUTCDate(startDate);
+
+    startDate.setDate(0);
+
+    // Turn into the first monday of the month
+    while (startDate.getDay() !== 1) {
+      // Subtract one day until we get to a Monday
+      startDate.setDate(startDate.getDate() - 1);
+    }
+
+    console.log(startDate);
+
+    const args: MutationCreateEventArgs = {
+      data: {
+        organizationId: testOrganization?.id,
+        allDay: true,
+        description: "newDescription",
+        isPublic: false,
+        isRegisterable: false,
+        latitude: 1,
+        longitude: 1,
+        location: "newLocation",
+        recurring: true,
+        startDate,
+        startTime: startDate.toUTCString(),
+        title: "newTitle",
+        recurrance: "ONCE",
+      },
+      recurrenceRuleData: {
+        frequency: "MONTHLY",
+        weekDays: ["MO"],
+        count: 10,
+        weekDayOccurenceInMonth: -1,
+      },
+    };
+
+    const context = {
+      userId: testUser?.id,
+    };
+    const { createEvent: createEventResolver } = await import(
+      "../../../src/resolvers/Mutation/createEvent"
+    );
+
+    const createEventPayload = await createEventResolver?.({}, args, context);
+
+    expect(createEventPayload).toEqual(
+      expect.objectContaining({
+        allDay: true,
+        description: "newDescription",
+        isPublic: false,
+        isRegisterable: false,
+        latitude: 1,
+        longitude: 1,
+        location: "newLocation",
+        recurring: true,
+        title: "newTitle",
+        creatorId: testUser?._id,
+        admins: expect.arrayContaining([testUser?._id]),
+        organization: testOrganization?._id,
+      }),
+    );
+
+    const recurrenceRule = await RecurrenceRule.findOne({
+      frequency: Frequency.MONTHLY,
+      startDate,
+    });
+
+    const baseRecurringEvent = await Event.findOne({
+      isBaseRecurringEvent: true,
+      startDate: startDate.toUTCString(),
+    });
+
+    const recurringEvents = await Event.find({
+      recurring: true,
+      isBaseRecurringEvent: false,
+      recurrenceRuleId: recurrenceRule?._id,
+      baseRecurringEventId: baseRecurringEvent?._id,
+    }).lean();
+
+    expect(recurringEvents).toBeDefined();
+    expect(recurringEvents).toHaveLength(10);
+
+    for (const recurringEventInstance of recurringEvents) {
+      const recurringEventInstanceDate = new Date(
+        recurringEventInstance.startDate,
+      );
+
+      // get the day of the week
+      const dayOfWeek = recurringEventInstanceDate.getDay();
+
+      // get the current occurrence of week day in month
+      const dayOfMonth = recurringEventInstanceDate.getDate();
+      const occurrence = Math.ceil(dayOfMonth / 7);
+
+      // get total occurences of monday in the month
+      // it will also be the last occurence of monday in that month
+      const totalOccurencesOfMonday = countTotalMondaysInMonth(
+        recurringEventInstanceDate,
+      );
+
+      expect(dayOfWeek).toEqual(1);
+      expect(occurrence).toEqual(totalOccurencesOfMonday);
+    }
 
     const attendeeExists = await EventAttendee.exists({
       userId: testUser?._id,

--- a/tests/resolvers/Mutation/createEvent.spec.ts
+++ b/tests/resolvers/Mutation/createEvent.spec.ts
@@ -617,7 +617,7 @@ describe("resolvers -> Mutation -> createEvent", () => {
       },
       recurrenceRuleData: {
         frequency: "WEEKLY",
-        weekDays: ["TH", "SA"],
+        weekDays: ["THURSDAY", "SATURDAY"],
         count: 10,
       },
     };
@@ -1003,7 +1003,7 @@ describe("resolvers -> Mutation -> createEvent", () => {
       },
       recurrenceRuleData: {
         frequency: "MONTHLY",
-        weekDays: ["MO"],
+        weekDays: ["MONDAY"],
         count: 10,
         weekDayOccurenceInMonth: 1,
       },
@@ -1104,8 +1104,6 @@ describe("resolvers -> Mutation -> createEvent", () => {
       startDate.setDate(startDate.getDate() - 1);
     }
 
-    console.log(startDate);
-
     const args: MutationCreateEventArgs = {
       data: {
         organizationId: testOrganization?.id,
@@ -1124,7 +1122,7 @@ describe("resolvers -> Mutation -> createEvent", () => {
       },
       recurrenceRuleData: {
         frequency: "MONTHLY",
-        weekDays: ["MO"],
+        weekDays: ["MONDAY"],
         count: 10,
         weekDayOccurenceInMonth: -1,
       },


### PR DESCRIPTION
### What kind of change does this PR introduce?

1) Adds `recurrenceRule` field and the corresponding field resolver to the `Event` schema, which is to be used while updating recurring events PalisadoesFoundation/talawa-admin#1643.
2) Adds more recurrence properties to the `RecurrenceRule`, i.e. `interval`, `bysetpos` [link](https://github.com/jkbrzt/rrule#api).

### Issue Number:

Fixes #2090 

### Did you add tests for your changes?

Yes