### PR TITLE
Fix .env Persistence Issue in DevContainer (#3102)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -67,7 +67,7 @@
 		"ghcr.io/devcontainers/features/github-cli": {}
 	},
 	"init": true,
-	"initializeCommand": "cp -n ./envFiles/.env.devcontainer ./.env",
+	"initializeCommand": "/bin/sh -c 'test -f ./.env || cp ./envFiles/.env.devcontainer ./.env'",
 	"name": "talawa_api",
 	"overrideCommand": true,
 	"postCreateCommand": "sudo chown talawa:talawa ./.pnpm-store ./node_modules && fnm install && fnm use && corepack enable npm && corepack enable && corepack install && pnpm install --prod=false && pnpm start_development_server",


### PR DESCRIPTION
### Overview

This PR addresses issue #3102, where the DevContainer setup was failing due to improper handling of the .env file.

Previously, the initializeCommand in .devcontainer/devcontainer.json used:

`/bin/sh -c 'cp -n ./envFiles/.env.devcontainer ./.env'`

which caused:

- Build failures unless .env was manually copied before running devcontainer build.
- Runtime failures when using devcontainer up due to .env already existing.
- VS Code DevContainer failing to open because .env persisted and caused conflicts.

### Fix Implemented

The initializeCommand has been updated to:

`"initializeCommand": "/bin/sh -c 'test -f ./.env || cp ./envFiles/.env.devcontainer ./.env'"`

### Key improvements:

- Ensures .env is only created if it doesn’t exist.
- Prevents unnecessary manual deletion of .env before running devcontainer up.
- Fixes DevContainer startup issues in VS Code.
- Improves developer workflow by eliminating redundant setup steps.

### How to Test

1. Fresh DevContainer Build

`cp envFiles/.env.devcontainer .env`
`devcontainer up --workspace-folder .`

-  .env should be created if missing.
- The build should succeed without errors.

2. Start the DevContainer

`devcontainer up --workspace-folder .`

- It should start without requiring manual .env deletion.

3. Open in VS Code

- DevContainer should open without .env conflicts.

### Related Issue

Fixes #3102

### Ready for Review

This PR streamlines setup. Let me know if any changes are needed! 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated development container initialization to safely copy environment configuration files without overwriting existing `.env` files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->