### PR TITLE
Test fix: `src/utilities/createSampleOrganizationUtil.ts` and `createUserTag`

### DIFF
--- a/src/utilities/createSampleOrganizationUtil.ts
+++ b/src/utilities/createSampleOrganizationUtil.ts
@@ -71,27 +71,6 @@ export const generateUserData = async (
   };
 };
 
-const createUser = async (
-  generatedUser: InterfaceUser & mongoose.Document<any, any, InterfaceUser>,
-): Promise<InterfaceUser & mongoose.Document<any, any, InterfaceUser>> => {
-  const savedUser = await generatedUser.save();
-  const appUserProfile = await AppUserProfile.create({
-    userId: savedUser._id,
-  });
-  const sampleModel = new SampleData({
-    documentId: savedUser._id,
-    collectionName: "User",
-  });
-  const sampleModel2 = new SampleData({
-    documentId: appUserProfile._id,
-    collectionName: "AppUserProfile",
-  });
-
-  await sampleModel.save();
-  await sampleModel2.save();
-  return savedUser;
-};
-
 export const generateEventData = async (
   users: InterfaceUser[],
   organizationId: string,

--- a/tests/resolvers/Mutation/createUserTag.spec.ts
+++ b/tests/resolvers/Mutation/createUserTag.spec.ts
@@ -11,6 +11,7 @@ import {
   ORGANIZATION_NOT_FOUND_ERROR,
   TAG_NOT_FOUND,
   TAG_ALREADY_EXISTS,
+  USER_NOT_AUTHORIZED_ERROR,
 } from "../../../src/constants";
 import {
   beforeAll,
@@ -26,7 +27,7 @@ import type {
   TestUserType,
 } from "../../helpers/userAndOrg";
 import { createTestUser } from "../../helpers/userAndOrg";
-import { OrganizationTagUser } from "../../../src/models";
+import { AppUserProfile, OrganizationTagUser } from "../../../src/models";
 import type { TestUserTagType } from "../../helpers/tags";
 import { createRootTagWithOrg } from "../../helpers/tags";
 
@@ -80,8 +81,10 @@ describe("resolvers -> Mutation -> createUserTag", () => {
       );
 
       await createUserTagResolver?.({}, args, context);
-      // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-    } catch (error: any) {
+    } catch (error: unknown) {
+      if (!(error instanceof Error)) {
+        throw new Error("Expected an error to be thrown");
+      }
       expect(spy).toBeCalledWith(USER_NOT_FOUND_ERROR.MESSAGE);
       expect(error.message).toEqual(
         `Translated ${USER_NOT_FOUND_ERROR.MESSAGE}`,
@@ -113,8 +116,10 @@ describe("resolvers -> Mutation -> createUserTag", () => {
       );
 
       await createUserTagResolver?.({}, args, context);
-      // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-    } catch (error: any) {
+    } catch (error: unknown) {
+      if (!(error instanceof Error)) {
+        throw new Error("Expected an error to be thrown");
+      }
       expect(spy).toBeCalledWith(ORGANIZATION_NOT_FOUND_ERROR.MESSAGE);
       expect(error.message).toEqual(
         `Translated ${ORGANIZATION_NOT_FOUND_ERROR.MESSAGE}`,
@@ -147,8 +152,10 @@ describe("resolvers -> Mutation -> createUserTag", () => {
       );
 
       await createUserTagResolver?.({}, args, context);
-      // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-    } catch (error: any) {
+    } catch (error: unknown) {
+      if (!(error instanceof Error)) {
+        throw new Error("Expected an error to be thrown");
+      }
       expect(spy).toBeCalledWith(TAG_NOT_FOUND.MESSAGE);
       expect(error.message).toEqual(`Translated ${TAG_NOT_FOUND.MESSAGE}`);
     }
@@ -179,8 +186,10 @@ describe("resolvers -> Mutation -> createUserTag", () => {
       );
 
       await createUserTagResolver?.({}, args, context);
-      // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-    } catch (error: any) {
+    } catch (error: unknown) {
+      if (!(error instanceof Error)) {
+        throw new Error("Expected an error to be thrown");
+      }
       expect(spy).toBeCalledWith(INCORRECT_TAG_INPUT.MESSAGE);
       expect(error.message).toEqual(
         `Translated ${INCORRECT_TAG_INPUT.MESSAGE}`,
@@ -213,8 +222,10 @@ describe("resolvers -> Mutation -> createUserTag", () => {
       );
 
       await createUserTagResolver?.({}, args, context);
-      // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-    } catch (error: any) {
+    } catch (error: unknown) {
+      if (!(error instanceof Error)) {
+        throw new Error("Expected an error to be thrown");
+      }
       expect(spy).toBeCalledWith(USER_NOT_AUTHORIZED_TO_CREATE_TAG.MESSAGE);
       expect(error.message).toEqual(
         `Translated ${USER_NOT_AUTHORIZED_TO_CREATE_TAG.MESSAGE}`,
@@ -247,8 +258,10 @@ describe("resolvers -> Mutation -> createUserTag", () => {
       );
 
       await createUserTagResolver?.({}, args, context);
-      // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-    } catch (error: any) {
+    } catch (error: unknown) {
+      if (!(error instanceof Error)) {
+        throw new Error("Expected an error to be thrown");
+      }
       expect(spy).toBeCalledWith(TAG_ALREADY_EXISTS.MESSAGE);
       expect(error.message).toEqual(`Translated ${TAG_ALREADY_EXISTS.MESSAGE}`);
     }
@@ -292,5 +305,42 @@ describe("resolvers -> Mutation -> createUserTag", () => {
     });
 
     expect(createdTagExists).toBeTruthy();
+  });
+
+  it("throws an error if the user does not have appUserProfile", async () => {
+    await AppUserProfile.deleteOne({
+      userId: testUser?._id,
+    });
+    const { requestContext } = await import("../../../src/libraries");
+    const spy = vi
+      .spyOn(requestContext, "translate")
+      .mockImplementationOnce((message) => `Translated ${message}`);
+    try {
+      const args: MutationCreateUserTagArgs = {
+        input: {
+          organizationId: new Types.ObjectId().toString(),
+          name: "TestUserTag",
+          tagColor: "#000000",
+        },
+      };
+
+      const context = {
+        userId: testUser?.id,
+      };
+
+      const { createUserTag: createUserTagResolver } = await import(
+        "../../../src/resolvers/Mutation/createUserTag"
+      );
+
+      await createUserTagResolver?.({}, args, context);
+    } catch (error: unknown) {
+      expect(spy).toBeCalledWith(USER_NOT_AUTHORIZED_ERROR.MESSAGE);
+      if (!(error instanceof Error)) {
+        throw new Error("Expected an error to be thrown");
+      }
+      expect(error.message).toEqual(
+        `Translated ${USER_NOT_AUTHORIZED_ERROR.MESSAGE}`,
+      );
+    }
   });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Test fix

**Issue Number:**

Fixes #2078 & fixes #2200

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

<img width="1303" alt="image" src="https://github.com/PalisadoesFoundation/talawa-api/assets/76090263/8ef84789-f717-4dd4-a72c-d6e62aba0dbd">
<img width="1315" alt="image" src="https://github.com/PalisadoesFoundation/talawa-api/assets/76090263/c12ee946-4074-429a-a7fe-ce5b6466f90a">


**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

- Add tests for `createSampleOrganizationUtil`
- Add tests for `createUsertag`
- remove all `any` and eslint-disable and added type for errors

**Does this PR introduce a breaking change?**

No

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes
