### PR TITLE
test: Added tests for `removeUserFamily.ts`

### DIFF
--- a/tests/resolvers/Mutation/removeUserFamily.spec.ts
+++ b/tests/resolvers/Mutation/removeUserFamily.spec.ts
@@ -23,6 +23,7 @@ import type {
   TestUserType,
 } from "../../helpers/userAndUserFamily";
 import { createTestUserFunc } from "../../helpers/userAndUserFamily";
+import { AppUserProfile } from "../../../src/models";
 
 let MONGOOSE_INSTANCE: typeof mongoose;
 let testUsers: TestUserType[];
@@ -133,6 +134,38 @@ describe("resolvers -> Mutation -> removeUserFamily", () => {
       expect(spy).toHaveBeenCalledWith(USER_FAMILY_NOT_FOUND_ERROR.MESSAGE);
       expect((error as Error).message).toEqual(
         `${USER_FAMILY_NOT_FOUND_ERROR.MESSAGE}`,
+      );
+    }
+  });
+
+  it("throws user not found error if current user profile is not found", async () => {
+    const { requestContext } = await import("../../../src/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementation((message) => message);
+
+    try {
+      const args: MutationRemoveUserFamilyArgs = {
+        familyId: testUserFamily?.id,
+      };
+
+      await AppUserProfile.deleteOne({
+        userId: testUsers[0]?.id,
+      });
+
+      const context = {
+        userId: testUsers[0]?.id,
+      };
+
+      const { removeUserFamily: removeUserFamilyResolver } = await import(
+        "../../../src/resolvers/Mutation/removeUserFamily"
+      );
+
+      await removeUserFamilyResolver?.({}, args, context);
+    } catch (error) {
+      expect(spy).toHaveBeenCalledWith(USER_NOT_FOUND_ERROR.MESSAGE);
+      expect((error as Error).message).toEqual(
+        `${USER_NOT_FOUND_ERROR.MESSAGE}`,
       );
     }
   });


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Tests for `removeUserFamily.ts` file.
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #2066 

**Did you add tests for your changes?**
Yes
<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**
![image](https://github.com/PalisadoesFoundation/talawa-api/assets/112749383/4ff248fa-63c4-474c-968d-2881d547f096)
![image](https://github.com/PalisadoesFoundation/talawa-api/assets/112749383/ee81e36c-f26b-4ec0-a6c7-1b9cee31aedb)

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
N/A
<!--Add link to Talawa-Docs.-->

**Summary**
- Ensured 100% code coverage for `removeUserFamily.ts` file.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->
