### PR TITLE
fix minor bug: ensure single database connection on server startup

### DIFF
--- a/src/config/plugins/loadPlugins.ts
+++ b/src/config/plugins/loadPlugins.ts
@@ -6,7 +6,7 @@ import mongoose from "mongoose";
 // Only loads plugin data for the time if it's not currently present in the database
 const loadPlugins = async (): Promise<void> => {
   try {
-    await mongoose.connect(process.env.MONGO_URI as string);
+    await mongoose.connect(process.env.MONGO_DB_URL as string);
     logger.info("\x1b[1m\x1b[32m%s\x1b[0m", `Connected to the database`);
     const res = await Plugin.find();
     const databaseTitle = mongoose.connection.db.databaseName;

--- a/src/db.ts
+++ b/src/db.ts
@@ -3,11 +3,10 @@ import { MONGO_DB_URL } from "./constants";
 import { logger } from "./libraries";
 import { checkReplicaSet } from "./utilities/checkReplicaSet";
 
-let isConnected = false;
 let session!: mongoose.ClientSession;
 
 export const connect = async (dbName?: string): Promise<void> => {
-  if (isConnected) {
+  if (mongoose.connection.readyState !== 0) {
     return;
   }
 
@@ -22,7 +21,6 @@ export const connect = async (dbName?: string): Promise<void> => {
     } else {
       logger.info("Session not started --> Not Connected to a replica set!");
     }
-    isConnected = true;
   } catch (error: unknown) {
     if (error instanceof Error) {
       const errorMessage = error.toString();
@@ -58,13 +56,12 @@ export const connect = async (dbName?: string): Promise<void> => {
 };
 
 export const disconnect = async (): Promise<void> => {
-  if (!isConnected) {
+  if (mongoose.connection.readyState === 0) {
     logger.warn("No active database connection to disconnect.");
     return;
   }
   session?.endSession();
   await mongoose.connection.close();
-  isConnected = false;
 };
 
 export { session };

--- a/src/db.ts
+++ b/src/db.ts
@@ -6,10 +6,12 @@ import { checkReplicaSet } from "./utilities/checkReplicaSet";
 let session!: mongoose.ClientSession;
 
 export const connect = async (dbName?: string): Promise<void> => {
+  // firstly we check if a connection to the database already exists.
   if (mongoose.connection.readyState !== 0) {
+    // if the connection state is not 0, it means a connection already exists so we return.
     return;
   }
-
+  // if no connection exists, we try to establish a new connection.
   try {
     await mongoose.connect(MONGO_DB_URL as string, {
       dbName,


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

bugfix

**Issue Number:**

Fixes #2161

**Did you add tests for your changes?**

No

**Snapshots/Videos:**

<img width="1280" alt="image" src="https://github.com/PalisadoesFoundation/talawa-api/assets/97400153/302ba1a5-d87f-4922-aeca-fe5870ee289a">

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

No
<!--Add link to Talawa-Docs.-->

**Summary**

1. This PR resolves a bug causing server errors due to an incorrect MongoDB URI in the loadPlugin function.
2. It prevents multiple database connections during startup by implementing logic to check for existing connections before establishing a new one.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes
