### PR TITLE
Create systemd file so the app can run as a Linux system daemon. #2737

### DIFF
--- a/examples/linux/systemd/systemd-talawa-api.service
+++ b/examples/linux/systemd/systemd-talawa-api.service
@@ -22,28 +22,44 @@
 Description=Talawa API Service
 After=network.target
 
+Documentation=https://github.com/talawa-api/
+After=postgresql.service redis.service
+Requires=postgresql.service
+Wants=redis.service
+
 [Service]
 User=talawa
 Group=talawa
+
 Environment=CODEROOT=/home/talawa/talawa-api
 Environment=TALAWA_API_CONFIGDIR=/etc/talawa
 Environment=VIRTUAL_ENV=$CODEROOT/venv/bin
 Environment=PATH=$VIRTUAL_ENV:$PATH
 Environment=START=--start "STOP=--stop --force" "RESTART=--restart --force"
+EnvironmentFile=/etc/examples/linux/systemd/talawa-api.env
 
-# Command to start Talawa API
-ExecStart=/bin/bash -c '${VIRTUAL_ENV}/python3 ${CODEROOT}/main.py $START'
-
-# Command to stop Talawa API
-ExecStop=/bin/bash -c '${VIRTUAL_ENV}/python3 ${CODEROOT}/main.py $STOP'
-
-# Command to restart Talawa API
-ExecReload=/bin/bash -c '${VIRTUAL_ENV}/python3 ${CODEROOT}/main.py $RESTART'
+ExecStart=${VIRTUAL_ENV}/python3 ${CODEROOT}/main.py ${START}
+ExecStop=${VIRTUAL_ENV}/python3 ${CODEROOT}/main.py ${STOP}
+ExecReload=${VIRTUAL_ENV}/python3 ${CODEROOT}/main.py ${RESTART}
 
 RemainAfterExit=yes
 GuessMainPID=yes
 Type=forking
 RuntimeDirectory=talawa
+
+# Restart policy
+Restart=always
+RestartSec=3
+
+# Security settings
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=full
+ProtectHome=read-only
+
+# Resource limits
+LimitNOFILE=65535
+LimitNPROC=4096
 
 [Install]
 WantedBy=multi-user.target

--- a/examples/linux/systemd/systemd-talawa-api.service
+++ b/examples/linux/systemd/systemd-talawa-api.service
@@ -1,0 +1,49 @@
+
+# READ ALL STEPS BEFORE PROCEEDING
+#
+# 0) Change the daemon_directory setting in your configuration file to 
+#    /var/run/talawa-api
+# 1) Copy this file to one of these directories depending on your Linux version
+#        i.  RedHat variants: /usr/lib/systemd/system/
+#        ii. Debian/Ubuntu variants: /lib/systemd/system/
+# 2) Edit the CODEROOT path to be the full path of the Talawa API's root directory
+# 3) Edit the TALAWA_API_CONFIGDIR path to be the full path of the Talawa API's configuration directory
+#    This defaults to /etc/ directory of the Talawa API codebase
+# 4) Edit the User and Group to match the POSIX user you want the daemon
+#    to run as.
+# 5) Run the command "sudo systemctl daemon-reload". This needs to be run only once
+# 6) Run the command "sudo systemctl start talawa-api.service" to start
+# 7) Run the command "sudo systemctl stop talawa-api.service" to stop
+# 8) Run the command "sudo systemctl restart talawa-api.service" to restart
+# 9) Run the command "sudo systemctl enable talawa-api.service" to make
+#    talawa-api start automatically on boot
+
+[Unit]
+Description=Talawa API Service
+After=network.target
+
+[Service]
+User=talawa
+Group=talawa
+Environment=CODEROOT=/home/talawa/talawa-api
+Environment=TALAWA_API_CONFIGDIR=/etc/talawa
+Environment=VIRTUAL_ENV=$CODEROOT/venv/bin
+Environment=PATH=$VIRTUAL_ENV:$PATH
+Environment=START=--start "STOP=--stop --force" "RESTART=--restart --force"
+
+# Command to start Talawa API
+ExecStart=/bin/bash -c '${VIRTUAL_ENV}/python3 ${CODEROOT}/main.py $START'
+
+# Command to stop Talawa API
+ExecStop=/bin/bash -c '${VIRTUAL_ENV}/python3 ${CODEROOT}/main.py $STOP'
+
+# Command to restart Talawa API
+ExecReload=/bin/bash -c '${VIRTUAL_ENV}/python3 ${CODEROOT}/main.py $RESTART'
+
+RemainAfterExit=yes
+GuessMainPID=yes
+Type=forking
+RuntimeDirectory=talawa
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/linux/systemd/systemd-talawa-api.service
+++ b/examples/linux/systemd/systemd-talawa-api.service
@@ -11,6 +11,12 @@
 #    This defaults to /etc/ directory of the Talawa API codebase
 # 4) Edit the User and Group to match the POSIX user you want the daemon
 #    to run as.
+# 4a) Set appropriate permissions:
+#     sudo chown -R talawa:talawa /etc/talawa
+#     sudo chmod 750 /etc/talawa
+# 4b) If using SELinux, set the correct context:
+#     sudo semanage fcontext -a -t bin_t "/home/talawa/talawa-api/main.py"
+#     sudo restorecon -v /home/talawa/talawa-api/main.py
 # 5) Run the command "sudo systemctl daemon-reload". This needs to be run only once
 # 6) Run the command "sudo systemctl start talawa-api.service" to start
 # 7) Run the command "sudo systemctl stop talawa-api.service" to stop
@@ -44,7 +50,7 @@ ExecReload=${VIRTUAL_ENV}/python3 ${CODEROOT}/main.py ${RESTART}
 
 RemainAfterExit=yes
 GuessMainPID=yes
-Type=forking
+Type=simple
 RuntimeDirectory=talawa
 
 # Restart policy

--- a/examples/linux/systemd/talawa-api.env
+++ b/examples/linux/systemd/talawa-api.env
@@ -1,0 +1,7 @@
+CODEROOT=/home/talawa/talawa-api
+TALAWA_API_CONFIGDIR=/etc/talawa
+VIRTUAL_ENV=${CODEROOT}/venv/bin
+PATH=${VIRTUAL_ENV}:${PATH}
+START=--start
+STOP=--stop --force
+RESTART=--restart --force


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.

-->
  
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->
  
**What kind of change does this PR introduce?**
  
- Feature: Adds a new systemd service file for Talawa API to allow it to run as a Linux service.

**Issue Number:**
- *2737*

Fixes #<!-- Add related issue number here. -->

**Did you add tests for your changes?**
- No. This change is related to creating a service file for systemd, and doesn't involve direct code functionality changes, so testing is not applicable.

**Snapshots/Videos:**
- N/A (As it's a configuration file, visual snapshots are not applicable)

**If relevant, did you update the documentation?**
- Yes. Updated relevant configuration documentation on the Talawa Docs to include details about setting up the `systemd-talawa-api.service` for automatic startup.

**Summary**

This pull request introduces a `systemd` service file (`systemd-talawa-api.service`) to enable the Talawa API to run as a service on Linux systems. This allows the Talawa API to be easily managed using standard `systemctl` commands (such as start, stop, restart, and enable on boot). 

The service file sets up:
- The user and group under which the service runs.
- Environment variables for the Talawa API's root directory and configuration.
- Commands for starting, stopping, and restarting the API.
  
This change ensures that the Talawa API can be run as a background service in production environments, improving its manageability and availability.

**Does this PR introduce a breaking change?**
- No, this PR does not introduce any breaking changes to the functionality of Talawa API. It only adds configuration for managing the API as a service.

**Other information**
- The `systemd-talawa-api.service` file is configured for systems running RedHat/CentOS/Fedora or Debian/Ubuntu, based on the paths where `systemd` services are typically stored.
- You may need to update the `CODEROOT` and `TALAWA_API_CONFIGDIR` paths in the service file to match the actual directory paths on your system.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
- Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new systemd service file for managing the Talawa API as a system service on Linux systems.
	- Added a new environment configuration file for the Talawa API, defining essential environment variables and command options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->