### PR TITLE
 Fix superadmin access #2307 with user-posted media

### DIFF
--- a/src/resolvers/Organization/posts.ts
+++ b/src/resolvers/Organization/posts.ts
@@ -27,7 +27,11 @@ import { MAXIMUM_FETCH_LIMIT } from "../../constants";
  *
  * @throws GraphQLError Throws an error if the provided arguments are invalid.
  */
-export const posts: OrganizationResolvers["posts"] = async (parent, args) => {
+export const posts: OrganizationResolvers["posts"] = async (
+  parent,
+  args,
+  context,
+) => {
   const parseGraphQLConnectionArgumentsResult =
     await parseGraphQLConnectionArguments({
       args,
@@ -75,12 +79,17 @@ export const posts: OrganizationResolvers["posts"] = async (parent, args) => {
       .countDocuments()
       .exec(),
   ]);
+  const posts = objectList.map((post: InterfacePost) => ({
+    ...post,
+    imageUrl: post.imageUrl ? `${context.apiRootUrl}${post.imageUrl}` : null,
+    videoUrl: post.videoUrl ? `${context.apiRootUrl}${post.videoUrl}` : null,
+  }));
   return transformToDefaultGraphQLConnection<
     ParsedCursor,
     InterfacePost,
     InterfacePost
   >({
-    objectList,
+    objectList: posts,
     parsedArgs,
     totalCount,
   });

--- a/src/resolvers/Organization/posts.ts
+++ b/src/resolvers/Organization/posts.ts
@@ -81,8 +81,12 @@ export const posts: OrganizationResolvers["posts"] = async (
   ]);
   const posts = objectList.map((post: InterfacePost) => ({
     ...post,
-    imageUrl: post.imageUrl ? `${context.apiRootUrl}${post.imageUrl}` : null,
-    videoUrl: post.videoUrl ? `${context.apiRootUrl}${post.videoUrl}` : null,
+    imageUrl: post.imageUrl
+      ? new URL(post.imageUrl, context.apiRootUrl).toString()
+      : null,
+    videoUrl: post.videoUrl
+      ? new URL(post.videoUrl, context.apiRootUrl).toString()
+      : null,
   }));
   return transformToDefaultGraphQLConnection<
     ParsedCursor,

--- a/tests/resolvers/Organization/posts.spec.ts
+++ b/tests/resolvers/Organization/posts.spec.ts
@@ -70,7 +70,7 @@ describe("resolvers -> Organization -> post", () => {
       creatorId: testUser?._id,
     }).countDocuments();
 
-    const context = { apiRootUrl: undefined };
+    const context = { apiRootUrl: "http://example.com" };
 
     const formattedPost2 = {
       ...testPost2?.toObject(),

--- a/tests/resolvers/Organization/posts.spec.ts
+++ b/tests/resolvers/Organization/posts.spec.ts
@@ -9,7 +9,6 @@ import {
   parseCursor,
   posts as postResolver,
 } from "../../../src/resolvers/Organization/posts";
-import type { PostEdge } from "../../../src/types/generatedGraphQLTypes";
 import type { DefaultGraphQLArgumentError } from "../../../src/utilities/graphQLConnection";
 import { connect, disconnect } from "../../helpers/db";
 import { createTestPost, type TestPostType } from "../../helpers/posts";
@@ -71,12 +70,66 @@ describe("resolvers -> Organization -> post", () => {
       creatorId: testUser?._id,
     }).countDocuments();
 
-    expect((connection?.edges[0] as unknown as PostEdge).cursor).toEqual(
-      testPost2?._id.toString(),
-    );
-    expect((connection?.edges[1] as unknown as PostEdge).cursor).toEqual(
-      testPost?._id.toString(),
-    );
+    const context = { apiRootUrl: undefined };
+
+    const formattedPost2 = {
+      ...testPost2?.toObject(),
+      imageUrl: testPost2?.imageUrl
+        ? new URL(testPost2.imageUrl, context.apiRootUrl).toString()
+        : null,
+      videoUrl: testPost2?.videoUrl
+        ? new URL(testPost2.videoUrl, context.apiRootUrl).toString()
+        : null,
+    };
+
+    const formattedPost = {
+      ...testPost?.toObject(),
+      imageUrl: testPost?.imageUrl
+        ? new URL(testPost.imageUrl, context.apiRootUrl).toString()
+        : null,
+      videoUrl: testPost?.videoUrl
+        ? new URL(testPost.videoUrl, context.apiRootUrl).toString()
+        : null,
+    };
+
+    expect(connection).toEqual({
+      edges: [
+        {
+          cursor: formattedPost2._id?.toString(),
+          node: {
+            ...formattedPost2,
+            _id: formattedPost2._id?.toString(),
+            imageUrl: testPost?.imageUrl
+              ? new URL(testPost.imageUrl, context.apiRootUrl).toString()
+              : null,
+            videoUrl: formattedPost2?.videoUrl
+              ? new URL(formattedPost2.videoUrl, context.apiRootUrl).toString()
+              : null,
+          },
+        },
+        {
+          cursor: formattedPost._id?.toString(),
+          node: {
+            ...formattedPost,
+            _id: formattedPost?._id?.toString(),
+            imageUrl: formattedPost?.imageUrl
+              ? new URL(formattedPost.imageUrl, context.apiRootUrl).toString()
+              : null,
+            videoUrl: formattedPost?.videoUrl
+              ? new URL(formattedPost.videoUrl, context.apiRootUrl).toString()
+              : null,
+          },
+        },
+      ],
+      pageInfo: {
+        endCursor: testPost?._id.toString(),
+        hasNextPage: false,
+        hasPreviousPage: false,
+        startCursor: testPost2?._id.toString(),
+      },
+      totalCount,
+    });
+
     expect(connection?.pageInfo.endCursor).toEqual(testPost?._id.toString());
     expect(connection?.pageInfo.hasNextPage).toBe(false);
     expect(connection?.pageInfo.hasPreviousPage).toBe(false);


### PR DESCRIPTION


**What kind of change does this PR introduce?**

 bugfix

**Issue Number:**

Fixes #2307 

**Did you add tests for your changes?**

tested locally on the machine

**Snapshots/Videos:**

https://github.com/PalisadoesFoundation/talawa-api/assets/71646466/53e978cf-0106-49bc-99ad-e69280c2c30b




**If relevant, did you update the documentation?**

No need

**Summary**

There was an issue with organization's post resolver which was not letting the super-admin accessing the organization in which user posted the media.

**Does this PR introduce a breaking change?**

NO

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved post resolver to dynamically update `imageUrl` and `videoUrl` based on the context, ensuring URLs are always up-to-date.

- **Bug Fixes**
  - Enhanced post data formatting and comparison in tests to ensure consistency and accuracy in post-related functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->