### PR TITLE
Added corrections

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -67,7 +67,8 @@ const config: Config = {
           type: "docSidebar",
           sidebarId: "tutorialSidebar",
           position: "left",
-          label: "Docs",
+          label: "General",
+          href : "https://docs.talawa.io/",
         },
         {
           label: "Mobile Guide",

--- a/docs/src/components/layout/HeaderHero.tsx
+++ b/docs/src/components/layout/HeaderHero.tsx
@@ -12,13 +12,15 @@ function HeaderHero() {
       <TwoColumns
         reverse
         columnOne={
-          <img
-            className="custom-image bounce-animation"
-            src={useBaseUrl("img/image-01.png")}
-            alt="Talawa member management software interface showcase"
-            loading="lazy"
-            srcSet={`${useBaseUrl("img/image-01.png")} 1x, ${useBaseUrl("img/image-01@2x.png")} 2x`}
-          />
+          <div className="image-container">
+            <img
+              className="custom-image bounce-animation"
+              src={useBaseUrl("img/image-01.png")}
+              alt="Talawa member management software interface showcase"
+              loading="lazy"
+              // srcSet={`${useBaseUrl("img/image-01.png")} 1x, ${useBaseUrl("img/image-01@2x.png")} 2x`}
+            />
+          </div>
         }
         columnTwo={
           <>

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -1266,3 +1266,14 @@ textarea,
     padding-right: 0 !important;
   }
 }
+.image-container {
+  width: 100%;
+  height: auto;
+  overflow: hidden;
+}
+
+.image-container img {
+  width: 100%;
+  height: auto;
+  object-fit: contain;
+}

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -1,10 +1,7 @@
-// Import the necessary modules
 import React from "react";
 import Head from "@docusaurus/Head";
 import Layout from "@theme/Layout";
 import useHomePageAnimations  from "../hooks/useHomePageAnimations";
-
-// Import the components
 import  HeaderHero  from "../components/layout/HeaderHero";
 import  SecondPanel  from "../components/layout/SecondPanel";
 import  ThirdPanel  from "../components/layout/ThirdPanel";


### PR DESCRIPTION

**What kind of change does this PR introduce?**
Bugfix

**Issue Number:**

Fixes 

**Snapshots/Videos:**

**Summary**

Understood. I will follow the Concise Mode instructions in responding to your request.

To address the image cut-off issue:

1. Wrap the image in a container with `overflow: hidden` to ensure the entire image is visible.
2. Set the image's height to `auto` to allow it to scale proportionally.
3. Use `object-fit: contain` to fit the image within the container.

This should resolve the cut-off problem on wide screens. Let me know if you have any other questions!

**Does this PR introduce a breaking change?**
No



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated navigation configuration to redirect "Docs" link to "https://docs.talawa.io/"
  
- **Style**
	- Added `.image-container` CSS class to manage image display and sizing
	- Implemented responsive image handling with `object-fit: contain`
  
- **Chores**
	- Removed comments from the `index.tsx` file for cleaner code structure
<!-- end of auto-generated comment: release notes by coderabbit.ai -->