### PR TITLE
 Fix superadmin access issue with user-posted media

### DIFF
--- a/src/resolvers/Organization/posts.ts
+++ b/src/resolvers/Organization/posts.ts
@@ -27,7 +27,11 @@ import { MAXIMUM_FETCH_LIMIT } from "../../constants";
  *
  * @throws GraphQLError Throws an error if the provided arguments are invalid.
  */
-export const posts: OrganizationResolvers["posts"] = async (parent, args) => {
+export const posts: OrganizationResolvers["posts"] = async (
+  parent,
+  args,
+  context,
+) => {
   const parseGraphQLConnectionArgumentsResult =
     await parseGraphQLConnectionArguments({
       args,
@@ -75,12 +79,19 @@ export const posts: OrganizationResolvers["posts"] = async (parent, args) => {
       .countDocuments()
       .exec(),
   ]);
+
+  const posts = objectList.map((post: InterfacePost) => ({
+    ...post,
+    imageUrl: post.imageUrl ? `${context.apiRootUrl}${post.imageUrl}` : null,
+    videoUrl: post.videoUrl ? `${context.apiRootUrl}${post.videoUrl}` : null,
+  }));
+
   return transformToDefaultGraphQLConnection<
     ParsedCursor,
     InterfacePost,
     InterfacePost
   >({
-    objectList,
+    objectList: posts,
     parsedArgs,
     totalCount,
   });


### PR DESCRIPTION
<!--


**What kind of change does this PR introduce?**

 a bugfix

**Issue Number:**

Fixes #2307 

**Did you add tests for your changes?**

tested locally on the machine

**Snapshots/Videos:**

https://github.com/PalisadoesFoundation/talawa-api/assets/71646466/3b5dff38-9f11-4304-b0d9-6f83bff19361


**If relevant, did you update the documentation?**

Not required

**Summary**

there was an issue in organization's post resolver which was breaking superadmin to access the org in which the media is posted.

**Does this PR introduce a breaking change?**

NO

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the posts resolver to include `imageUrl` and `videoUrl` with appropriate prefixes for better media handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->