### PR TITLE
UpdatedBy field changed to userId

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1649,7 +1649,6 @@ input UpdateAgendaItemInput {
   relatedEvent: ID
   sequence: Int
   title: String
-  updatedBy: ID!
   urls: [String]
   users: [ID]
 }

--- a/src/typeDefs/inputs.ts
+++ b/src/typeDefs/inputs.ts
@@ -65,7 +65,6 @@ export const inputs = gql`
     duration: String
     attachments: [String]
     relatedEvent: ID
-    updatedBy: ID!
     urls: [String]
     users: [ID]
     categories: [ID]

--- a/src/types/generatedGraphQLTypes.ts
+++ b/src/types/generatedGraphQLTypes.ts
@@ -2719,7 +2719,6 @@ export type UpdateAgendaItemInput = {
   relatedEvent?: InputMaybe<Scalars['ID']['input']>;
   sequence?: InputMaybe<Scalars['Int']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
-  updatedBy: Scalars['ID']['input'];
   urls?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   users?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
 };

--- a/tests/resolvers/Mutation/updateAgendaItem.spec.ts
+++ b/tests/resolvers/Mutation/updateAgendaItem.spec.ts
@@ -108,7 +108,7 @@ describe("resolvers -> Mutation -> updateAgendaItem", () => {
       const args: MutationUpdateAgendaItemArgs = {
         id: "",
         input: {
-          updatedBy: new Types.ObjectId().toString(),
+          title: "Test Item New",
         },
       };
 
@@ -126,7 +126,7 @@ describe("resolvers -> Mutation -> updateAgendaItem", () => {
       const args: MutationUpdateAgendaItemArgs = {
         id: new Types.ObjectId().toString(),
         input: {
-          updatedBy: testAdminUser?._id,
+          title: "Test Item New",
         },
       };
 
@@ -146,7 +146,7 @@ describe("resolvers -> Mutation -> updateAgendaItem", () => {
       const args: MutationUpdateAgendaItemArgs = {
         id: testAgendaItem._id.toString(),
         input: {
-          updatedBy: testUser?._id,
+          title: "Test Item New",
         },
       };
 
@@ -165,7 +165,6 @@ describe("resolvers -> Mutation -> updateAgendaItem", () => {
     const args: MutationUpdateAgendaItemArgs = {
       id: testAgendaItem._id.toString(),
       input: {
-        updatedBy: testAdminUser?._id,
         title: "Test Item New",
         duration: "One hour plus extra time ",
         relatedEvent: testEvent?._id.toString(),
@@ -199,7 +198,6 @@ describe("resolvers -> Mutation -> updateAgendaItem", () => {
       id: testAgendaItem?._id,
       input: {
         description: "Updated Description",
-        updatedBy: testUser?._id,
       },
     };
 


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Feature
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #2358 

**Did you add tests for your changes?**

<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**
![image](https://github.com/PalisadoesFoundation/talawa-api/assets/137816099/fc8787f1-e76f-41b8-b30d-774a943208d3)

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the `updatedBy` field from the `UpdateAgendaItemInput` type to resolve user update inconsistencies.

- **Tests**
  - Updated test cases for `updateAgendaItem` to replace the `updatedBy` field with `title` and `description` fields for validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->