### PR TITLE
Add Search Functionality for Agenda Item Categories

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -140,6 +140,10 @@ type AgendaItem {
   users: [User]
 }
 
+input AgendaItemCategoryWhereInput {
+  name_contains: String
+}
+
 type AgendaSection {
   _id: ID!
   createdAt: Date!
@@ -1556,7 +1560,7 @@ type Query {
   agendaCategory(id: ID!): AgendaCategory!
   agendaItemByEvent(relatedEventId: ID!): [AgendaItem]
   agendaItemByOrganization(organizationId: ID!): [AgendaItem]
-  agendaItemCategoriesByOrganization(organizationId: ID!): [AgendaCategory]
+  agendaItemCategoriesByOrganization(organizationId: ID!, where: AgendaItemCategoryWhereInput): [AgendaCategory]
   chatById(id: ID!): Chat!
   chatsByUserId(id: ID!, where: ChatWhereInput): [Chat]
   checkAuth: User!

--- a/src/resolvers/Query/agendaItemCategoriesByOrganization.ts
+++ b/src/resolvers/Query/agendaItemCategoriesByOrganization.ts
@@ -1,5 +1,6 @@
 import type { QueryResolvers } from "../../types/generatedGraphQLTypes";
 import { AgendaCategoryModel } from "../../models";
+import { getWhere } from "./helperFunctions/getWhere";
 /**
  * This query will fetch all categories for the organization from database.
  * @param _parent-
@@ -8,7 +9,9 @@ import { AgendaCategoryModel } from "../../models";
  */
 export const agendaItemCategoriesByOrganization: QueryResolvers["agendaItemCategoriesByOrganization"] =
   async (_parent, args) => {
+    const where = getWhere(args.where);
     return await AgendaCategoryModel.find({
       organizationId: args.organizationId,
+      ...where,
     }).lean();
   };

--- a/src/resolvers/Query/helperFunctions/getWhere.ts
+++ b/src/resolvers/Query/helperFunctions/getWhere.ts
@@ -15,6 +15,7 @@ import type {
   ActionItemCategoryWhereInput,
   ChatWhereInput,
   EventVolunteerWhereInput,
+  AgendaItemCategoryWhereInput,
 } from "../../../types/generatedGraphQLTypes";
 
 /**
@@ -42,6 +43,7 @@ export const getWhere = <T = unknown>(
             DonationWhereInput &
             ActionItemWhereInput &
             ActionItemCategoryWhereInput &
+            AgendaItemCategoryWhereInput &
             CampaignWhereInput &
             FundWhereInput &
             PledgeWhereInput &

--- a/src/typeDefs/inputs.ts
+++ b/src/typeDefs/inputs.ts
@@ -95,6 +95,10 @@ export const inputs = gql`
     is_disabled: Boolean
   }
 
+  input AgendaItemCategoryWhereInput {
+    name_contains: String
+  }
+
   input CreateAgendaCategoryInput {
     name: String!
     description: String

--- a/src/typeDefs/queries.ts
+++ b/src/typeDefs/queries.ts
@@ -32,7 +32,10 @@ export const queries = gql`
 
     agendaItemByOrganization(organizationId: ID!): [AgendaItem]
 
-    agendaItemCategoriesByOrganization(organizationId: ID!): [AgendaCategory]
+    agendaItemCategoriesByOrganization(
+      organizationId: ID!
+      where: AgendaItemCategoryWhereInput
+    ): [AgendaCategory]
 
     getAgendaItem(id: ID!): AgendaItem
 

--- a/src/types/generatedGraphQLTypes.ts
+++ b/src/types/generatedGraphQLTypes.ts
@@ -210,6 +210,10 @@ export type AgendaItem = {
   users?: Maybe<Array<Maybe<User>>>;
 };
 
+export type AgendaItemCategoryWhereInput = {
+  name_contains?: InputMaybe<Scalars['String']['input']>;
+};
+
 export type AgendaSection = {
   __typename?: 'AgendaSection';
   _id: Scalars['ID']['output'];
@@ -2463,6 +2467,7 @@ export type QueryAgendaItemByOrganizationArgs = {
 
 export type QueryAgendaItemCategoriesByOrganizationArgs = {
   organizationId: Scalars['ID']['input'];
+  where?: InputMaybe<AgendaItemCategoryWhereInput>;
 };
 
 
@@ -3510,6 +3515,7 @@ export type ResolversTypes = {
   AdvertisementsConnection: ResolverTypeWrapper<Omit<AdvertisementsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<ResolversTypes['AdvertisementEdge']>>> }>;
   AgendaCategory: ResolverTypeWrapper<InterfaceAgendaCategoryModel>;
   AgendaItem: ResolverTypeWrapper<InterfaceAgendaItemModel>;
+  AgendaItemCategoryWhereInput: AgendaItemCategoryWhereInput;
   AgendaSection: ResolverTypeWrapper<InterfaceAgendaSectionModel>;
   AggregatePost: ResolverTypeWrapper<AggregatePost>;
   AggregateUser: ResolverTypeWrapper<AggregateUser>;
@@ -3745,6 +3751,7 @@ export type ResolversParentTypes = {
   AdvertisementsConnection: Omit<AdvertisementsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<ResolversParentTypes['AdvertisementEdge']>>> };
   AgendaCategory: InterfaceAgendaCategoryModel;
   AgendaItem: InterfaceAgendaItemModel;
+  AgendaItemCategoryWhereInput: AgendaItemCategoryWhereInput;
   AgendaSection: InterfaceAgendaSectionModel;
   AggregatePost: AggregatePost;
   AggregateUser: AggregateUser;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature

**Issue Number:**

Fixes : https://github.com/PalisadoesFoundation/talawa-admin/issues/2372

**Snapshots/Videos:**

https://www.loom.com/share/fb28b6228fc649158f8db6eba1ab1fc6

**Summary**

Search Functionality: Implemented a search feature to filter agenda item categories based on user input.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced agenda item category filtering with a new `name_contains` search option
	- Added ability to filter agenda item categories by substring within their name
	- Introduced more flexible querying for agenda item categories by organization

- **Improvements**
	- Added role-based access control directive for enhanced security

<!-- end of auto-generated comment: release notes by coderabbit.ai -->