### PR TITLE
Added getVenueByOrgId Resolver with sorting/filtering

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsc --pretty --project tsconfig.build.json",
     "dev": "concurrently  \"tsx --watch ./src/index.ts\" \"graphql-codegen --watch\"",
+    "glen": "\"tsx ./src/index.ts\"",
     "prebuild": "graphql-codegen && rimraf ./build",
     "prod": "cross-env NODE_ENV=production pm2-runtime start ./build/server.js",
     "start": "cross-env pm2-runtime start ./build/server.js --watch",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "build": "tsc --pretty --project tsconfig.build.json",
     "dev": "concurrently  \"tsx --watch ./src/index.ts\" \"graphql-codegen --watch\"",
-    "glen": "\"tsx ./src/index.ts\"",
     "prebuild": "graphql-codegen && rimraf ./build",
     "prod": "cross-env NODE_ENV=production pm2-runtime start ./build/server.js",
     "start": "cross-env pm2-runtime start ./build/server.js --watch",

--- a/schema.graphql
+++ b/schema.graphql
@@ -1934,19 +1934,10 @@ enum VenueOrderByInput {
 }
 
 input VenueWhereInput {
-  id: ID
-  id_contains: ID
-  id_in: [ID!]
-  id_not: ID
-  id_not_in: [ID!]
-  id_starts_with: ID
-  name: String
+  description_contains: String
+  description_starts_with: String
   name_contains: String
-  name_in: [String!]
-  name_not: String
-  name_not_in: [String!]
   name_starts_with: String
-  organization_id: ID
 }
 
 enum WeekDays {

--- a/schema.graphql
+++ b/schema.graphql
@@ -1446,6 +1446,7 @@ type Query {
   getFundraisingCampaignById(id: ID!): FundraisingCampaign!
   getFundraisingCampaignPledgeById(id: ID!): FundraisingCampaignPledge!
   getPlugins: [Plugin]
+  getVenueByOrgId(first: Int, orderBy: VenueOrderByInput, orgId: ID!, skip: Int, where: VenueWhereInput): [Venue]
   getlanguage(lang_code: String!): [Translation]
   hasSubmittedFeedback(eventId: ID!, userId: ID!): Boolean
   isSampleOrganization(id: ID!): Boolean!
@@ -1925,6 +1926,27 @@ input VenueInput {
   file: String
   name: String!
   organizationId: ID!
+}
+
+enum VenueOrderByInput {
+  capacity_ASC
+  capacity_DESC
+}
+
+input VenueWhereInput {
+  id: ID
+  id_contains: ID
+  id_in: [ID!]
+  id_not: ID
+  id_not_in: [ID!]
+  id_starts_with: ID
+  name: String
+  name_contains: String
+  name_in: [String!]
+  name_not: String
+  name_not_in: [String!]
+  name_starts_with: String
+  organization_id: ID
 }
 
 enum WeekDays {

--- a/src/resolvers/Query/getVenueByOrgId.ts
+++ b/src/resolvers/Query/getVenueByOrgId.ts
@@ -1,0 +1,22 @@
+import type { QueryResolvers } from "../../types/generatedGraphQLTypes";
+import type { InterfaceVenue } from "../../models";
+import { Venue } from "../../models";
+import { getWhere } from "./helperFunctions/getWhere";
+import { getSort } from "./helperFunctions/getSort";
+
+export const getVenueByOrgId: QueryResolvers["getVenueByOrgId"] = async (
+  _parent,
+  args,
+) => {
+  const where = getWhere<InterfaceVenue>(args.where);
+  const sort = getSort(args.orderBy);
+
+  return await Venue.find({
+    organization: args.orgId,
+    ...where,
+  })
+    .limit(args.first ?? 0)
+    .skip(args.skip ?? 0)
+    .sort(sort)
+    .lean();
+};

--- a/src/resolvers/Query/helperFunctions/getSort.ts
+++ b/src/resolvers/Query/helperFunctions/getSort.ts
@@ -5,6 +5,7 @@ import type {
   OrganizationOrderByInput,
   PostOrderByInput,
   UserOrderByInput,
+  VenueOrderByInput,
 } from "../../../types/generatedGraphQLTypes";
 
 export const getSort = (
@@ -14,6 +15,7 @@ export const getSort = (
         | OrganizationOrderByInput
         | PostOrderByInput
         | UserOrderByInput
+        | VenueOrderByInput
       >
     | undefined,
 ):
@@ -34,6 +36,18 @@ export const getSort = (
     case "id_DESC":
       sortPayload = {
         _id: -1,
+      };
+      break;
+
+    case "capacity_ASC":
+      sortPayload = {
+        capacity: 1,
+      };
+      break;
+
+    case "capacity_DESC":
+      sortPayload = {
+        capacity: -1,
       };
       break;
 

--- a/src/resolvers/Query/helperFunctions/getWhere.ts
+++ b/src/resolvers/Query/helperFunctions/getWhere.ts
@@ -8,6 +8,7 @@ import type {
   OrganizationWhereInput,
   PostWhereInput,
   UserWhereInput,
+  VenueWhereInput,
 } from "../../../types/generatedGraphQLTypes";
 
 /**
@@ -33,7 +34,8 @@ export const getWhere = <T = unknown>(
             UserWhereInput &
             DonationWhereInput &
             ActionItemWhereInput &
-            FundWhereInput
+            FundWhereInput &
+            VenueWhereInput
         >
       >
     | undefined,
@@ -735,6 +737,24 @@ export const getWhere = <T = unknown>(
     wherePayload = {
       ...wherePayload,
       text: regexp,
+    };
+  }
+
+  if (where.name_starts_with) {
+    const regexp = new RegExp("^" + where.name_starts_with);
+    wherePayload = {
+      ...wherePayload,
+      name: regexp,
+    };
+  }
+
+  if (where.name_contains) {
+    wherePayload = {
+      ...wherePayload,
+      name: {
+        $regex: where.name_contains,
+        $options: "i",
+      },
     };
   }
 

--- a/src/resolvers/Query/index.ts
+++ b/src/resolvers/Query/index.ts
@@ -38,6 +38,7 @@ import { usersConnection } from "./usersConnection";
 import { venue } from "./venue";
 import { getEventAttendee } from "./getEventAttendee";
 import { getEventAttendeesByEventId } from "./getEventAttendeesByEventId";
+import { getVenueByOrgId } from "./getVenueByOrgId";
 
 export const Query: QueryResolvers = {
   actionItemsByEvent,
@@ -79,4 +80,5 @@ export const Query: QueryResolvers = {
   fundsByOrganization,
   getEventAttendee,
   getEventAttendeesByEventId,
+  getVenueByOrgId,
 };

--- a/src/typeDefs/enums.ts
+++ b/src/typeDefs/enums.ts
@@ -109,6 +109,11 @@ export const enums = gql`
     NON_USER
   }
 
+  enum VenueOrderByInput {
+    capacity_ASC
+    capacity_DESC
+  }
+
   enum WeekDays {
     MONDAY
     TUESDAY

--- a/src/typeDefs/inputs.ts
+++ b/src/typeDefs/inputs.ts
@@ -586,4 +586,22 @@ export const inputs = gql`
     description: String
     file: String
   }
+
+  input VenueWhereInput {
+    id: ID
+    id_not: ID
+    id_in: [ID!]
+    id_not_in: [ID!]
+    id_contains: ID
+    id_starts_with: ID
+
+    name: String
+    name_not: String
+    name_in: [String!]
+    name_not_in: [String!]
+    name_contains: String
+    name_starts_with: String
+
+    organization_id: ID
+  }
 `;

--- a/src/typeDefs/inputs.ts
+++ b/src/typeDefs/inputs.ts
@@ -588,20 +588,9 @@ export const inputs = gql`
   }
 
   input VenueWhereInput {
-    id: ID
-    id_not: ID
-    id_in: [ID!]
-    id_not_in: [ID!]
-    id_contains: ID
-    id_starts_with: ID
-
-    name: String
-    name_not: String
-    name_in: [String!]
-    name_not_in: [String!]
     name_contains: String
     name_starts_with: String
-
-    organization_id: ID
+    description_starts_with: String
+    description_contains: String
   }
 `;

--- a/src/typeDefs/queries.ts
+++ b/src/typeDefs/queries.ts
@@ -76,6 +76,15 @@ export const queries = gql`
     getlanguage(lang_code: String!): [Translation]
 
     getPlugins: [Plugin]
+
+    getVenueByOrgId(
+      orgId: ID!
+      where: VenueWhereInput
+      first: Int
+      skip: Int
+      orderBy: VenueOrderByInput
+    ): [Venue]
+
     advertisementsConnection(
       after: String
       before: String

--- a/src/types/generatedGraphQLTypes.ts
+++ b/src/types/generatedGraphQLTypes.ts
@@ -3014,19 +3014,10 @@ export type VenueOrderByInput =
   | 'capacity_DESC';
 
 export type VenueWhereInput = {
-  id?: InputMaybe<Scalars['ID']['input']>;
-  id_contains?: InputMaybe<Scalars['ID']['input']>;
-  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
-  id_not?: InputMaybe<Scalars['ID']['input']>;
-  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
-  id_starts_with?: InputMaybe<Scalars['ID']['input']>;
-  name?: InputMaybe<Scalars['String']['input']>;
+  description_contains?: InputMaybe<Scalars['String']['input']>;
+  description_starts_with?: InputMaybe<Scalars['String']['input']>;
   name_contains?: InputMaybe<Scalars['String']['input']>;
-  name_in?: InputMaybe<Array<Scalars['String']['input']>>;
-  name_not?: InputMaybe<Scalars['String']['input']>;
-  name_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
   name_starts_with?: InputMaybe<Scalars['String']['input']>;
-  organization_id?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type WeekDays =

--- a/src/types/generatedGraphQLTypes.ts
+++ b/src/types/generatedGraphQLTypes.ts
@@ -2238,6 +2238,7 @@ export type Query = {
   getFundraisingCampaignById: FundraisingCampaign;
   getFundraisingCampaignPledgeById: FundraisingCampaignPledge;
   getPlugins?: Maybe<Array<Maybe<Plugin>>>;
+  getVenueByOrgId?: Maybe<Array<Maybe<Venue>>>;
   getlanguage?: Maybe<Array<Maybe<Translation>>>;
   hasSubmittedFeedback?: Maybe<Scalars['Boolean']['output']>;
   isSampleOrganization: Scalars['Boolean']['output'];
@@ -2400,6 +2401,15 @@ export type QueryGetFundraisingCampaignByIdArgs = {
 
 export type QueryGetFundraisingCampaignPledgeByIdArgs = {
   id: Scalars['ID']['input'];
+};
+
+
+export type QueryGetVenueByOrgIdArgs = {
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<VenueOrderByInput>;
+  orgId: Scalars['ID']['input'];
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<VenueWhereInput>;
 };
 
 
@@ -2999,6 +3009,26 @@ export type VenueInput = {
   organizationId: Scalars['ID']['input'];
 };
 
+export type VenueOrderByInput =
+  | 'capacity_ASC'
+  | 'capacity_DESC';
+
+export type VenueWhereInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_contains?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_starts_with?: InputMaybe<Scalars['ID']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  name_contains?: InputMaybe<Scalars['String']['input']>;
+  name_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  name_not?: InputMaybe<Scalars['String']['input']>;
+  name_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  name_starts_with?: InputMaybe<Scalars['String']['input']>;
+  organization_id?: InputMaybe<Scalars['ID']['input']>;
+};
+
 export type WeekDays =
   | 'FRIDAY'
   | 'MONDAY'
@@ -3307,6 +3337,8 @@ export type ResolversTypes = {
   UsersConnectionEdge: ResolverTypeWrapper<Omit<UsersConnectionEdge, 'node'> & { node: ResolversTypes['User'] }>;
   Venue: ResolverTypeWrapper<InterfaceVenueModel>;
   VenueInput: VenueInput;
+  VenueOrderByInput: VenueOrderByInput;
+  VenueWhereInput: VenueWhereInput;
   WeekDays: WeekDays;
   createChatInput: CreateChatInput;
   createDirectChatPayload: ResolverTypeWrapper<Omit<CreateDirectChatPayload, 'directChat' | 'userErrors'> & { directChat?: Maybe<ResolversTypes['DirectChat']>, userErrors: Array<ResolversTypes['CreateDirectChatError']> }>;
@@ -3492,6 +3524,7 @@ export type ResolversParentTypes = {
   UsersConnectionEdge: Omit<UsersConnectionEdge, 'node'> & { node: ResolversParentTypes['User'] };
   Venue: InterfaceVenueModel;
   VenueInput: VenueInput;
+  VenueWhereInput: VenueWhereInput;
   createChatInput: CreateChatInput;
   createDirectChatPayload: Omit<CreateDirectChatPayload, 'directChat' | 'userErrors'> & { directChat?: Maybe<ResolversParentTypes['DirectChat']>, userErrors: Array<ResolversParentTypes['CreateDirectChatError']> };
   createGroupChatInput: CreateGroupChatInput;
@@ -4388,6 +4421,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   getFundraisingCampaignById?: Resolver<ResolversTypes['FundraisingCampaign'], ParentType, ContextType, RequireFields<QueryGetFundraisingCampaignByIdArgs, 'id'>>;
   getFundraisingCampaignPledgeById?: Resolver<ResolversTypes['FundraisingCampaignPledge'], ParentType, ContextType, RequireFields<QueryGetFundraisingCampaignPledgeByIdArgs, 'id'>>;
   getPlugins?: Resolver<Maybe<Array<Maybe<ResolversTypes['Plugin']>>>, ParentType, ContextType>;
+  getVenueByOrgId?: Resolver<Maybe<Array<Maybe<ResolversTypes['Venue']>>>, ParentType, ContextType, RequireFields<QueryGetVenueByOrgIdArgs, 'orgId'>>;
   getlanguage?: Resolver<Maybe<Array<Maybe<ResolversTypes['Translation']>>>, ParentType, ContextType, RequireFields<QueryGetlanguageArgs, 'lang_code'>>;
   hasSubmittedFeedback?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<QueryHasSubmittedFeedbackArgs, 'eventId' | 'userId'>>;
   isSampleOrganization?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<QueryIsSampleOrganizationArgs, 'id'>>;

--- a/tests/helpers/venue.ts
+++ b/tests/helpers/venue.ts
@@ -2,8 +2,9 @@ import { nanoid } from "nanoid";
 import { Venue, type InterfaceVenue } from "../../src/models";
 import type { Document, Types } from "mongoose";
 
-export type TestVenueType = InterfaceVenue &
-  Document<string, Record<string, unknown>, InterfaceVenue>;
+export type TestVenueType =
+  | (InterfaceVenue & Document<unknown, unknown, InterfaceVenue>)
+  | null;
 
 export const createTestVenue = async (
   organizationId: Types.ObjectId,
@@ -17,4 +18,34 @@ export const createTestVenue = async (
   });
 
   return testVenue as TestVenueType;
+};
+
+export const createTestVenuesForOrganization = async (
+  organizationId: Types.ObjectId,
+): Promise<TestVenueType[]> => {
+  const testVenue1 = await Venue.create({
+    name: nanoid().toLowerCase(),
+    description: nanoid().toLowerCase(),
+    capacity: 5 + Math.floor(Math.random() * 100),
+    organization: organizationId,
+    imageUrl: null,
+  });
+
+  const testVenue2 = await Venue.create({
+    name: nanoid().toLowerCase(),
+    description: nanoid().toLowerCase(),
+    capacity: 5 + Math.floor(Math.random() * 100),
+    organization: organizationId,
+    imageUrl: null,
+  });
+
+  const testVenue3 = await Venue.create({
+    name: nanoid().toLowerCase(),
+    description: nanoid().toLowerCase(),
+    capacity: 5 + Math.floor(Math.random() * 100),
+    organization: organizationId,
+    imageUrl: null,
+  });
+
+  return [testVenue1, testVenue2, testVenue3];
 };

--- a/tests/resolvers/Query/getVenueByOrgId.spec.ts
+++ b/tests/resolvers/Query/getVenueByOrgId.spec.ts
@@ -1,0 +1,138 @@
+import "dotenv/config";
+import { Venue } from "../../../src/models";
+import { getVenueByOrgId as getVenueByOrgIdResolver } from "../../../src/resolvers/Query/getVenueByOrgId";
+import { beforeAll, afterAll, describe, it, expect } from "vitest";
+import type { QueryGetVenueByOrgIdArgs } from "../../../src/types/generatedGraphQLTypes";
+import { connect, disconnect } from "../../helpers/db";
+import type mongoose from "mongoose";
+import type { TestVenueType } from "../../helpers/venue";
+import { createTestVenuesForOrganization } from "../../helpers/venue";
+import type { TestOrganizationType } from "../../helpers/userAndOrg";
+import { createTestUserAndOrganization } from "../../helpers/userAndOrg";
+
+let MONGOOSE_INSTANCE: typeof mongoose;
+let testVenues: TestVenueType[];
+let testOrganization: TestOrganizationType;
+
+describe("resolvers -> Query -> getVenueByOrgId", () => {
+  beforeAll(async () => {
+    MONGOOSE_INSTANCE = await connect();
+    const testUserAndOrganization = await createTestUserAndOrganization();
+    testOrganization = testUserAndOrganization[1];
+    testVenues = await createTestVenuesForOrganization(testOrganization?._id);
+  });
+
+  afterAll(async () => {
+    await disconnect(MONGOOSE_INSTANCE);
+  });
+
+  it(`returns venues filtered by args.where === { name_starts_with: testVenues[2].name }`, async () => {
+    const shortenedNameOfVenue = testVenues[2]?.name?.substring(0, 3);
+    const args: QueryGetVenueByOrgIdArgs = {
+      orgId: testOrganization?._id,
+      where: {
+        name_starts_with: shortenedNameOfVenue,
+      },
+    };
+
+    const getVenueByOrgId = await getVenueByOrgIdResolver?.({}, args, {});
+
+    const venuesByOrganization = await Venue.find({
+      organization: testOrganization?._id,
+      name: new RegExp("^" + shortenedNameOfVenue),
+    }).lean();
+
+    expect(getVenueByOrgId).toEqual(venuesByOrganization);
+  });
+
+  it(`returns venues filtered by args.where === { name_contains: testVenues[2].name }`, async () => {
+    const shortenedNameOfVenue = testVenues[2]?.name?.substring(2);
+    const args: QueryGetVenueByOrgIdArgs = {
+      orgId: testOrganization?._id,
+      where: {
+        name_contains: shortenedNameOfVenue,
+      },
+    };
+
+    const getVenueByOrgId = await getVenueByOrgIdResolver?.({}, args, {});
+
+    const venuesByOrganization = await Venue.find({
+      organization: testOrganization?._id,
+      name: { $regex: shortenedNameOfVenue, $options: "i" },
+    }).lean();
+
+    expect(getVenueByOrgId).toEqual(venuesByOrganization);
+  });
+
+  it(`returns venues filtered by args.where === { description_starts_with: testVenues[2].description }`, async () => {
+    const shortenedDescOfVenue = testVenues[2]?.description?.substring(0, 3);
+    const args: QueryGetVenueByOrgIdArgs = {
+      orgId: testOrganization?._id,
+      where: {
+        description_starts_with: shortenedDescOfVenue,
+      },
+    };
+
+    const getVenueByOrgId = await getVenueByOrgIdResolver?.({}, args, {});
+
+    const venuesByOrganization = await Venue.find({
+      organization: testOrganization?._id,
+      description: new RegExp("^" + shortenedDescOfVenue),
+    }).lean();
+
+    expect(getVenueByOrgId).toEqual(venuesByOrganization);
+  });
+
+  it(`returns venues filtered by args.where === { description_contains: testVenues[2].description }`, async () => {
+    const shortenedDescOfVenue = testVenues[2]?.description?.substring(2);
+    const args: QueryGetVenueByOrgIdArgs = {
+      orgId: testOrganization?._id,
+      where: {
+        description_contains: shortenedDescOfVenue,
+      },
+    };
+
+    const getVenueByOrgId = await getVenueByOrgIdResolver?.({}, args, {});
+
+    const venuesByOrganization = await Venue.find({
+      organization: testOrganization?._id,
+      description: { $regex: shortenedDescOfVenue, $options: "i" },
+    }).lean();
+
+    expect(getVenueByOrgId).toEqual(venuesByOrganization);
+  });
+
+  it(`return venues sorted by args.orderBy === capacity_DESC`, async () => {
+    const args: QueryGetVenueByOrgIdArgs = {
+      orgId: testOrganization?._id,
+      orderBy: "capacity_DESC",
+    };
+
+    const getVenueByOrgId = await getVenueByOrgIdResolver?.({}, args, {});
+
+    const venuesByOrganization = await Venue.find({
+      organization: testOrganization?._id,
+    })
+      .sort({ capacity: -1 })
+      .lean();
+
+    expect(getVenueByOrgId).toEqual(venuesByOrganization);
+  });
+
+  it(`return venues sorted by args.orderBy === capacity_ASC`, async () => {
+    const args: QueryGetVenueByOrgIdArgs = {
+      orgId: testOrganization?._id,
+      orderBy: "capacity_ASC",
+    };
+
+    const getVenueByOrgId = await getVenueByOrgIdResolver?.({}, args, {});
+
+    const venuesByOrganization = await Venue.find({
+      organization: testOrganization?._id,
+    })
+      .sort({ capacity: 1 })
+      .lean();
+
+    expect(getVenueByOrgId).toEqual(venuesByOrganization);
+  });
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

feature 

**Issue Number:**

Fixes #2169 

**Did you add tests for your changes?**

Yes 

**Snapshots/Videos:**


https://github.com/PalisadoesFoundation/talawa-api/assets/109027247/ac33a0e8-9e0d-4183-8001-c68e1264a007





**Summary**

- Added `getVenueByOrgId` query resolver with support for
     - fetch venues specific to orgId
     - sorting by capacity (ASC/DESC)
     - Filtering by Description
     - Filtering by Name

**Does this PR introduce a breaking change?**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes
