### PR TITLE
[FIX]: ignore-sensitive-files-pr check

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,6 +12,7 @@
 name: PR Workflow
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - '**'
 
@@ -27,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
-          persist-crendetials: true
+          persist-credentials: true
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -91,7 +92,9 @@ jobs:
           exit 1
 
   Check-Sensitive-Files:
-    if: ${{ github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'ignore-sensitive-files-pr') }}
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      !contains(github.event.pull_request.labels.*.name, 'ignore-sensitive-files-pr')
     name: Checks if sensitive files have been changed without authorization
     runs-on: ubuntu-latest
     steps:
@@ -99,7 +102,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
-          persist-crendetials: true
+          persist-credentials: true
 
       
       - name: Get Changed Unauthorized files
@@ -154,7 +157,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
-          persist-crendetials: true
+          persist-credentials: true
         
       - name: Get changed files
         id: changed-files
@@ -309,7 +312,7 @@ jobs:
           ./.github/workflows/check-jsdocs-comment.py
 
       - name: 'Run JSDocs'
-        if: env.RUN_JSDOCS == 'True'
+        if: env.RUN_JSDOCS == 'true'
         run: echo "Run JSdocs :${{ env.RUN_JSDOCS }}"
   
   Branch-check:


### PR DESCRIPTION
**What kind of change does this PR introduce?**

`ignore-sensitive-files-pr check` works but that if the action has `on: [pull_request]`, the label(s) need to be there at PR creation time and not added afterward otherwise your github action doesn't rerun.

Default triggers are `opened`, `synchronize` and `reopened`
Runs your workflow when activity on a pull request in the workflow's repository occurs. For example, if no activity types are specified, the workflow runs when a pull request is opened or reopened or when the head branch of the pull request is updated.

**Doc Reference**: [https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request
](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request)

So to fix this added  `types: [opened, synchronize, reopened, labeled, unlabeled]` which triggers the workflows when these actions take place

**Other Informmation-**
Also fixed : `persist-crendetials` to `persist-credentials`


**Issue Number:**

Fixes #2699 

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced pull request workflow with additional trigger events for better automation.
	- New validation step to ensure source and target branches of pull requests are not the same.

- **Bug Fixes**
	- Corrected credential handling options for improved security during workflow execution.
	- Implemented file count check to prevent excessive changes in pull requests.

- **Improvements**
	- Reformatted conditions for better readability and clarity in the workflow processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->