### PR TITLE
feat:added updateAgendaItem.test.ts

### DIFF
--- a/src/graphql/inputs/MutationUpdateAgendaItemInput.ts
+++ b/src/graphql/inputs/MutationUpdateAgendaItemInput.ts
@@ -2,7 +2,7 @@ import type { z } from "zod";
 import { agendaItemsTableInsertSchema } from "~/src/drizzle/tables/agendaItems";
 import { builder } from "~/src/graphql/builder";
 
-export const mutationUpdateAgendaItemInputSchema = agendaItemsTableInsertSchema
+export const MutationUpdateAgendaItemInputSchema = agendaItemsTableInsertSchema
 	.pick({
 		description: true,
 		duration: true,
@@ -22,7 +22,7 @@ export const mutationUpdateAgendaItemInputSchema = agendaItemsTableInsertSchema
 	);
 
 export const MutationUpdateAgendaItemInput = builder
-	.inputRef<z.infer<typeof mutationUpdateAgendaItemInputSchema>>(
+	.inputRef<z.infer<typeof MutationUpdateAgendaItemInputSchema>>(
 		"MutationUpdateAgendaItemInput",
 	)
 	.implement({

--- a/src/graphql/types/Mutation/updateAgendaItem.ts
+++ b/src/graphql/types/Mutation/updateAgendaItem.ts
@@ -2,17 +2,282 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { agendaItemsTable } from "~/src/drizzle/tables/agendaItems";
 import { builder } from "~/src/graphql/builder";
+import type { GraphQLContext } from "~/src/graphql/context";
 import {
 	MutationUpdateAgendaItemInput,
-	mutationUpdateAgendaItemInputSchema,
+	MutationUpdateAgendaItemInputSchema,
 } from "~/src/graphql/inputs/MutationUpdateAgendaItemInput";
 import { AgendaItem } from "~/src/graphql/types/AgendaItem/AgendaItem";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 import { isNotNullish } from "~/src/utilities/isNotNullish";
 
 const mutationUpdateAgendaItemArgumentsSchema = z.object({
-	input: mutationUpdateAgendaItemInputSchema,
+	input: MutationUpdateAgendaItemInputSchema,
 });
+
+export async function updateAgendaItemResolver(
+	_parent: unknown,
+	args: {
+		input: {
+			id: string;
+			name?: string | null | undefined;
+			description?: string | null | undefined;
+			duration?: string | null | undefined;
+			folderId?: string | null | undefined;
+			key?: string | null | undefined;
+		};
+	},
+	ctx: GraphQLContext,
+) {
+	if (!ctx.currentClient.isAuthenticated) {
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "unauthenticated",
+			},
+		});
+	}
+
+	const {
+		data: parsedArgs,
+		error,
+		success,
+	} = mutationUpdateAgendaItemArgumentsSchema.safeParse(args);
+
+	if (!success) {
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "invalid_arguments",
+				issues: error.issues.map((issue) => ({
+					argumentPath: issue.path,
+					message: issue.message,
+				})),
+			},
+		});
+	}
+
+	const currentUserId = ctx.currentClient.user.id;
+
+	const [currentUser, existingAgendaItem] = await Promise.all([
+		ctx.drizzleClient.query.usersTable.findFirst({
+			columns: { role: true },
+			where: (fields, { eq }) => eq(fields.id, currentUserId),
+		}),
+		ctx.drizzleClient.query.agendaItemsTable.findFirst({
+			columns: { type: true },
+			with: {
+				folder: {
+					columns: { eventId: true },
+					with: {
+						event: {
+							columns: { startAt: true },
+							with: {
+								organization: {
+									columns: { countryCode: true },
+									with: {
+										membershipsWhereOrganization: {
+											columns: { role: true },
+											where: (fields, { eq }) =>
+												eq(fields.memberId, currentUserId),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			where: (fields, operators) =>
+				operators.eq(fields.id, parsedArgs.input.id),
+		}),
+	]);
+
+	if (currentUser === undefined) {
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "unauthenticated",
+			},
+		});
+	}
+
+	if (existingAgendaItem === undefined) {
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "arguments_associated_resources_not_found",
+				issues: [
+					{
+						argumentPath: ["input", "id"],
+					},
+				],
+			},
+		});
+	}
+
+	if (existingAgendaItem.type === "note") {
+		if (
+			parsedArgs.input.duration !== undefined &&
+			parsedArgs.input.key !== undefined
+		) {
+			throw new TalawaGraphQLError({
+				extensions: {
+					code: "forbidden_action_on_arguments_associated_resources",
+					issues: [
+						{
+							argumentPath: ["input", "duration"],
+							message: `Cannot be provided for an agenda item of type "${existingAgendaItem.type}"`,
+						},
+						{
+							argumentPath: ["input", "key"],
+							message: `Cannot be provided for an agenda item of type "${existingAgendaItem.type}"`,
+						},
+					],
+				},
+			});
+		}
+
+		if (parsedArgs.input.duration !== undefined) {
+			throw new TalawaGraphQLError({
+				extensions: {
+					code: "forbidden_action_on_arguments_associated_resources",
+					issues: [
+						{
+							argumentPath: ["input", "duration"],
+							message: `Cannot be provided for an agenda item of type "${existingAgendaItem.type}"`,
+						},
+					],
+				},
+			});
+		}
+
+		if (parsedArgs.input.key !== undefined) {
+			throw new TalawaGraphQLError({
+				extensions: {
+					code: "forbidden_action_on_arguments_associated_resources",
+					issues: [
+						{
+							argumentPath: ["input", "key"],
+							message: `Cannot be provided for an agenda item of type "${existingAgendaItem.type}"`,
+						},
+					],
+				},
+			});
+		}
+	}
+
+	if (
+		(existingAgendaItem.type === "general" ||
+			existingAgendaItem.type === "scripture") &&
+		parsedArgs.input.key !== undefined
+	) {
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "forbidden_action_on_arguments_associated_resources",
+				issues: [
+					{
+						argumentPath: ["input", "key"],
+						message: `Cannot be provided for an agenda item of type "${existingAgendaItem.type}"`,
+					},
+				],
+			},
+		});
+	}
+
+	if (isNotNullish(parsedArgs.input.folderId)) {
+		const folderId = parsedArgs.input.folderId;
+
+		const existingAgendaFolder =
+			await ctx.drizzleClient.query.agendaFoldersTable.findFirst({
+				columns: { eventId: true, isAgendaItemFolder: true },
+				where: (fields, operators) => operators.eq(fields.id, folderId),
+			});
+
+		if (existingAgendaFolder === undefined) {
+			throw new TalawaGraphQLError({
+				extensions: {
+					code: "arguments_associated_resources_not_found",
+					issues: [
+						{
+							argumentPath: ["input", "folderId"],
+						},
+					],
+				},
+			});
+		}
+
+		if (existingAgendaFolder.eventId !== existingAgendaItem.folder.eventId) {
+			throw new TalawaGraphQLError({
+				extensions: {
+					code: "forbidden_action_on_arguments_associated_resources",
+					issues: [
+						{
+							argumentPath: ["input", "folderId"],
+							message:
+								"This agenda folder does not belong to the event to the agenda item.",
+						},
+					],
+				},
+			});
+		}
+
+		if (!existingAgendaFolder.isAgendaItemFolder) {
+			throw new TalawaGraphQLError({
+				extensions: {
+					code: "forbidden_action_on_arguments_associated_resources",
+					issues: [
+						{
+							argumentPath: ["input", "folderId"],
+							message: "This agenda folder cannot be a folder to agenda items.",
+						},
+					],
+				},
+			});
+		}
+	}
+
+	const currentUserOrganizationMembership =
+		existingAgendaItem.folder.event.organization
+			.membershipsWhereOrganization[0];
+
+	if (
+		currentUser.role !== "administrator" &&
+		(currentUserOrganizationMembership === undefined ||
+			currentUserOrganizationMembership.role !== "administrator")
+	) {
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "unauthorized_action_on_arguments_associated_resources",
+				issues: [
+					{
+						argumentPath: ["input", "id"],
+					},
+				],
+			},
+		});
+	}
+
+	const [updatedAgendaItem] = await ctx.drizzleClient
+		.update(agendaItemsTable)
+		.set({
+			description: parsedArgs.input.description,
+			duration: parsedArgs.input.duration,
+			folderId: parsedArgs.input.folderId,
+			key: parsedArgs.input.key,
+			name: parsedArgs.input.name,
+			updaterId: currentUserId,
+		})
+		.where(eq(agendaItemsTable.id, parsedArgs.input.id))
+		.returning();
+
+	// Updated agenda item not being returned means that either it was deleted or its id column was changed by external entities before this update operation could take place.
+	if (updatedAgendaItem === undefined) {
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "unexpected",
+			},
+		});
+	}
+
+	return updatedAgendaItem;
+}
 
 builder.mutationField("updateAgendaItem", (t) =>
 	t.field({
@@ -24,274 +289,7 @@ builder.mutationField("updateAgendaItem", (t) =>
 			}),
 		},
 		description: "Mutation field to update an agenda item.",
-		resolve: async (_parent, args, ctx) => {
-			if (!ctx.currentClient.isAuthenticated) {
-				throw new TalawaGraphQLError({
-					extensions: {
-						code: "unauthenticated",
-					},
-				});
-			}
-
-			const {
-				data: parsedArgs,
-				error,
-				success,
-			} = mutationUpdateAgendaItemArgumentsSchema.safeParse(args);
-
-			if (!success) {
-				throw new TalawaGraphQLError({
-					extensions: {
-						code: "invalid_arguments",
-						issues: error.issues.map((issue) => ({
-							argumentPath: issue.path,
-							message: issue.message,
-						})),
-					},
-				});
-			}
-
-			const currentUserId = ctx.currentClient.user.id;
-
-			const [currentUser, existingAgendaItem] = await Promise.all([
-				ctx.drizzleClient.query.usersTable.findFirst({
-					columns: {
-						role: true,
-					},
-					where: (fields, operators) => operators.eq(fields.id, currentUserId),
-				}),
-				ctx.drizzleClient.query.agendaItemsTable.findFirst({
-					columns: {
-						type: true,
-					},
-					with: {
-						folder: {
-							columns: {
-								eventId: true,
-							},
-							with: {
-								event: {
-									columns: {
-										startAt: true,
-									},
-									with: {
-										organization: {
-											columns: {
-												countryCode: true,
-											},
-											with: {
-												membershipsWhereOrganization: {
-													columns: {
-														role: true,
-													},
-													where: (fields, operators) =>
-														operators.eq(fields.memberId, currentUserId),
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					where: (fields, operators) =>
-						operators.eq(fields.id, parsedArgs.input.id),
-				}),
-			]);
-
-			if (currentUser === undefined) {
-				throw new TalawaGraphQLError({
-					extensions: {
-						code: "unauthenticated",
-					},
-				});
-			}
-
-			if (existingAgendaItem === undefined) {
-				throw new TalawaGraphQLError({
-					extensions: {
-						code: "arguments_associated_resources_not_found",
-						issues: [
-							{
-								argumentPath: ["input", "id"],
-							},
-						],
-					},
-				});
-			}
-
-			if (existingAgendaItem.type === "note") {
-				if (
-					parsedArgs.input.duration !== undefined &&
-					parsedArgs.input.key !== undefined
-				) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "forbidden_action_on_arguments_associated_resources",
-							issues: [
-								{
-									argumentPath: ["input", "duration"],
-									message: `Cannot be provided for an agenda item of type "${existingAgendaItem.type}"`,
-								},
-								{
-									argumentPath: ["input", "key"],
-									message: `Cannot be provided for an agenda item of type "${existingAgendaItem.type}"`,
-								},
-							],
-						},
-					});
-				}
-
-				if (parsedArgs.input.duration !== undefined) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "forbidden_action_on_arguments_associated_resources",
-							issues: [
-								{
-									argumentPath: ["input", "duration"],
-									message: `Cannot be provided for an agenda item of type "${existingAgendaItem.type}"`,
-								},
-							],
-						},
-					});
-				}
-
-				if (parsedArgs.input.key !== undefined) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "forbidden_action_on_arguments_associated_resources",
-							issues: [
-								{
-									argumentPath: ["input", "key"],
-									message: `Cannot be provided for an agenda item of type "${existingAgendaItem.type}"`,
-								},
-							],
-						},
-					});
-				}
-			}
-
-			if (
-				(existingAgendaItem.type === "general" ||
-					existingAgendaItem.type === "scripture") &&
-				parsedArgs.input.key !== undefined
-			) {
-				throw new TalawaGraphQLError({
-					extensions: {
-						code: "forbidden_action_on_arguments_associated_resources",
-						issues: [
-							{
-								argumentPath: ["input", "key"],
-								message: `Cannot be provided for an agenda item of type "${existingAgendaItem.type}"`,
-							},
-						],
-					},
-				});
-			}
-
-			if (isNotNullish(parsedArgs.input.folderId)) {
-				const folderId = parsedArgs.input.folderId;
-
-				const existingAgendaFolder =
-					await ctx.drizzleClient.query.agendaFoldersTable.findFirst({
-						columns: {
-							eventId: true,
-							isAgendaItemFolder: true,
-						},
-						where: (fields, operators) => operators.eq(fields.id, folderId),
-					});
-
-				if (existingAgendaFolder === undefined) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "arguments_associated_resources_not_found",
-							issues: [
-								{
-									argumentPath: ["input", "folderId"],
-								},
-							],
-						},
-					});
-				}
-
-				if (
-					existingAgendaFolder.eventId !== existingAgendaItem.folder.eventId
-				) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "forbidden_action_on_arguments_associated_resources",
-							issues: [
-								{
-									argumentPath: ["input", "folderId"],
-									message:
-										"This agenda folder does not belong to the event to the agenda item.",
-								},
-							],
-						},
-					});
-				}
-
-				if (!existingAgendaFolder.isAgendaItemFolder) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "forbidden_action_on_arguments_associated_resources",
-							issues: [
-								{
-									argumentPath: ["input", "folderId"],
-									message:
-										"This agenda folder cannot be a folder to agenda items.",
-								},
-							],
-						},
-					});
-				}
-			}
-
-			const currentUserOrganizationMembership =
-				existingAgendaItem.folder.event.organization
-					.membershipsWhereOrganization[0];
-
-			if (
-				currentUser.role !== "administrator" &&
-				(currentUserOrganizationMembership === undefined ||
-					currentUserOrganizationMembership.role !== "administrator")
-			) {
-				throw new TalawaGraphQLError({
-					extensions: {
-						code: "unauthorized_action_on_arguments_associated_resources",
-						issues: [
-							{
-								argumentPath: ["input", "id"],
-							},
-						],
-					},
-				});
-			}
-
-			const [updatedAgendaItem] = await ctx.drizzleClient
-				.update(agendaItemsTable)
-				.set({
-					description: parsedArgs.input.description,
-					duration: parsedArgs.input.duration,
-					folderId: parsedArgs.input.folderId,
-					key: parsedArgs.input.key,
-					name: parsedArgs.input.name,
-					updaterId: currentUserId,
-				})
-				.where(eq(agendaItemsTable.id, parsedArgs.input.id))
-				.returning();
-
-			// Updated agenda item not being returned means that either it was deleted or its `id` column was changed by external entities before this update operation could take place.
-			if (updatedAgendaItem === undefined) {
-				throw new TalawaGraphQLError({
-					extensions: {
-						code: "unexpected",
-					},
-				});
-			}
-
-			return updatedAgendaItem;
-		},
+		resolve: updateAgendaItemResolver,
 		type: AgendaItem,
 	}),
 );

--- a/test/graphql/types/Mutation/updateAgendaItem.test.ts
+++ b/test/graphql/types/Mutation/updateAgendaItem.test.ts
@@ -67,11 +67,7 @@ const authenticatedContext: TestContext = {
 	},
 	minio: {
 		bucketName: "talawa",
-		client: {
-			listBuckets: vi.fn(),
-			putObject: vi.fn(),
-			getObject: vi.fn(),
-		} as unknown as MinioClient,
+		client: {} as MinioClient, // minimal mock that satisfies the type
 	},
 	pubsub: {
 		publish: vi.fn(),

--- a/test/graphql/types/Mutation/updateAgendaItem.test.ts
+++ b/test/graphql/types/Mutation/updateAgendaItem.test.ts
@@ -1,0 +1,910 @@
+import type { FastifyBaseLogger } from "fastify";
+import type { Client as MinioClient } from "minio";
+import { createMockLogger } from "test/utilities/mockLogger";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GraphQLContext } from "~/src/graphql/context";
+import { updateAgendaItemResolver } from "~/src/graphql/types/Mutation/updateAgendaItem";
+
+interface TestContext extends Omit<GraphQLContext, "log"> {
+	drizzleClient: {
+		query: {
+			usersTable: {
+				findFirst: ReturnType<typeof vi.fn>;
+			};
+			agendaItemsTable: {
+				findFirst: ReturnType<typeof vi.fn>;
+			};
+			agendaFoldersTable: {
+				findFirst: ReturnType<typeof vi.fn>;
+			};
+		};
+		update: ReturnType<typeof vi.fn>;
+		set: ReturnType<typeof vi.fn>;
+		where: ReturnType<typeof vi.fn>;
+		returning: ReturnType<typeof vi.fn>;
+	} & GraphQLContext["drizzleClient"];
+	log: FastifyBaseLogger;
+}
+
+// Mock the Drizzle client
+const drizzleClientMock = {
+	query: {
+		usersTable: {
+			findFirst: vi.fn(),
+		},
+		agendaItemsTable: {
+			findFirst: vi.fn(),
+		},
+		agendaFoldersTable: {
+			findFirst: vi.fn(),
+		},
+	},
+	update: vi.fn().mockReturnThis(),
+	set: vi.fn().mockReturnThis(),
+	where: vi.fn().mockReturnThis(),
+	returning: vi.fn(),
+} as unknown as TestContext["drizzleClient"];
+
+const mockLogger = createMockLogger();
+
+const authenticatedContext: TestContext = {
+	currentClient: {
+		isAuthenticated: true,
+		user: {
+			id: "user_1",
+		},
+	},
+	drizzleClient: drizzleClientMock,
+	log: mockLogger,
+	envConfig: {
+		API_BASE_URL: "http://localhost:3000",
+	},
+	jwt: {
+		sign: vi.fn().mockReturnValue("mock-token"),
+	},
+	minio: {
+		bucketName: "talawa",
+		client: {
+			listBuckets: vi.fn(),
+			putObject: vi.fn(),
+			getObject: vi.fn(),
+		} as unknown as MinioClient,
+	},
+	pubsub: {
+		publish: vi.fn(),
+		subscribe: vi.fn(),
+	},
+};
+
+const unauthenticatedContext: TestContext = {
+	...authenticatedContext,
+	currentClient: {
+		isAuthenticated: false,
+	},
+};
+
+describe("updateAgendaItemResolver", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	/**
+	 * Test authentication check
+	 * Verifies that the resolver rejects unauthorized access attempts
+	 * Expected: Returns unauthenticated error when client is not authenticated
+	 */
+
+	it("should throw unauthenticated error when attempting to update agenda item without authentication", async () => {
+		await expect(
+			updateAgendaItemResolver(
+				{},
+				{
+					input: {
+						id: "123e4567-e89b-12d3-a456-426614174000",
+						name: "Updated Name",
+					},
+				},
+				unauthenticatedContext,
+			),
+		).rejects.toThrowError(
+			expect.objectContaining({
+				message: expect.any(String),
+				extensions: { code: "unauthenticated" },
+			}),
+		);
+	});
+
+	it("should throw invalid_arguments error when updating agenda item with invalid UUID format", async () => {
+		await expect(
+			updateAgendaItemResolver(
+				{},
+				{
+					input: {
+						id: "invalid-id",
+					},
+				},
+				authenticatedContext,
+			),
+		).rejects.toMatchObject({
+			extensions: { code: "invalid_arguments" },
+		});
+	});
+
+	it("should throw unauthenticated error when user ID from token is not found in database", async () => {
+		drizzleClientMock.query.usersTable.findFirst.mockResolvedValue(undefined);
+
+		await expect(
+			updateAgendaItemResolver(
+				{},
+				{
+					input: {
+						id: "123e4567-e89b-12d3-a456-426614174000",
+						name: "Updated Name",
+					},
+				},
+				authenticatedContext,
+			),
+		).rejects.toThrowError(
+			expect.objectContaining({
+				message: expect.any(String),
+				extensions: {
+					code: "unauthenticated",
+				},
+			}),
+		);
+	});
+
+	it("should throw arguments_associated_resources_not_found error when agenda item ID does not exist", async () => {
+		drizzleClientMock.query.usersTable.findFirst.mockResolvedValue({
+			role: "regular",
+		});
+		drizzleClientMock.query.agendaItemsTable.findFirst.mockResolvedValue(
+			undefined,
+		);
+
+		await expect(
+			updateAgendaItemResolver(
+				{},
+				{
+					input: {
+						id: "123e4567-e89b-12d3-a456-426614174000",
+						name: "Updated Name",
+					},
+				},
+				authenticatedContext,
+			),
+		).rejects.toThrowError(
+			expect.objectContaining({
+				message: expect.any(String),
+				extensions: {
+					code: "arguments_associated_resources_not_found",
+					issues: [
+						{
+							argumentPath: ["input", "id"],
+						},
+					],
+				},
+			}),
+		);
+	});
+
+	it("should throw unauthorized_action error when non-admin user attempts to update agenda item", async () => {
+		drizzleClientMock.query.usersTable.findFirst.mockResolvedValue({
+			role: "regular",
+		});
+		drizzleClientMock.query.agendaItemsTable.findFirst.mockResolvedValue({
+			type: "general",
+			folder: {
+				event: {
+					organization: {
+						membershipsWhereOrganization: [],
+					},
+				},
+			},
+		});
+
+		await expect(
+			updateAgendaItemResolver(
+				{},
+				{
+					input: {
+						id: "123e4567-e89b-12d3-a456-426614174000",
+						name: "Updated Name",
+					},
+				},
+				authenticatedContext,
+			),
+		).rejects.toThrowError(
+			expect.objectContaining({
+				message: expect.any(String),
+				extensions: {
+					code: "unauthorized_action_on_arguments_associated_resources",
+					issues: [
+						{
+							argumentPath: ["input", "id"],
+						},
+					],
+				},
+			}),
+		);
+	});
+
+	it("should throw forbidden_action error when attempting to set duration or key for note-type agenda item", async () => {
+		drizzleClientMock.query.usersTable.findFirst.mockResolvedValue({
+			role: "administrator",
+		});
+		drizzleClientMock.query.agendaItemsTable.findFirst.mockResolvedValue({
+			type: "note",
+			folder: {
+				event: {
+					organization: {
+						membershipsWhereOrganization: [{ role: "administrator" }],
+					},
+				},
+			},
+		});
+
+		await expect(
+			updateAgendaItemResolver(
+				{},
+				{
+					input: {
+						id: "123e4567-e89b-12d3-a456-426614174000",
+						duration: "10",
+						key: "C",
+					},
+				},
+				authenticatedContext,
+			),
+		).rejects.toThrowError(
+			expect.objectContaining({
+				message: expect.any(String),
+				extensions: {
+					code: "forbidden_action_on_arguments_associated_resources",
+					issues: [
+						{
+							argumentPath: ["input", "duration"],
+							message: 'Cannot be provided for an agenda item of type "note"',
+						},
+						{
+							argumentPath: ["input", "key"],
+							message: 'Cannot be provided for an agenda item of type "note"',
+						},
+					],
+				},
+			}),
+		);
+	});
+
+	it("should throw forbidden_action error when attempting to set key for general-type agenda item", async () => {
+		drizzleClientMock.query.usersTable.findFirst.mockResolvedValue({
+			role: "administrator",
+		});
+		drizzleClientMock.query.agendaItemsTable.findFirst.mockResolvedValue({
+			type: "general",
+			folder: {
+				event: {
+					organization: {
+						membershipsWhereOrganization: [{ role: "administrator" }],
+					},
+				},
+			},
+		});
+
+		await expect(
+			updateAgendaItemResolver(
+				{},
+				{
+					input: {
+						id: "123e4567-e89b-12d3-a456-426614174000",
+						key: "C",
+					},
+				},
+				authenticatedContext,
+			),
+		).rejects.toThrowError(
+			expect.objectContaining({
+				message: expect.any(String),
+				extensions: {
+					code: "forbidden_action_on_arguments_associated_resources",
+					issues: [
+						{
+							argumentPath: ["input", "key"],
+							message:
+								'Cannot be provided for an agenda item of type "general"',
+						},
+					],
+				},
+			}),
+		);
+	});
+
+	it("should throw arguments_associated_resources_not_found error when specified folder ID does not exist", async () => {
+		drizzleClientMock.query.usersTable.findFirst.mockResolvedValue({
+			role: "administrator",
+		});
+		drizzleClientMock.query.agendaItemsTable.findFirst.mockResolvedValue({
+			type: "general",
+			folder: {
+				eventId: "event_1",
+				event: {
+					organization: {
+						membershipsWhereOrganization: [{ role: "administrator" }],
+					},
+				},
+			},
+		});
+		drizzleClientMock.query.agendaFoldersTable.findFirst.mockResolvedValue(
+			undefined,
+		);
+
+		await expect(
+			updateAgendaItemResolver(
+				{},
+				{
+					input: {
+						id: "123e4567-e89b-12d3-a456-426614174000",
+						folderId: "123e4567-e89b-12d3-a456-426614174001",
+						name: "Updated Name",
+					},
+				},
+				authenticatedContext,
+			),
+		).rejects.toThrowError(
+			expect.objectContaining({
+				message: expect.any(String),
+				extensions: {
+					code: "arguments_associated_resources_not_found",
+					issues: [
+						{
+							argumentPath: ["input", "folderId"],
+						},
+					],
+				},
+			}),
+		);
+	});
+
+	it("should throw forbidden_action error when target folder belongs to different event", async () => {
+		drizzleClientMock.query.usersTable.findFirst.mockResolvedValue({
+			role: "administrator",
+		});
+		drizzleClientMock.query.agendaItemsTable.findFirst.mockResolvedValue({
+			type: "general",
+			folder: {
+				eventId: "event_1",
+				event: {
+					organization: {
+						membershipsWhereOrganization: [{ role: "administrator" }],
+					},
+				},
+			},
+		});
+		drizzleClientMock.query.agendaFoldersTable.findFirst.mockResolvedValue({
+			eventId: "event_2",
+			isAgendaItemFolder: true,
+		});
+
+		await expect(
+			updateAgendaItemResolver(
+				{},
+				{
+					input: {
+						id: "123e4567-e89b-12d3-a456-426614174000",
+						folderId: "123e4567-e89b-12d3-a456-426614174001",
+						name: "Updated Name",
+					},
+				},
+				authenticatedContext,
+			),
+		).rejects.toThrowError(
+			expect.objectContaining({
+				message: expect.any(String),
+				extensions: {
+					code: "forbidden_action_on_arguments_associated_resources",
+					issues: [
+						{
+							argumentPath: ["input", "folderId"],
+							message:
+								"This agenda folder does not belong to the event to the agenda item.",
+						},
+					],
+				},
+			}),
+		);
+	});
+
+	it("should throw forbidden_action error when target folder is not marked as agenda item folder", async () => {
+		drizzleClientMock.query.usersTable.findFirst.mockResolvedValue({
+			role: "administrator",
+		});
+		drizzleClientMock.query.agendaItemsTable.findFirst.mockResolvedValue({
+			type: "general",
+			folder: {
+				eventId: "event_1",
+				event: {
+					organization: {
+						membershipsWhereOrganization: [{ role: "administrator" }],
+					},
+				},
+			},
+		});
+		drizzleClientMock.query.agendaFoldersTable.findFirst.mockResolvedValue({
+			eventId: "event_1",
+			isAgendaItemFolder: false,
+		});
+
+		await expect(
+			updateAgendaItemResolver(
+				{},
+				{
+					input: {
+						id: "123e4567-e89b-12d3-a456-426614174000",
+						folderId: "123e4567-e89b-12d3-a456-426614174001",
+						name: "Updated Name",
+					},
+				},
+				authenticatedContext,
+			),
+		).rejects.toThrowError(
+			expect.objectContaining({
+				message: expect.any(String),
+				extensions: {
+					code: "forbidden_action_on_arguments_associated_resources",
+					issues: [
+						{
+							argumentPath: ["input", "folderId"],
+							message: "This agenda folder cannot be a folder to agenda items.",
+						},
+					],
+				},
+			}),
+		);
+	});
+
+	it("should successfully update agenda item when admin user provides valid input", async () => {
+		drizzleClientMock.query.usersTable.findFirst.mockResolvedValue({
+			role: "administrator",
+		});
+		drizzleClientMock.query.agendaItemsTable.findFirst.mockResolvedValue({
+			type: "general",
+			folder: {
+				eventId: "event_1",
+				event: {
+					organization: {
+						membershipsWhereOrganization: [{ role: "administrator" }],
+					},
+				},
+			},
+		});
+		drizzleClientMock.query.agendaFoldersTable.findFirst.mockResolvedValue({
+			eventId: "event_1",
+			isAgendaItemFolder: true,
+		});
+		drizzleClientMock.update.mockReturnValue({
+			set: vi.fn().mockReturnThis(),
+			where: vi.fn().mockReturnThis(),
+			returning: vi
+				.fn()
+				.mockResolvedValue([
+					{ id: "123e4567-e89b-12d3-a456-426614174000", name: "Updated Name" },
+				]),
+		});
+
+		const result = await updateAgendaItemResolver(
+			{},
+			{
+				input: {
+					id: "123e4567-e89b-12d3-a456-426614174000",
+					name: "Updated Name",
+				},
+			},
+			authenticatedContext,
+		);
+
+		expect(result).toEqual({
+			id: "123e4567-e89b-12d3-a456-426614174000",
+			name: "Updated Name",
+		});
+	});
+
+	it("should throw unexpected error when database update operation returns empty result", async () => {
+		drizzleClientMock.query.usersTable.findFirst.mockResolvedValue({
+			role: "administrator",
+		});
+		drizzleClientMock.query.agendaItemsTable.findFirst.mockResolvedValue({
+			type: "general",
+			folder: {
+				eventId: "event_1",
+				event: {
+					organization: {
+						membershipsWhereOrganization: [{ role: "administrator" }],
+					},
+				},
+			},
+		});
+		drizzleClientMock.update.mockReturnValue({
+			set: vi.fn().mockReturnThis(),
+			where: vi.fn().mockReturnThis(),
+			returning: vi.fn().mockResolvedValue([]),
+		});
+
+		await expect(
+			updateAgendaItemResolver(
+				{},
+				{
+					input: {
+						id: "123e4567-e89b-12d3-a456-426614174000",
+						name: "Updated Name",
+					},
+				},
+				authenticatedContext,
+			),
+		).rejects.toThrowError(
+			expect.objectContaining({
+				message: expect.any(String),
+				extensions: {
+					code: "unexpected",
+				},
+			}),
+		);
+	});
+
+	// Test for note-type agenda item with only duration
+	it("should throw forbidden_action error when attempting to set only duration for note-type agenda item", async () => {
+		drizzleClientMock.query.usersTable.findFirst.mockResolvedValue({
+			role: "administrator",
+		});
+		drizzleClientMock.query.agendaItemsTable.findFirst.mockResolvedValue({
+			type: "note",
+			folder: {
+				event: {
+					organization: {
+						membershipsWhereOrganization: [{ role: "administrator" }],
+					},
+				},
+			},
+		});
+
+		await expect(
+			updateAgendaItemResolver(
+				{},
+				{
+					input: {
+						id: "123e4567-e89b-12d3-a456-426614174000",
+						duration: "10",
+					},
+				},
+				authenticatedContext,
+			),
+		).rejects.toThrowError(
+			expect.objectContaining({
+				message: expect.any(String),
+				extensions: {
+					code: "forbidden_action_on_arguments_associated_resources",
+					issues: [
+						{
+							argumentPath: ["input", "duration"],
+							message: 'Cannot be provided for an agenda item of type "note"',
+						},
+					],
+				},
+			}),
+		);
+	});
+
+	// Test for note-type agenda item with only key
+	it("should throw forbidden_action error when attempting to set only key for note-type agenda item", async () => {
+		drizzleClientMock.query.usersTable.findFirst.mockResolvedValue({
+			role: "administrator",
+		});
+		drizzleClientMock.query.agendaItemsTable.findFirst.mockResolvedValue({
+			type: "note",
+			folder: {
+				event: {
+					organization: {
+						membershipsWhereOrganization: [{ role: "administrator" }],
+					},
+				},
+			},
+		});
+
+		await expect(
+			updateAgendaItemResolver(
+				{},
+				{
+					input: {
+						id: "123e4567-e89b-12d3-a456-426614174000",
+						key: "C",
+					},
+				},
+				authenticatedContext,
+			),
+		).rejects.toThrowError(
+			expect.objectContaining({
+				message: expect.any(String),
+				extensions: {
+					code: "forbidden_action_on_arguments_associated_resources",
+					issues: [
+						{
+							argumentPath: ["input", "key"],
+							message: 'Cannot be provided for an agenda item of type "note"',
+						},
+					],
+				},
+			}),
+		);
+	});
+
+	// Test for scripture-type agenda item with key
+	it("should throw forbidden_action error when attempting to set key for scripture-type agenda item", async () => {
+		drizzleClientMock.query.usersTable.findFirst.mockResolvedValue({
+			role: "administrator",
+		});
+		drizzleClientMock.query.agendaItemsTable.findFirst.mockResolvedValue({
+			type: "scripture",
+			folder: {
+				event: {
+					organization: {
+						membershipsWhereOrganization: [{ role: "administrator" }],
+					},
+				},
+			},
+		});
+
+		await expect(
+			updateAgendaItemResolver(
+				{},
+				{
+					input: {
+						id: "123e4567-e89b-12d3-a456-426614174000",
+						key: "C",
+					},
+				},
+				authenticatedContext,
+			),
+		).rejects.toThrowError(
+			expect.objectContaining({
+				message: expect.any(String),
+				extensions: {
+					code: "forbidden_action_on_arguments_associated_resources",
+					issues: [
+						{
+							argumentPath: ["input", "key"],
+							message:
+								'Cannot be provided for an agenda item of type "scripture"',
+						},
+					],
+				},
+			}),
+		);
+	});
+
+	// Test for note-type agenda item with both duration and key
+	it("should throw error when updating note-type agenda item with both duration and key", async () => {
+		drizzleClientMock.query.usersTable.findFirst.mockResolvedValue({
+			role: "administrator",
+		});
+		drizzleClientMock.query.agendaItemsTable.findFirst.mockResolvedValue({
+			type: "note",
+			folder: {
+				event: {
+					organization: {
+						membershipsWhereOrganization: [{ role: "administrator" }],
+					},
+				},
+			},
+		});
+
+		await expect(
+			updateAgendaItemResolver(
+				{},
+				{
+					input: {
+						id: "123e4567-e89b-12d3-a456-426614174000",
+						duration: "10",
+						key: "C",
+					},
+				},
+				authenticatedContext,
+			),
+		).rejects.toThrowError(
+			expect.objectContaining({
+				message: expect.any(String),
+				extensions: {
+					code: "forbidden_action_on_arguments_associated_resources",
+					issues: [
+						{
+							argumentPath: ["input", "duration"],
+							message: 'Cannot be provided for an agenda item of type "note"',
+						},
+						{
+							argumentPath: ["input", "key"],
+							message: 'Cannot be provided for an agenda item of type "note"',
+						},
+					],
+				},
+			}),
+		);
+	});
+
+	// Test for note-type agenda item with only duration
+	it("should throw error when updating note-type agenda item with duration", async () => {
+		drizzleClientMock.query.usersTable.findFirst.mockResolvedValue({
+			role: "administrator",
+		});
+		drizzleClientMock.query.agendaItemsTable.findFirst.mockResolvedValue({
+			type: "note",
+			folder: {
+				event: {
+					organization: {
+						membershipsWhereOrganization: [{ role: "administrator" }],
+					},
+				},
+			},
+		});
+
+		await expect(
+			updateAgendaItemResolver(
+				{},
+				{
+					input: {
+						id: "123e4567-e89b-12d3-a456-426614174000",
+						duration: "10",
+					},
+				},
+				authenticatedContext,
+			),
+		).rejects.toThrowError(
+			expect.objectContaining({
+				message: expect.any(String),
+				extensions: {
+					code: "forbidden_action_on_arguments_associated_resources",
+					issues: [
+						{
+							argumentPath: ["input", "duration"],
+							message: 'Cannot be provided for an agenda item of type "note"',
+						},
+					],
+				},
+			}),
+		);
+	});
+
+	// Test for concurrent deletion scenario
+	it("should throw unexpected error when agenda item is not returned after update", async () => {
+		drizzleClientMock.query.usersTable.findFirst.mockResolvedValue({
+			role: "administrator",
+		});
+		drizzleClientMock.query.agendaItemsTable.findFirst.mockResolvedValue({
+			type: "general",
+			folder: {
+				event: {
+					organization: {
+						membershipsWhereOrganization: [{ role: "administrator" }],
+					},
+				},
+			},
+		});
+		// Mock update to return empty array (simulating concurrent deletion)
+		drizzleClientMock.update.mockReturnValue({
+			set: () => ({
+				where: () => ({
+					returning: () => [],
+				}),
+			}),
+		});
+
+		await expect(
+			updateAgendaItemResolver(
+				{},
+				{
+					input: {
+						id: "123e4567-e89b-12d3-a456-426614174000",
+						name: "Updated Name",
+					},
+				},
+				authenticatedContext,
+			),
+		).rejects.toThrowError(
+			expect.objectContaining({
+				message: expect.any(String),
+				extensions: {
+					code: "unexpected",
+				},
+			}),
+		);
+	});
+
+	it("should handle note-type agenda item validations", async () => {
+		drizzleClientMock.query.usersTable.findFirst.mockResolvedValue({
+			role: "administrator",
+		});
+		drizzleClientMock.query.agendaItemsTable.findFirst.mockResolvedValue({
+			type: "note",
+			folder: {
+				eventId: "event_1",
+				event: {
+					organization: {
+						membershipsWhereOrganization: [{ role: "administrator" }],
+					},
+				},
+			},
+		});
+
+		// Test both duration and key provided (lines 80, 90)
+		await expect(
+			updateAgendaItemResolver(
+				{},
+				{
+					input: {
+						id: "123e4567-e89b-12d3-a456-426614174000",
+						duration: "10",
+						key: "C",
+					},
+				},
+				authenticatedContext,
+			),
+		).rejects.toThrowError(
+			expect.objectContaining({
+				extensions: {
+					code: "forbidden_action_on_arguments_associated_resources",
+					issues: [
+						{
+							argumentPath: ["input", "duration"],
+							message: 'Cannot be provided for an agenda item of type "note"',
+						},
+						{
+							argumentPath: ["input", "key"],
+							message: 'Cannot be provided for an agenda item of type "note"',
+						},
+					],
+				},
+			}),
+		);
+	});
+
+	it("should handle folder validation and update authorization", async () => {
+		drizzleClientMock.query.usersTable.findFirst.mockResolvedValue({
+			role: "regular", // Non-admin user
+		});
+		drizzleClientMock.query.agendaItemsTable.findFirst.mockResolvedValue({
+			type: "general",
+			folder: {
+				eventId: "event_1",
+				event: {
+					organization: {
+						membershipsWhereOrganization: [
+							{ role: "regular" }, // Non-admin role in organization (lines 242-243)
+						],
+					},
+				},
+			},
+		});
+
+		// Test unauthorized update attempt
+		await expect(
+			updateAgendaItemResolver(
+				{},
+				{
+					input: {
+						id: "123e4567-e89b-12d3-a456-426614174000",
+						name: "Updated Name",
+					},
+				},
+				authenticatedContext,
+			),
+		).rejects.toThrowError(
+			expect.objectContaining({
+				extensions: {
+					code: "unauthorized_action_on_arguments_associated_resources",
+					issues: [
+						{
+							argumentPath: ["input", "id"],
+						},
+					],
+				},
+			}),
+		);
+	});
+});

--- a/test/graphql/types/Mutation/updateAgendaItem.test.ts
+++ b/test/graphql/types/Mutation/updateAgendaItem.test.ts
@@ -601,51 +601,6 @@ describe("updateAgendaItemResolver", () => {
 		);
 	});
 
-	// Test for concurrent deletion scenario
-	it("should throw unexpected error when agenda item is not returned after update", async () => {
-		drizzleClientMock.query.usersTable.findFirst.mockResolvedValue({
-			role: "administrator",
-		});
-		drizzleClientMock.query.agendaItemsTable.findFirst.mockResolvedValue({
-			type: "general",
-			folder: {
-				event: {
-					organization: {
-						membershipsWhereOrganization: [{ role: "administrator" }],
-					},
-				},
-			},
-		});
-		// Mock update to return empty array (simulating concurrent deletion)
-		drizzleClientMock.update.mockReturnValue({
-			set: () => ({
-				where: () => ({
-					returning: () => [],
-				}),
-			}),
-		});
-
-		await expect(
-			updateAgendaItemResolver(
-				{},
-				{
-					input: {
-						id: "123e4567-e89b-12d3-a456-426614174000",
-						name: "Updated Name",
-					},
-				},
-				authenticatedContext,
-			),
-		).rejects.toThrowError(
-			expect.objectContaining({
-				message: expect.any(String),
-				extensions: {
-					code: "unexpected",
-				},
-			}),
-		);
-	});
-
 	// Helper function to reduce setup code duplication
 	const setupNoteTypeAgendaItemTest = () => {
 		drizzleClientMock.query.usersTable.findFirst.mockResolvedValue({


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Tests for src/graphql/types/Mutation/updateAgendaItem.ts
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number: 2922**

Fixes :#2922 

**Snapshots/Videos:**
![Screenshot 2025-02-09 140734](https://github.com/user-attachments/assets/d7815426-4444-47bb-8440-e2732ae51d82)


<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**
Added test for updateAgendaItem.ts 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
	- The agenda item update process was reorganized to improve modularity and ensure consistent behavior, including robust handling of errors and validation.
- **Tests**
	- Introduced a comprehensive suite of tests to validate authentication, input checks, authorization, and error responses, ensuring a reliable update experience for users.
- **New Features**
	- Updated the agenda item update schema to include optional fields for folder ID and name, enhancing user flexibility during updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->