### PR TITLE
fix:network in docker-compose

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -40,6 +40,8 @@ services:
     volumes:
       - .:/usr/src/app
       - /usr/src/app/node_modules
+    ports:
+      - ${SERVER_PORT}:${SERVER_PORT}
     depends_on:
       - mongodb
       - redis-stack-server
@@ -48,6 +50,8 @@ services:
       - MONGO_DB_URL=mongodb://mongodb:27017
       - REDIS_HOST=redis-stack-server
       - REDIS_PORT=6379
+    networks:
+      - talawa-network
 
   caddy:
     image: caddy/caddy:2.2.1-alpine


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug

fixes https://github.com/PalisadoesFoundation/talawa-api/issues/2746


**Summary**

This PR corrects the docker-compose.dev.yml file that helps set up the project using docker containers.
The App is running in a container `talawa-api-dev` and it is not able to connect to any other containers like redis since they are not on the same network.


**Does this PR introduce a breaking change?**

No

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes