### PR TITLE
allow hot reloading `api` devcontainer environment variables

### DIFF
--- a/docker/compose.devcontainer.yaml
+++ b/docker/compose.devcontainer.yaml
@@ -27,6 +27,7 @@ services:
     # https://docs.docker.com/compose/environment-variables/
     # https://docs.docker.com/reference/compose-file/services/#environment
     # https://docs.docker.com/reference/compose-file/merge/#reset-value
+    # This resets any environment variables set under this keyword in other compose configuration files which prevents injecting those environment variables with default values within the execution context of this service. This in turn allows mutations to values of environment variables specific to this service within the `.env` file present within this service's devcontainer to take effect without restarting or rebuilding it.
     environment: !reset []
     # https://docs.docker.com/reference/dockerfile/#healthcheck
     # https://docs.docker.com/reference/compose-file/services/#healthcheck

--- a/docker/compose.devcontainer.yaml
+++ b/docker/compose.devcontainer.yaml
@@ -26,9 +26,8 @@ services:
         required: false
     # https://docs.docker.com/compose/environment-variables/
     # https://docs.docker.com/reference/compose-file/services/#environment
-    environment:
-      - API_DEBUGGER_HOST=${API_DEBUGGER_HOST:?error}
-      - API_DEBUGGER_PORT=${API_DEBUGGER_PORT:?error}
+    # https://docs.docker.com/reference/compose-file/merge/#reset-value
+    environment: !reset []
     # https://docs.docker.com/reference/dockerfile/#healthcheck
     # https://docs.docker.com/reference/compose-file/services/#healthcheck
     healthcheck:


### PR DESCRIPTION
this change will make environment variables required within the internal execution context of `api` devcontainer to take effect without requiring rebuild or restart of the devcontainer

<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

feature

**Issue Number:**

Fixes #<!--Add related issue number here.-->

**Snapshots/Videos:**

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

This change will make it so that mutations to environment variables required within the internal execution context of `api` devcontainer take effect without requiring rebuilds or restarts of the devcontainer.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated Docker Compose configuration for the development environment.
	- Reset environment variable settings for the API service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->