### PR TITLE
Added `usertags` connection (GSoC)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -336,7 +336,7 @@ input CreateUserTagInput {
   name: String!
   organizationId: ID!
   parentTagId: ID
-  tagColor: String!
+  tagColor: String
 }
 
 enum Currency {
@@ -1913,6 +1913,7 @@ type UserTag {
 type UserTagsConnection {
   edges: [UserTagsConnectionEdge!]!
   pageInfo: DefaultConnectionPageInfo!
+  totalCount: PositiveInt
 }
 
 """A default connection edge on the UserTag type for UserTagsConnection."""

--- a/src/resolvers/Organization/index.ts
+++ b/src/resolvers/Organization/index.ts
@@ -11,6 +11,7 @@ import { membershipRequests } from "./membershipRequests";
 import { pinnedPosts } from "./pinnedPosts";
 import { posts } from "./posts";
 import { advertisements } from "./advertisements";
+import { userTags } from "./userTags";
 
 import { venues } from "./venues";
 // import { userTags } from "./userTags";
@@ -27,7 +28,7 @@ export const Organization: OrganizationResolvers = {
   membershipRequests,
   pinnedPosts,
   funds,
+  userTags,
   posts,
   venues,
-  // userTags,
 };

--- a/src/resolvers/Organization/userTags.ts
+++ b/src/resolvers/Organization/userTags.ts
@@ -1,0 +1,120 @@
+import type { OrganizationResolvers } from "../../types/generatedGraphQLTypes";
+import type { InterfaceOrganizationTagUser } from "../../models";
+import { OrganizationTagUser } from "../../models";
+import {
+  getCommonGraphQLConnectionFilter,
+  getCommonGraphQLConnectionSort,
+  parseGraphQLConnectionArguments,
+  transformToDefaultGraphQLConnection,
+  type DefaultGraphQLArgumentError,
+  type ParseGraphQLConnectionCursorArguments,
+  type ParseGraphQLConnectionCursorResult,
+} from "../../utilities/graphQLConnection";
+import { GraphQLError } from "graphql";
+import { MAXIMUM_FETCH_LIMIT } from "../../constants";
+import type { Types } from "mongoose";
+
+export const userTags: OrganizationResolvers["userTags"] = async (
+  parent,
+  args,
+) => {
+  const parseGraphQLConnectionArgumentsResult =
+    await parseGraphQLConnectionArguments({
+      args,
+      parseCursor: (args) =>
+        parseCursor({
+          ...args,
+          organizationId: parent._id,
+        }),
+      maximumLimit: MAXIMUM_FETCH_LIMIT,
+    });
+
+  if (!parseGraphQLConnectionArgumentsResult.isSuccessful) {
+    throw new GraphQLError("Invalid arguments provided.", {
+      extensions: {
+        code: "INVALID_ARGUMENTS",
+        errors: parseGraphQLConnectionArgumentsResult.errors,
+      },
+    });
+  }
+
+  const { parsedArgs } = parseGraphQLConnectionArgumentsResult;
+
+  const filter = getCommonGraphQLConnectionFilter({
+    cursor: parsedArgs.cursor,
+    direction: parsedArgs.direction,
+  });
+
+  const sort = getCommonGraphQLConnectionSort({
+    direction: parsedArgs.direction,
+  });
+
+  const [objectList, totalCount] = await Promise.all([
+    OrganizationTagUser.find({
+      ...filter,
+      organizationId: parent._id,
+    })
+      .sort(sort)
+      .limit(parsedArgs.limit)
+      .lean()
+      .exec(),
+    OrganizationTagUser.find({
+      organizationId: parent._id,
+    })
+      .countDocuments()
+      .exec(),
+  ]);
+
+  return transformToDefaultGraphQLConnection<
+    ParsedCursor,
+    InterfaceOrganizationTagUser,
+    InterfaceOrganizationTagUser
+  >({
+    objectList,
+    parsedArgs,
+    totalCount,
+  });
+};
+
+/*
+This is typescript type of the parsed cursor for this connection resolver.
+*/
+type ParsedCursor = string;
+
+/*
+This function is used to validate and transform the cursor passed to this connnection
+resolver.
+*/
+export const parseCursor = async ({
+  cursorValue,
+  cursorName,
+  cursorPath,
+  organizationId,
+}: ParseGraphQLConnectionCursorArguments & {
+  organizationId: string | Types.ObjectId;
+}): ParseGraphQLConnectionCursorResult<ParsedCursor> => {
+  const errors: DefaultGraphQLArgumentError[] = [];
+  const tag = await OrganizationTagUser.findOne({
+    _id: cursorValue,
+    organizationId,
+  });
+
+  if (!tag) {
+    errors.push({
+      message: `Argument ${cursorName} is an invalid cursor.`,
+      path: cursorPath,
+    });
+  }
+
+  if (errors.length !== 0) {
+    return {
+      errors,
+      isSuccessful: false,
+    };
+  }
+
+  return {
+    isSuccessful: true,
+    parsedCursor: cursorValue,
+  };
+};

--- a/src/typeDefs/inputs.ts
+++ b/src/typeDefs/inputs.ts
@@ -34,7 +34,7 @@ export const inputs = gql`
 
   input CreateUserTagInput {
     name: String!
-    tagColor: String!
+    tagColor: String
     parentTagId: ID
     organizationId: ID!
   }

--- a/src/typeDefs/types.ts
+++ b/src/typeDefs/types.ts
@@ -738,6 +738,7 @@ export const types = gql`
   type UserTagsConnection {
     edges: [UserTagsConnectionEdge!]!
     pageInfo: DefaultConnectionPageInfo!
+    totalCount: PositiveInt
   }
 
   """

--- a/src/types/generatedGraphQLTypes.ts
+++ b/src/types/generatedGraphQLTypes.ts
@@ -414,7 +414,7 @@ export type CreateUserTagInput = {
   name: Scalars['String']['input'];
   organizationId: Scalars['ID']['input'];
   parentTagId?: InputMaybe<Scalars['ID']['input']>;
-  tagColor: Scalars['String']['input'];
+  tagColor?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type Currency =
@@ -3020,6 +3020,7 @@ export type UserTagsConnection = {
   __typename?: 'UserTagsConnection';
   edges: Array<UserTagsConnectionEdge>;
   pageInfo: DefaultConnectionPageInfo;
+  totalCount?: Maybe<Scalars['PositiveInt']['output']>;
 };
 
 /** A default connection edge on the UserTag type for UserTagsConnection. */
@@ -4706,6 +4707,7 @@ export type UserTagResolvers<ContextType = any, ParentType extends ResolversPare
 export type UserTagsConnectionResolvers<ContextType = any, ParentType extends ResolversParentTypes['UserTagsConnection'] = ResolversParentTypes['UserTagsConnection']> = {
   edges?: Resolver<Array<ResolversTypes['UserTagsConnectionEdge']>, ParentType, ContextType>;
   pageInfo?: Resolver<ResolversTypes['DefaultConnectionPageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<Maybe<ResolversTypes['PositiveInt']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/tests/resolvers/Organization/userTags.spec.ts
+++ b/tests/resolvers/Organization/userTags.spec.ts
@@ -1,0 +1,121 @@
+import "dotenv/config";
+import { GraphQLError } from "graphql";
+import type mongoose from "mongoose";
+import { Types } from "mongoose";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type {
+  InterfaceOrganization} from "../../../src/models";
+import {
+  OrganizationTagUser,
+} from "../../../src/models";
+import {
+  parseCursor,
+  userTags as userTagsResolver,
+} from "../../../src/resolvers/Organization/userTags";
+import type { DefaultGraphQLArgumentError } from "../../../src/utilities/graphQLConnection";
+import { connect, disconnect } from "../../helpers/db";
+import type { TestUserTagType } from "../../helpers/tags";
+import { createRootTagsWithOrg } from "../../helpers/tags";
+import type { TestOrganizationType } from "../../helpers/userAndOrg";
+
+let MONGOOSE_INSTANCE: typeof mongoose;
+let testUserTag1: TestUserTagType, testUserTag2: TestUserTagType;
+let testOrganization: TestOrganizationType;
+
+beforeAll(async () => {
+  MONGOOSE_INSTANCE = await connect();
+  [, testOrganization, [testUserTag1, testUserTag2]] =
+    await createRootTagsWithOrg(2);
+});
+
+afterAll(async () => {
+  await disconnect(MONGOOSE_INSTANCE);
+});
+
+describe("userTags resolver", () => {
+  const parent = testOrganization?.toObject() as InterfaceOrganization;
+  it(`throws GraphQLError if invalid arguments are provided to the resolver`, async () => {
+    try {
+      await userTagsResolver?.(parent, {}, {});
+    } catch (error) {
+      if (error instanceof GraphQLError) {
+        expect(error.extensions.code).toEqual("INVALID_ARGUMENTS");
+        expect(
+          (error.extensions.errors as DefaultGraphQLArgumentError[]).length,
+        ).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it(`returns the expected connection object`, async () => {
+    const parent = testOrganization?.toObject() as InterfaceOrganization;
+
+    const connection = await userTagsResolver?.(
+      parent,
+      {
+        first: 2,
+      },
+      {},
+    );
+
+    const totalCount = await OrganizationTagUser.find({
+      organizationId: testOrganization?._id,
+    }).countDocuments();
+
+    expect(connection).toEqual({
+      edges: [
+        {
+          cursor: testUserTag2?._id.toString(),
+          node: {
+            ...testUserTag2,
+            _id: testUserTag2?._id.toString(),
+          },
+        },
+        {
+          cursor: testUserTag1?._id.toString(),
+          node: {
+            ...testUserTag1,
+            _id: testUserTag1?._id.toString(),
+          },
+        },
+      ],
+      pageInfo: {
+        endCursor: testUserTag1?._id.toString(),
+        hasNextPage: false,
+        hasPreviousPage: false,
+        startCursor: testUserTag2?._id.toString(),
+      },
+      totalCount,
+    });
+  });
+});
+
+describe("parseCursor function", () => {
+  it("returns failure state if argument cursorValue is an invalid cursor", async () => {
+    const result = await parseCursor({
+      cursorName: "after",
+      cursorPath: ["after"],
+      cursorValue: new Types.ObjectId().toString(),
+      organizationId: testOrganization?._id.toString() as string,
+    });
+
+    expect(result.isSuccessful).toEqual(false);
+    if (result.isSuccessful === false) {
+      expect(result.errors.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns success state if argument cursorValue is a valid cursor", async () => {
+    const result = await parseCursor({
+      cursorName: "after",
+      cursorPath: ["after"],
+      cursorValue: testUserTag1?._id.toString() as string,
+      organizationId: testOrganization?._id.toString() as string,
+    });
+
+    expect(result.isSuccessful).toEqual(true);
+    if (result.isSuccessful === true) {
+      expect(result.parsedCursor).toEqual(testUserTag1?._id.toString());
+    }
+  });
+});

--- a/tests/resolvers/Organization/userTags.spec.ts
+++ b/tests/resolvers/Organization/userTags.spec.ts
@@ -3,11 +3,8 @@ import { GraphQLError } from "graphql";
 import type mongoose from "mongoose";
 import { Types } from "mongoose";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type {
-  InterfaceOrganization} from "../../../src/models";
-import {
-  OrganizationTagUser,
-} from "../../../src/models";
+import type { InterfaceOrganization } from "../../../src/models";
+import { OrganizationTagUser } from "../../../src/models";
 import {
   parseCursor,
   userTags as userTagsResolver,


### PR DESCRIPTION
### What kind of change does this PR introduce?
It adds the `userTags` connection to the organization schema.

### Issue Number:

Fixes #2393

### Did you add tests for your changes?

Yes

### Does this PR introduce a breaking change?

No

### Other information

This needs to be merged first before the next PR for the corresponding issue in admin PalisadoesFoundation/talawa-admin#2037

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `userTags` resolver to fetch tags associated with an organization.
  - Added a `totalCount` field to `UserTagsConnection` to provide the total number of user tags.

- **Improvements**
  - Made the `tagColor` field optional in `CreateUserTagInput` to allow more flexibility.

- **Tests**
  - Added test cases for the `userTags` resolver and `parseCursor` function to ensure proper functionality and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->