### PR TITLE
Enforce Pagination Limits on USER_LIST and ORGANIZATION_CONNECTION_LIST Queries

### DIFF
--- a/src/graphql/types/Organization/organizationConnectionList.ts
+++ b/src/graphql/types/Organization/organizationConnectionList.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+import { builder } from "~/src/graphql/builder";
+import { Organization } from "~/src/graphql/types/Organization/Organization";
+import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
+
+const organizationConnectionListArgumentsSchema = z.object({
+  first: z.number().min(1).max(100).default(10),
+  skip: z.number().min(0).default(0),
+});
+
+builder.queryField("organizationConnectionList", (t) =>
+  t.field({
+    args: {
+      first: t.arg({ type: "Int", required: false }),
+      skip: t.arg({ type: "Int", required: false }),
+    },
+    type: [Organization],
+    resolve: async (_parent, args, ctx) => {
+      const {
+        data: parsedArgs,
+        error,
+        success,
+      } = organizationConnectionListArgumentsSchema.safeParse(args);
+
+      if (!success) {
+        throw new TalawaGraphQLError({
+          extensions: {
+            code: "invalid_arguments",
+            issues: error.issues.map((issue) => ({
+              argumentPath: issue.path,
+              message: issue.message,
+            })),
+          },
+        });
+      }
+
+      const { first, skip } = parsedArgs;
+
+      // Fetch organizations with pagination
+      const organizations =
+        await ctx.drizzleClient.query.organizationsTable.findMany({
+          limit: first,
+          offset: skip,
+        });
+
+      return organizations;
+    },
+  }),
+);

--- a/src/graphql/types/Organization/organizationConnectionList.ts
+++ b/src/graphql/types/Organization/organizationConnectionList.ts
@@ -4,46 +4,46 @@ import { Organization } from "~/src/graphql/types/Organization/Organization";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 
 const organizationConnectionListArgumentsSchema = z.object({
-  first: z.number().min(1).max(100).default(10),
-  skip: z.number().min(0).default(0),
+	first: z.number().min(1).max(100).default(10),
+	skip: z.number().min(0).default(0),
 });
 
 builder.queryField("organizationConnectionList", (t) =>
-  t.field({
-    args: {
-      first: t.arg({ type: "Int", required: false }),
-      skip: t.arg({ type: "Int", required: false }),
-    },
-    type: [Organization],
-    resolve: async (_parent, args, ctx) => {
-      const {
-        data: parsedArgs,
-        error,
-        success,
-      } = organizationConnectionListArgumentsSchema.safeParse(args);
+	t.field({
+		args: {
+			first: t.arg({ type: "Int", required: false }),
+			skip: t.arg({ type: "Int", required: false }),
+		},
+		type: [Organization],
+		resolve: async (_parent, args, ctx) => {
+			const {
+				data: parsedArgs,
+				error,
+				success,
+			} = organizationConnectionListArgumentsSchema.safeParse(args);
 
-      if (!success) {
-        throw new TalawaGraphQLError({
-          extensions: {
-            code: "invalid_arguments",
-            issues: error.issues.map((issue) => ({
-              argumentPath: issue.path,
-              message: issue.message,
-            })),
-          },
-        });
-      }
+			if (!success) {
+				throw new TalawaGraphQLError({
+					extensions: {
+						code: "invalid_arguments",
+						issues: error.issues.map((issue) => ({
+							argumentPath: issue.path,
+							message: issue.message,
+						})),
+					},
+				});
+			}
 
-      const { first, skip } = parsedArgs;
+			const { first, skip } = parsedArgs;
 
-      // Fetch organizations with pagination
-      const organizations =
-        await ctx.drizzleClient.query.organizationsTable.findMany({
-          limit: first,
-          offset: skip,
-        });
+			// Fetch organizations with pagination
+			const organizations =
+				await ctx.drizzleClient.query.organizationsTable.findMany({
+					limit: first,
+					offset: skip,
+				});
 
-      return organizations;
-    },
-  }),
+			return organizations;
+		},
+	}),
 );

--- a/src/graphql/types/Organization/organizationConnectionList.ts
+++ b/src/graphql/types/Organization/organizationConnectionList.ts
@@ -4,46 +4,46 @@ import { Organization } from "~/src/graphql/types/Organization/Organization";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 
 const organizationConnectionListArgumentsSchema = z.object({
-  first: z.number().min(1).max(100).default(10),
-  skip: z.number().min(0).default(0),
+	first: z.number().min(1).max(100).default(10),
+	skip: z.number().min(0).default(0),
 });
 
 builder.queryField("organizationConnectionList", (t) =>
-  t.field({
-    args: {
-      first: t.arg({ type: "Int", required: false }),
-      skip: t.arg({ type: "Int", required: false }),
-    },
-    type: [Organization],
-    resolve: async (_parent, args, ctx) => {
-      const {
-        data: parsedArgs,
-        error,
-        success,
-      } = organizationConnectionListArgumentsSchema.safeParse(args);
+	t.field({
+		args: {
+			first: t.arg({ type: "Int", required: false }),
+			skip: t.arg({ type: "Int", required: false }),
+		},
+		type: [Organization],
+		resolve: async (_parent, args, ctx) => {
+			const {
+				data: parsedArgs,
+				error,
+				success,
+			} = organizationConnectionListArgumentsSchema.safeParse(args);
 
-      if (!success) {
-        throw new TalawaGraphQLError({
-          extensions: {
-            code: "invalid_arguments",
-            issues: error.issues.map((issue) => ({
-              argumentPath: issue.path,
-              message: issue.message,
-            })),
-          },
-        });
-      }
+			if (!success) {
+				throw new TalawaGraphQLError({
+					extensions: {
+						code: "invalid_arguments",
+						issues: error.issues.map((issue) => ({
+							argumentPath: issue.path,
+							message: issue.message,
+						})),
+					},
+				});
+			}
 
-      const { first, skip } = parsedArgs;
+			const { first, skip } = parsedArgs;
 
-      // Fetch organizations with pagination
-      const organizations =
-        await ctx.drizzleClient.query.organizationsTable.findMany({
-          limit: first,
-          offset: skip,
-        });
+			// Fetch organizations with pagination
+			const organizations =
+				await ctx.drizzleClient.query.organizationsTable.findMany({
+					limit: first,
+					offset: skip,
+				});
 
-      return organizations;
-    },
-  })
+			return organizations;
+		},
+	})
 );

--- a/src/graphql/types/Organization/organizationConnectionList.ts
+++ b/src/graphql/types/Organization/organizationConnectionList.ts
@@ -4,46 +4,46 @@ import { Organization } from "~/src/graphql/types/Organization/Organization";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 
 const organizationConnectionListArgumentsSchema = z.object({
-	first: z.number().min(1).max(100).default(10),
-	skip: z.number().min(0).default(0),
+  first: z.number().min(1).max(100).default(10),
+  skip: z.number().min(0).default(0),
 });
 
 builder.queryField("organizationConnectionList", (t) =>
-	t.field({
-		args: {
-			first: t.arg({ type: "Int", required: false }),
-			skip: t.arg({ type: "Int", required: false }),
-		},
-		type: [Organization],
-		resolve: async (_parent, args, ctx) => {
-			const {
-				data: parsedArgs,
-				error,
-				success,
-			} = organizationConnectionListArgumentsSchema.safeParse(args);
+  t.field({
+    args: {
+      first: t.arg({ type: "Int", required: false }),
+      skip: t.arg({ type: "Int", required: false }),
+    },
+    type: [Organization],
+    resolve: async (_parent, args, ctx) => {
+      const {
+        data: parsedArgs,
+        error,
+        success,
+      } = organizationConnectionListArgumentsSchema.safeParse(args);
 
-			if (!success) {
-				throw new TalawaGraphQLError({
-					extensions: {
-						code: "invalid_arguments",
-						issues: error.issues.map((issue) => ({
-							argumentPath: issue.path,
-							message: issue.message,
-						})),
-					},
-				});
-			}
+      if (!success) {
+        throw new TalawaGraphQLError({
+          extensions: {
+            code: "invalid_arguments",
+            issues: error.issues.map((issue) => ({
+              argumentPath: issue.path,
+              message: issue.message,
+            })),
+          },
+        });
+      }
 
-			const { first, skip } = parsedArgs;
+      const { first, skip } = parsedArgs;
 
-			// Fetch organizations with pagination
-			const organizations =
-				await ctx.drizzleClient.query.organizationsTable.findMany({
-					limit: first,
-					offset: skip,
-				});
+      // Fetch organizations with pagination
+      const organizations =
+        await ctx.drizzleClient.query.organizationsTable.findMany({
+          limit: first,
+          offset: skip,
+        });
 
-			return organizations;
-		},
-	}),
+      return organizations;
+    },
+  })
 );

--- a/src/graphql/types/Organization/organizationConnectionList.ts
+++ b/src/graphql/types/Organization/organizationConnectionList.ts
@@ -45,5 +45,5 @@ builder.queryField("organizationConnectionList", (t) =>
 
 			return organizations;
 		},
-	})
+	}),
 );

--- a/src/graphql/types/User/userList.ts
+++ b/src/graphql/types/User/userList.ts
@@ -4,45 +4,45 @@ import { User } from "~/src/graphql/types/User/User";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 
 const userListArgumentsSchema = z.object({
-  first: z.number().min(1).max(100).default(10),
-  skip: z.number().min(0).default(0),
+	first: z.number().min(1).max(100).default(10),
+	skip: z.number().min(0).default(0),
 });
 
 builder.queryField("userList", (t) =>
-  t.field({
-    args: {
-      first: t.arg({ type: "Int", required: false }),
-      skip: t.arg({ type: "Int", required: false }),
-    },
-    type: [User],
-    resolve: async (_parent, args, ctx) => {
-      const {
-        data: parsedArgs,
-        error,
-        success,
-      } = userListArgumentsSchema.safeParse(args);
+	t.field({
+		args: {
+			first: t.arg({ type: "Int", required: false }),
+			skip: t.arg({ type: "Int", required: false }),
+		},
+		type: [User],
+		resolve: async (_parent, args, ctx) => {
+			const {
+				data: parsedArgs,
+				error,
+				success,
+			} = userListArgumentsSchema.safeParse(args);
 
-      if (!success) {
-        throw new TalawaGraphQLError({
-          extensions: {
-            code: "invalid_arguments",
-            issues: error.issues.map((issue) => ({
-              argumentPath: issue.path,
-              message: issue.message,
-            })),
-          },
-        });
-      }
+			if (!success) {
+				throw new TalawaGraphQLError({
+					extensions: {
+						code: "invalid_arguments",
+						issues: error.issues.map((issue) => ({
+							argumentPath: issue.path,
+							message: issue.message,
+						})),
+					},
+				});
+			}
 
-      const { first, skip } = parsedArgs;
+			const { first, skip } = parsedArgs;
 
-      // Fetch users with pagination
-      const users = await ctx.drizzleClient.query.usersTable.findMany({
-        limit: first,
-        offset: skip,
-      });
+			// Fetch users with pagination
+			const users = await ctx.drizzleClient.query.usersTable.findMany({
+				limit: first,
+				offset: skip,
+			});
 
-      return users;
-    },
-  })
+			return users;
+		},
+	})
 );

--- a/src/graphql/types/User/userList.ts
+++ b/src/graphql/types/User/userList.ts
@@ -2,47 +2,48 @@ import { z } from "zod";
 import { builder } from "~/src/graphql/builder";
 import { User } from "~/src/graphql/types/User/User";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
+import { MAXIMUM_FETCH_LIMIT } from "~/src/constants";
 
 const userListArgumentsSchema = z.object({
- first: z.number().min(1).max(100).default(10),
- skip: z.number().min(0).default(0),
+  first: z.number().min(1).max(MAXIMUM_FETCH_LIMIT).default(10),
+  skip: z.number().min(0).default(0),
 });
 
 builder.queryField("userList", (t) =>
- t.field({
- 	args: {
- 		first: t.arg({ type: "Int", required: false }),
- 		skip: t.arg({ type: "Int", required: false }),
- 	},
- 	type: [User],
- 	resolve: async (_parent, args, ctx) => {
- 		const {
- 			data: parsedArgs,
- 			error,
- 			success,
- 		} = userListArgumentsSchema.safeParse(args);
+  t.field({
+    args: {
+      first: t.arg({ type: "Int", required: false }),
+      skip: t.arg({ type: "Int", required: false }),
+    },
+    type: [User],
+    resolve: async (_parent, args, ctx) => {
+      const {
+        data: parsedArgs,
+        error,
+        success,
+      } = userListArgumentsSchema.safeParse(args);
 
- 		if (!success) {
- 			throw new TalawaGraphQLError({
- 				extensions: {
- 					code: "invalid_arguments",
- 					issues: error.issues.map((issue) => ({
- 						argumentPath: issue.path,
- 						message: issue.message,
- 					})),
- 				},
- 			});
- 		}
+      if (!success) {
+        throw new TalawaGraphQLError({
+          extensions: {
+            code: "invalid_arguments",
+            issues: error.issues.map((issue) => ({
+              argumentPath: issue.path,
+              message: issue.message,
+            })),
+          },
+        });
+      }
 
- 		const { first, skip } = parsedArgs;
+      const { first, skip } = parsedArgs;
 
- 		// Fetch users with pagination
- 		const users = await ctx.drizzleClient.query.usersTable.findMany({
- 			limit: first,
- 			offset: skip,
- 		});
+      // Fetch users with pagination
+      const users = await ctx.drizzleClient.query.usersTable.findMany({
+        limit: first,
+        offset: skip,
+      });
 
- 		return users;
- 	},
- }),
+      return users;
+    },
+  }),
 );

--- a/src/graphql/types/User/userList.ts
+++ b/src/graphql/types/User/userList.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import { builder } from "~/src/graphql/builder";
+import { User } from "~/src/graphql/types/User/User";
+import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
+
+const userListArgumentsSchema = z.object({
+  first: z.number().min(1).max(100).default(10),
+  skip: z.number().min(0).default(0),
+});
+
+builder.queryField("userList", (t) =>
+  t.field({
+    args: {
+      first: t.arg({ type: "Int", required: false }),
+      skip: t.arg({ type: "Int", required: false }),
+    },
+    type: [User],
+    resolve: async (_parent, args, ctx) => {
+      const {
+        data: parsedArgs,
+        error,
+        success,
+      } = userListArgumentsSchema.safeParse(args);
+
+      if (!success) {
+        throw new TalawaGraphQLError({
+          extensions: {
+            code: "invalid_arguments",
+            issues: error.issues.map((issue) => ({
+              argumentPath: issue.path,
+              message: issue.message,
+            })),
+          },
+        });
+      }
+
+      const { first, skip } = parsedArgs;
+
+      // Fetch users with pagination
+      const users = await ctx.drizzleClient.query.usersTable.findMany({
+        limit: first,
+        offset: skip,
+      });
+
+      return users;
+    },
+  }),
+);

--- a/src/graphql/types/User/userList.ts
+++ b/src/graphql/types/User/userList.ts
@@ -44,5 +44,5 @@ builder.queryField("userList", (t) =>
 
 			return users;
 		},
-	})
+	}),
 );

--- a/src/graphql/types/User/userList.ts
+++ b/src/graphql/types/User/userList.ts
@@ -16,9 +16,9 @@ builder.queryField("userList", (t) =>
     },
     type: [User],
     resolve: async (_parent, args, ctx) => {
-      const { 
-        data: parsedArgs, 
-        error, 
+      const {
+        data: parsedArgs,
+        error,
         success,
       } = userListArgumentsSchema.safeParse(args);
 

--- a/src/graphql/types/User/userList.ts
+++ b/src/graphql/types/User/userList.ts
@@ -16,8 +16,11 @@ builder.queryField("userList", (t) =>
     },
     type: [User],
     resolve: async (_parent, args, ctx) => {
-      const { data: parsedArgs, error, success } =
-        userListArgumentsSchema.safeParse(args);
+      const { 
+        data: parsedArgs, 
+        error, 
+        success 
+      } = userListArgumentsSchema.safeParse(args);
 
       if (!success) {
         throw new TalawaGraphQLError({

--- a/src/graphql/types/User/userList.ts
+++ b/src/graphql/types/User/userList.ts
@@ -19,7 +19,7 @@ builder.queryField("userList", (t) =>
       const { 
         data: parsedArgs, 
         error, 
-        success 
+        success,
       } = userListArgumentsSchema.safeParse(args);
 
       if (!success) {

--- a/src/graphql/types/User/userList.ts
+++ b/src/graphql/types/User/userList.ts
@@ -4,45 +4,45 @@ import { User } from "~/src/graphql/types/User/User";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 
 const userListArgumentsSchema = z.object({
-  first: z.number().min(1).max(100).default(10),
-  skip: z.number().min(0).default(0),
+ first: z.number().min(1).max(100).default(10),
+ skip: z.number().min(0).default(0),
 });
 
 builder.queryField("userList", (t) =>
-  t.field({
-    args: {
-      first: t.arg({ type: "Int", required: false }),
-      skip: t.arg({ type: "Int", required: false }),
-    },
-    type: [User],
-    resolve: async (_parent, args, ctx) => {
-      const {
-        data: parsedArgs,
-        error,
-        success,
-      } = userListArgumentsSchema.safeParse(args);
+ t.field({
+ 	args: {
+ 		first: t.arg({ type: "Int", required: false }),
+ 		skip: t.arg({ type: "Int", required: false }),
+ 	},
+ 	type: [User],
+ 	resolve: async (_parent, args, ctx) => {
+ 		const {
+ 			data: parsedArgs,
+ 			error,
+ 			success,
+ 		} = userListArgumentsSchema.safeParse(args);
 
-      if (!success) {
-        throw new TalawaGraphQLError({
-          extensions: {
-            code: "invalid_arguments",
-            issues: error.issues.map((issue) => ({
-              argumentPath: issue.path,
-              message: issue.message,
-            })),
-          },
-        });
-      }
+ 		if (!success) {
+ 			throw new TalawaGraphQLError({
+ 				extensions: {
+ 					code: "invalid_arguments",
+ 					issues: error.issues.map((issue) => ({
+ 						argumentPath: issue.path,
+ 						message: issue.message,
+ 					})),
+ 				},
+ 			});
+ 		}
 
-      const { first, skip } = parsedArgs;
+ 		const { first, skip } = parsedArgs;
 
-      // Fetch users with pagination
-      const users = await ctx.drizzleClient.query.usersTable.findMany({
-        limit: first,
-        offset: skip,
-      });
+ 		// Fetch users with pagination
+ 		const users = await ctx.drizzleClient.query.usersTable.findMany({
+ 			limit: first,
+ 			offset: skip,
+ 		});
 
-      return users;
-    },
-  }),
+ 		return users;
+ 	},
+ }),
 );

--- a/src/graphql/types/User/userList.ts
+++ b/src/graphql/types/User/userList.ts
@@ -2,10 +2,9 @@ import { z } from "zod";
 import { builder } from "~/src/graphql/builder";
 import { User } from "~/src/graphql/types/User/User";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
-import { MAXIMUM_FETCH_LIMIT } from "~/src/constants";
 
 const userListArgumentsSchema = z.object({
-  first: z.number().min(1).max(MAXIMUM_FETCH_LIMIT).default(10),
+  first: z.number().min(1).max(100).default(10),
   skip: z.number().min(0).default(0),
 });
 
@@ -17,11 +16,8 @@ builder.queryField("userList", (t) =>
     },
     type: [User],
     resolve: async (_parent, args, ctx) => {
-      const {
-        data: parsedArgs,
-        error,
-        success,
-      } = userListArgumentsSchema.safeParse(args);
+      const { data: parsedArgs, error, success } =
+        userListArgumentsSchema.safeParse(args);
 
       if (!success) {
         throw new TalawaGraphQLError({
@@ -45,5 +41,5 @@ builder.queryField("userList", (t) =>
 
       return users;
     },
-  }),
+  })
 );


### PR DESCRIPTION

**What kind of change does this PR introduce?**

bugfix

**Issue Number:**

Fixes #3143 

**Snapshots/Videos:**

NA

**If relevant, did you update the documentation?**

NA

**Summary**

This PR addresses issue [#3143] by enforcing pagination limits on the `first` and `skip` parameters for the `USER_LIST` and `ORGANIZATION_CONNECTION_LIST` GraphQL queries. This prevents clients from requesting excessively large datasets, which could lead to potential denial-of-service (DoS) attacks by overwhelming server resources.

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

1.The changes have been manually tested to ensure they work as expected.
2.Test cases have not been added in this PR. It is recommended to add test cases to ensure the changes are thoroughly validated.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new query endpoint for retrieving organizations with flexible pagination options.
	- Added a new query endpoint for accessing user data, also supporting customizable pagination settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->