### PR TITLE
Fix: Event details cannot be updated by Admins

### DIFF
--- a/src/resolvers/Mutation/updateEvent.ts
+++ b/src/resolvers/Mutation/updateEvent.ts
@@ -108,16 +108,25 @@ export const updateEvent: MutationResolvers["updateEvent"] = async (
     );
   }
 
-  const currentUserIsEventAdmin = event.admins.some(
-    (admin) =>
-      admin === context.userID ||
-      new Types.ObjectId(admin).equals(context.userId),
+  // Boolean to determine whether user is an admin of organization.
+  const currentUserIsOrganizationAdmin = currentUserAppProfile.adminFor.some(
+    (organization) =>
+      organization &&
+      new Types.ObjectId(organization.toString()).equals(event?.organization),
   );
 
-  // checks if current user is an admin of the event with _id === args.id
+  // Boolean to determine whether user is an admin of event.
+  const currentUserIsEventAdmin = event.admins.some((admin) =>
+    admin.equals(currentUser?._id),
+  );
+
+  // Checks whether currentUser cannot update event.
   if (
-    currentUserIsEventAdmin === false &&
-    currentUserAppProfile.isSuperAdmin === false
+    !(
+      currentUserIsOrganizationAdmin ||
+      currentUserIsEventAdmin ||
+      currentUserAppProfile.isSuperAdmin
+    )
   ) {
     throw new errors.UnauthorizedError(
       requestContext.translate(USER_NOT_AUTHORIZED_ERROR.MESSAGE),

--- a/tests/resolvers/Mutation/updateEvent.spec.ts
+++ b/tests/resolvers/Mutation/updateEvent.spec.ts
@@ -7,6 +7,7 @@ import {
   EventAttendee,
   AppUserProfile,
 } from "../../../src/models";
+import type { InterfaceAppUserProfile } from "../../../src/models";
 import type { MutationUpdateEventArgs } from "../../../src/types/generatedGraphQLTypes";
 import {
   connect,
@@ -40,6 +41,7 @@ import { convertToUTCDate } from "../../../src/utilities/recurrenceDatesUtil";
 import { addWeeks } from "date-fns";
 import { RecurrenceRule } from "../../../src/models/RecurrenceRule";
 import { fail } from "assert";
+import { cacheAppUserProfile } from "../../../src/services/AppUserProfileCache/cacheAppUserProfile";
 
 let MONGOOSE_INSTANCE: typeof mongoose;
 let testUser: TestUserType;
@@ -157,14 +159,36 @@ describe("resolvers -> Mutation -> updateEvent", () => {
     }
   });
 
-  it(`throws UnauthorizedError if current user with _id === context.userId is
-  not an admin of event with _id === args.id`, async () => {
+  it(`throws UnauthorizedError if user with _id === context.userId is neither an
+  admin of organization with _id === event.organization for event with _id === args.id
+  or an admin for event with _id === args.id`, async () => {
     const { requestContext } = await import("../../../src/libraries");
     const spy = vi
       .spyOn(requestContext, "translate")
-      .mockImplementation((message) => `Translated ${message}`);
-
+      .mockImplementationOnce((message) => message);
     try {
+      await AppUserProfile.updateOne(
+        {
+          userId: testUser?._id,
+        },
+        {
+          $set: {
+            adminFor: [],
+          },
+        },
+      );
+
+      await Event.updateOne(
+        {
+          _id: testEvent?._id,
+        },
+        {
+          $set: {
+            admins: [],
+          },
+        },
+      );
+
       const args: MutationUpdateEventArgs = {
         id: testEvent?._id,
       };
@@ -179,11 +203,9 @@ describe("resolvers -> Mutation -> updateEvent", () => {
 
       await updateEventResolver?.({}, args, context);
     } catch (error: unknown) {
-      expect(spy).toHaveBeenCalledWith(USER_NOT_AUTHORIZED_ERROR.MESSAGE);
+      expect(spy).toBeCalledWith(USER_NOT_AUTHORIZED_ERROR.MESSAGE);
       if (error instanceof Error) {
-        expect(error.message).toEqual(
-          `Translated ${USER_NOT_AUTHORIZED_ERROR.MESSAGE}`,
-        );
+        USER_NOT_AUTHORIZED_ERROR.MESSAGE;
       } else {
         fail(`Expected UnauthorizedError, but got ${error}`);
       }
@@ -191,6 +213,26 @@ describe("resolvers -> Mutation -> updateEvent", () => {
   });
 
   it(`updates the event with _id === args.id and returns the updated event`, async () => {
+    const updatedTestUserAppProfile = await AppUserProfile.findOneAndUpdate(
+      {
+        userId: testUser?._id,
+      },
+      {
+        $push: {
+          adminFor: testOrganization?._id,
+        },
+      },
+      {
+        new: true,
+      },
+    ).lean();
+
+    if (updatedTestUserAppProfile !== null) {
+      await cacheAppUserProfile([
+        updatedTestUserAppProfile as InterfaceAppUserProfile,
+      ]);
+    }
+
     const updatedEvent = await Event.findOneAndUpdate(
       {
         _id: testEvent?._id,
@@ -1397,7 +1439,6 @@ describe("resolvers -> Mutation -> updateEvent", () => {
           recurring: false,
           startDate: "Tue Feb 14 2023",
           startTime: "",
-          title: "Random",
         },
       };
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
A bugfix.

**Issue Number:**
Fixes #2216  

**Did you add tests for your changes?**
Yes.

**Snapshots/Videos:**

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**
In the following PR, I have ensured that admins are able to update events.

**Does this PR introduce a breaking change?**
No.

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes.