### PR TITLE
added field connection resolver for organization events

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -769,6 +769,17 @@ input EventWhereInput {
   title_starts_with: String
 }
 
+type EventsConnection {
+  edges: [EventsConnectionEdge!]!
+  pageInfo: DefaultConnectionPageInfo!
+  totalCount: Int
+}
+
+type EventsConnectionEdge {
+  cursor: String!
+  node: Event!
+}
+
 type ExtendSession {
   accessToken: String!
   refreshToken: String!
@@ -1190,6 +1201,7 @@ type Organization {
   creator: User
   customFields: [OrganizationCustomField!]!
   description: String!
+  events(after: String, before: String, first: Int, last: Int): EventsConnection
   funds: [Fund]
   image: String
   members: [User]

--- a/src/resolvers/Organization/events.ts
+++ b/src/resolvers/Organization/events.ts
@@ -1,0 +1,122 @@
+import type { OrganizationResolvers } from "../../types/generatedGraphQLTypes";
+import { MAXIMUM_FETCH_LIMIT } from "../../constants";
+import {
+  type DefaultGraphQLArgumentError,
+  type ParseGraphQLConnectionCursorArguments,
+  type ParseGraphQLConnectionCursorResult,
+  getCommonGraphQLConnectionFilter,
+  getCommonGraphQLConnectionSort,
+  parseGraphQLConnectionArguments,
+  transformToDefaultGraphQLConnection,
+} from "../../utilities/graphQLConnection";
+import { GraphQLError } from "graphql";
+import type { InterfaceEvent } from "../../models";
+import { Event } from "../../models";
+import type { Types } from "mongoose";
+
+/**
+ * This is a non-root field connection resolver for fetching events created wihtin an
+ * organization using relay specification compliant cursor pagination. More info here:-
+ * {@link https://relay.dev/graphql/connections.htm.}
+ */
+export const events: OrganizationResolvers["events"] = async (parent, args) => {
+  const parseArgsResult = await parseGraphQLConnectionArguments({
+    args,
+    parseCursor: (args) =>
+      parseCursor({
+        ...args,
+        organizationId: parent._id,
+      }),
+    maximumLimit: MAXIMUM_FETCH_LIMIT,
+  });
+
+  if (parseArgsResult.isSuccessful === false) {
+    throw new GraphQLError("Invalid arguments provided.", {
+      extensions: {
+        code: "INVALID_ARGUMENTS",
+        errors: parseArgsResult.errors,
+      },
+    });
+  }
+
+  const { parsedArgs } = parseArgsResult;
+
+  const filter = getCommonGraphQLConnectionFilter({
+    cursor: parsedArgs.cursor,
+    direction: parsedArgs.direction,
+  });
+
+  const sort = getCommonGraphQLConnectionSort({
+    direction: parsedArgs.direction,
+  });
+
+  const [objectList, totalCount] = await Promise.all([
+    Event.find({
+      ...filter,
+      organization: parent._id,
+    })
+      .sort(sort)
+      .limit(parsedArgs.limit)
+      .lean()
+      .exec(),
+
+    Event.find({
+      organization: parent._id,
+    })
+      .countDocuments()
+      .exec(),
+  ]);
+
+  return transformToDefaultGraphQLConnection<
+    ParsedCursor,
+    InterfaceEvent,
+    InterfaceEvent
+  >({
+    objectList,
+    parsedArgs,
+    totalCount,
+  });
+};
+
+/*
+This is typescript type of the parsed cursor for this connection resolver.
+*/
+type ParsedCursor = string;
+
+/*
+This function is used to validate and transform the cursor passed to this connnection
+resolver.
+*/
+export const parseCursor = async ({
+  cursorValue,
+  cursorName,
+  cursorPath,
+  organizationId,
+}: ParseGraphQLConnectionCursorArguments & {
+  organizationId: string | Types.ObjectId;
+}): ParseGraphQLConnectionCursorResult<ParsedCursor> => {
+  const errors: DefaultGraphQLArgumentError[] = [];
+  const event = await Event.findOne({
+    _id: cursorValue,
+    organization: organizationId,
+  });
+
+  if (!event) {
+    errors.push({
+      message: `Argument ${cursorName} is an invalid cursor.`,
+      path: cursorPath,
+    });
+  }
+
+  if (errors.length !== 0) {
+    return {
+      errors,
+      isSuccessful: false,
+    };
+  }
+
+  return {
+    isSuccessful: true,
+    parsedCursor: cursorValue,
+  };
+};

--- a/src/typeDefs/types.ts
+++ b/src/typeDefs/types.ts
@@ -277,6 +277,17 @@ export const types = gql`
     agendaItems: [AgendaItem]
   }
 
+  type EventsConnection {
+    edges: [EventsConnectionEdge!]!
+    pageInfo: DefaultConnectionPageInfo!
+    totalCount: Int
+  }
+
+  type EventsConnectionEdge {
+    cursor: String!
+    node: Event!
+  }
+
   type EventVolunteer {
     _id: ID!
     createdAt: DateTime!
@@ -459,6 +470,12 @@ export const types = gql`
     actionItemCategories: [ActionItemCategory]
     agendaCategories: [AgendaCategory]
     admins(adminId: ID): [User!]
+    events(
+      after: String
+      before: String
+      first: Int
+      last: Int
+    ): EventsConnection
     membershipRequests(
       first: Int
       skip: Int

--- a/src/types/generatedGraphQLTypes.ts
+++ b/src/types/generatedGraphQLTypes.ts
@@ -852,6 +852,19 @@ export type EventWhereInput = {
   title_starts_with?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type EventsConnection = {
+  __typename?: 'EventsConnection';
+  edges: Array<EventsConnectionEdge>;
+  pageInfo: DefaultConnectionPageInfo;
+  totalCount?: Maybe<Scalars['Int']['output']>;
+};
+
+export type EventsConnectionEdge = {
+  __typename?: 'EventsConnectionEdge';
+  cursor: Scalars['String']['output'];
+  node: Event;
+};
+
 export type ExtendSession = {
   __typename?: 'ExtendSession';
   accessToken: Scalars['String']['output'];
@@ -1945,6 +1958,7 @@ export type Organization = {
   creator?: Maybe<User>;
   customFields: Array<OrganizationCustomField>;
   description: Scalars['String']['output'];
+  events?: Maybe<EventsConnection>;
   funds?: Maybe<Array<Maybe<Fund>>>;
   image?: Maybe<Scalars['String']['output']>;
   members?: Maybe<Array<Maybe<User>>>;
@@ -1966,6 +1980,14 @@ export type OrganizationAdminsArgs = {
 
 
 export type OrganizationAdvertisementsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type OrganizationEventsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -3161,7 +3183,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 ) => TResult | Promise<TResult>;
 
 /** Mapping of union types */
-export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
+export type ResolversUnionTypes<_RefType extends Record<string, unknown>> = {
   ConnectionError: ( InvalidCursor ) | ( MaximumValueError );
   CreateAdminError: ( OrganizationMemberNotFoundError ) | ( OrganizationNotFoundError ) | ( UserNotAuthorizedError ) | ( UserNotFoundError );
   CreateCommentError: ( PostNotFoundError );
@@ -3170,7 +3192,7 @@ export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
 };
 
 /** Mapping of interface types */
-export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = {
   ConnectionPageInfo: ( DefaultConnectionPageInfo );
   Error: ( MemberNotFoundError ) | ( OrganizationMemberNotFoundError ) | ( OrganizationNotFoundError ) | ( PostNotFoundError ) | ( UnauthenticatedError ) | ( UnauthorizedError ) | ( UserNotAuthorizedAdminError ) | ( UserNotAuthorizedError ) | ( UserNotFoundError );
   FieldError: ( InvalidCursor ) | ( MaximumLengthError ) | ( MaximumValueError ) | ( MinimumLengthError ) | ( MinimumValueError );
@@ -3248,6 +3270,8 @@ export type ResolversTypes = {
   EventVolunteerInput: EventVolunteerInput;
   EventVolunteerResponse: EventVolunteerResponse;
   EventWhereInput: EventWhereInput;
+  EventsConnection: ResolverTypeWrapper<Omit<EventsConnection, 'edges'> & { edges: Array<ResolversTypes['EventsConnectionEdge']> }>;
+  EventsConnectionEdge: ResolverTypeWrapper<Omit<EventsConnectionEdge, 'node'> & { node: ResolversTypes['Event'] }>;
   ExtendSession: ResolverTypeWrapper<ExtendSession>;
   Feedback: ResolverTypeWrapper<InterfaceFeedbackModel>;
   FeedbackInput: FeedbackInput;
@@ -3451,6 +3475,8 @@ export type ResolversParentTypes = {
   EventVolunteerGroupInput: EventVolunteerGroupInput;
   EventVolunteerInput: EventVolunteerInput;
   EventWhereInput: EventWhereInput;
+  EventsConnection: Omit<EventsConnection, 'edges'> & { edges: Array<ResolversParentTypes['EventsConnectionEdge']> };
+  EventsConnectionEdge: Omit<EventsConnectionEdge, 'node'> & { node: ResolversParentTypes['Event'] };
   ExtendSession: ExtendSession;
   Feedback: InterfaceFeedbackModel;
   FeedbackInput: FeedbackInput;
@@ -3979,6 +4005,19 @@ export type EventVolunteerGroupResolvers<ContextType = any, ParentType extends R
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type EventsConnectionResolvers<ContextType = any, ParentType extends ResolversParentTypes['EventsConnection'] = ResolversParentTypes['EventsConnection']> = {
+  edges?: Resolver<Array<ResolversTypes['EventsConnectionEdge']>, ParentType, ContextType>;
+  pageInfo?: Resolver<ResolversTypes['DefaultConnectionPageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type EventsConnectionEdgeResolvers<ContextType = any, ParentType extends ResolversParentTypes['EventsConnectionEdge'] = ResolversParentTypes['EventsConnectionEdge']> = {
+  cursor?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<ResolversTypes['Event'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type ExtendSessionResolvers<ContextType = any, ParentType extends ResolversParentTypes['ExtendSession'] = ResolversParentTypes['ExtendSession']> = {
   accessToken?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   refreshToken?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -4322,6 +4361,7 @@ export type OrganizationResolvers<ContextType = any, ParentType extends Resolver
   creator?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
   customFields?: Resolver<Array<ResolversTypes['OrganizationCustomField']>, ParentType, ContextType>;
   description?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  events?: Resolver<Maybe<ResolversTypes['EventsConnection']>, ParentType, ContextType, Partial<OrganizationEventsArgs>>;
   funds?: Resolver<Maybe<Array<Maybe<ResolversTypes['Fund']>>>, ParentType, ContextType>;
   image?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   members?: Resolver<Maybe<Array<Maybe<ResolversTypes['User']>>>, ParentType, ContextType>;
@@ -4741,6 +4781,8 @@ export type Resolvers<ContextType = any> = {
   EventAttendee?: EventAttendeeResolvers<ContextType>;
   EventVolunteer?: EventVolunteerResolvers<ContextType>;
   EventVolunteerGroup?: EventVolunteerGroupResolvers<ContextType>;
+  EventsConnection?: EventsConnectionResolvers<ContextType>;
+  EventsConnectionEdge?: EventsConnectionEdgeResolvers<ContextType>;
   ExtendSession?: ExtendSessionResolvers<ContextType>;
   Feedback?: FeedbackResolvers<ContextType>;
   FieldError?: FieldErrorResolvers<ContextType>;

--- a/tests/resolvers/Organization/events.spec.ts
+++ b/tests/resolvers/Organization/events.spec.ts
@@ -1,0 +1,158 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import "dotenv/config";
+import { GraphQLError } from "graphql";
+import type mongoose from "mongoose";
+import { Types } from "mongoose";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  type InterfaceOrganization,
+  Event,
+  Organization,
+  User,
+} from "../../../src/models";
+import {
+  events as eventsResolver,
+  parseCursor,
+} from "../../../src/resolvers/Organization/events";
+import type { DefaultGraphQLArgumentError } from "../../../src/utilities/graphQLConnection";
+import { connect, disconnect } from "../../helpers/db";
+import type { TestEventType } from "../../helpers/events";
+import { nanoid } from "nanoid";
+
+let MONGOOSE_INSTANCE: typeof mongoose;
+let testEvent1: TestEventType,
+  testEvent2: TestEventType,
+  testOrganization: InterfaceOrganization;
+
+beforeAll(async () => {
+  MONGOOSE_INSTANCE = await connect();
+
+  const testUser = await User.create({
+    email: `email${nanoid()}@email.com`,
+    firstName: "firstName",
+    lastName: "lastName",
+    password: "passwordHash",
+  });
+
+  testOrganization = await Organization.create({
+    creatorId: testUser._id,
+    description: "description",
+    name: "name",
+  });
+
+  const testEvents = await Event.insertMany([
+    {
+      allDay: true,
+      creatorId: testUser._id,
+      description: "description",
+      isPublic: true,
+      isRegisterable: true,
+      organization: testOrganization._id,
+      startDate: new Date(),
+      title: "title",
+    },
+    {
+      allDay: true,
+      creatorId: testUser._id,
+      description: "description",
+      isPublic: true,
+      isRegisterable: true,
+      organization: testOrganization._id,
+      startDate: new Date(),
+      title: "title",
+    },
+  ]);
+  testEvent1 = testEvents[0].toObject();
+  testEvent2 = testEvents[1].toObject();
+});
+
+afterAll(async () => {
+  await disconnect(MONGOOSE_INSTANCE);
+});
+
+describe("events resolver", () => {
+  const parent = testOrganization;
+  it(`throws GraphQLError if invalid arguments are provided to the resolver`, async () => {
+    try {
+      await eventsResolver?.(parent, {}, {});
+    } catch (error) {
+      if (error instanceof GraphQLError) {
+        expect(error.extensions.code).toEqual("INVALID_ARGUMENTS");
+        expect(
+          (error.extensions.errors as DefaultGraphQLArgumentError[]).length
+        ).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it(`returns the expected connection object`, async () => {
+    const parent = testOrganization;
+    const connection = await eventsResolver?.(
+      parent,
+      {
+        first: 2,
+      },
+      {}
+    );
+
+    const totalCount = await Event.find({
+      organization: testOrganization?._id,
+    }).countDocuments();
+
+    expect(connection).toEqual({
+      edges: [
+        {
+          cursor: testEvent2?._id.toString(),
+          node: {
+            ...testEvent2,
+            _id: testEvent2?._id.toString(),
+          },
+        },
+        {
+          cursor: testEvent1?._id.toString(),
+          node: {
+            ...testEvent1,
+            _id: testEvent1?._id.toString(),
+          },
+        },
+      ],
+      pageInfo: {
+        endCursor: testEvent1?._id.toString(),
+        hasNextPage: false,
+        hasPreviousPage: false,
+        startCursor: testEvent2?._id.toString(),
+      },
+      totalCount,
+    });
+  });
+});
+
+describe("parseCursor function", () => {
+  it("returns failure state if argument cursorValue is an invalid cursor", async () => {
+    const result = await parseCursor({
+      cursorName: "after",
+      cursorPath: ["after"],
+      cursorValue: new Types.ObjectId().toString(),
+      organizationId: testOrganization?._id.toString() as string,
+    });
+
+    expect(result.isSuccessful).toEqual(false);
+    if (result.isSuccessful === false) {
+      expect(result.errors.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns success state if argument cursorValue is a valid cursor", async () => {
+    const result = await parseCursor({
+      cursorName: "after",
+      cursorPath: ["after"],
+      cursorValue: testEvent1?._id.toString() as string,
+      organizationId: testOrganization?._id.toString() as string,
+    });
+
+    expect(result.isSuccessful).toEqual(true);
+    if (result.isSuccessful === true) {
+      expect(result.parsedCursor).toEqual(testEvent1?._id.toString());
+    }
+  });
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

feature

**Issue Number:**

Fixes #2319

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

-

**If relevant, did you update the documentation?**

-

**Summary**

Added field connection resolver for an organization's events to enable cursor pagination on them.

**Does this PR introduce a breaking change?**

-

**Other information**

-

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced cursor-based pagination for fetching events within an organization.
  - Added new types `EventsConnection` and `EventsConnectionEdge` to enhance event data handling.

- **Bug Fixes**
  - Ensured accurate event fetching through robust cursor validation and transformation.

- **Tests**
  - Implemented comprehensive tests for the new `events` resolver and cursor parsing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->