### PR TITLE
Fixes issue #2565

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "lodash": "^4.17.21",
         "markdown-toc": "^1.2.0",
         "mongodb": "^6.8.0",
-        "mongoose": "^8.3.2",
+        "mongoose": "^8.7.0",
         "mongoose-paginate-v2": "^1.8.3",
         "morgan": "^1.10.0",
         "nanoid": "^5.0.7",
@@ -12774,9 +12774,10 @@
       "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
     },
     "node_modules/mongodb": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.8.0.tgz",
-      "integrity": "sha512-HGQ9NWDle5WvwMnrvUxsFYPd3JEbqD3RgABHBQRuoCEND0qzhsd0iH5ypHsf1eJ+sXmvmyKpP+FLOKY8Il7jMw==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.9.0.tgz",
+      "integrity": "sha512-UMopBVx1LmEUbW/QE0Hw18u583PEDVQmUmVzzBRH0o/xtE9DBRA5ZYLOjpLIa03i8FXjzvQECJcqoMvCXftTUA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.5",
         "bson": "^6.7.0",
@@ -12828,17 +12829,18 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.3.2.tgz",
-      "integrity": "sha512-3JcpDjFI25cF/3xpu+4+9nM0lURQTNLcP86X83+LvuICdn453QQLmhSrUr2IPM/ffLiDE9KPl9slNb2s0hZPpg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.7.0.tgz",
+      "integrity": "sha512-rUCSF1mMYQXjXYdqEQLLlMD3xbcj2j1/hRn+9VnVj7ipzru/UoUZxlj/hWmteKMAh4EFnDZ+BIrmma9l/0Hi1g==",
+      "license": "MIT",
       "dependencies": {
-        "bson": "^6.5.0",
+        "bson": "^6.7.0",
         "kareem": "2.6.3",
-        "mongodb": "6.5.0",
+        "mongodb": "6.9.0",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",
-        "sift": "16.0.1"
+        "sift": "17.1.3"
       },
       "engines": {
         "node": ">=16.20.1"
@@ -12854,51 +12856,6 @@
       "integrity": "sha512-Fkg9amsmtRkqUQ19kwOvw6XodkqXoySr82MkV5XPeD+1u/m68tWnDcz3xRwDPzlIsAr1ctx/4Rz/bnfD3PIJqQ==",
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/mongoose/node_modules/mongodb": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.5.0.tgz",
-      "integrity": "sha512-Fozq68InT+JKABGLqctgtb8P56pRrJFkbhW0ux+x1mdHeyinor8oNzJqwLjV/t5X5nJGfTlluxfyMnOXNggIUA==",
-      "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.5",
-        "bson": "^6.4.0",
-        "mongodb-connection-string-url": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.20.1"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.1.0",
-        "gcp-metadata": "^5.2.0",
-        "kerberos": "^2.0.1",
-        "mongodb-client-encryption": ">=6.0.0 <7",
-        "snappy": "^7.2.2",
-        "socks": "^2.7.1"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-providers": {
-          "optional": true
-        },
-        "@mongodb-js/zstd": {
-          "optional": true
-        },
-        "gcp-metadata": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        },
-        "socks": {
-          "optional": true
-        }
       }
     },
     "node_modules/mongoose/node_modules/ms": {
@@ -15110,9 +15067,10 @@
       }
     },
     "node_modules/sift": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
-      "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ=="
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
+      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
+      "license": "MIT"
     },
     "node_modules/siginfo": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "lodash": "^4.17.21",
     "markdown-toc": "^1.2.0",
     "mongodb": "^6.8.0",
-    "mongoose": "^8.3.2",
+    "mongoose": "^8.7.0",
     "mongoose-paginate-v2": "^1.8.3",
     "morgan": "^1.10.0",
     "nanoid": "^5.0.7",


### PR DESCRIPTION
Title: Update Mongoose version from 8.3.2 to 8.7.0
Changes:
Updated package.json:
"mongoose": "^8.3.2" -> "mongoose": "^8.7.0"
Ran npm install to update the package-lock.json accordingly.
Ran npm test. Passes all tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version of the `mongoose` package to enhance performance and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->