### PR TITLE
fixes: broken link/activePath color/general

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -68,7 +68,8 @@ const config: Config = {
           sidebarId: "tutorialSidebar",
           position: "left",
           label: "General",
-          href: "https://docs.talawa.io/",
+          href: "https://docs.talawa.io/docs",
+          target: "_self",
         },
         {
           label: "Mobile Guide",
@@ -85,13 +86,15 @@ const config: Config = {
         {
           label: "API Guide",
           position: "left",
-          href: "/docs",
+          // href: "/docs",
+          // activeBasePath: "docs",
           target: "_self",
+          to: "/docs",
         },
         {
           label: "Demo",
           position: "left",
-          href: "http://admin-demo.talawa.io/",
+          href: "https://www.youtube.com/@PalisadoesOrganization/playlists",
         },
         {
           to: "https://github.com/PalisadoesFoundation",

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -368,7 +368,7 @@ a:hover {
 }
 
 /* Hide external link svg on Navbar */
-.iconExternalLink_nPIU {
+.navbar__item .iconExternalLink_efnC {
   display: none !important;
 }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- general before : points to talawa-main website
- general after : points to docs of talawa-main-website
- activePath nav-item gets blue
- fixes broken demo link : points to yt playlist of Palisadoes foundation
- removed the external source icon

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:** 

Fixes #2901 

**Snapshots/Videos:**
SS of change activePath turns blue and no external source icon with nav-items (after):

![Screenshot (187)](https://github.com/user-attachments/assets/1d7d6bff-e496-4335-9d6d-5e04aa49eef4)

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated navigation configuration in Docusaurus documentation site
	- Refined CSS styles for improved responsiveness and visual consistency
	- Modified navigation links, including changing demo link to a YouTube playlist
	- Updated color variables and styling for dark theme

<!-- end of auto-generated comment: release notes by coderabbit.ai -->