### PR TITLE
wrote Test: src/graphql/types/Mutation/deletePost.ts

### DIFF
--- a/src/graphql/types/Mutation/deletePost.ts
+++ b/src/graphql/types/Mutation/deletePost.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { postsTable } from "~/src/drizzle/tables/posts";
 import { builder } from "~/src/graphql/builder";
+import type { GraphQLContext } from "~/src/graphql/context";
 import {
 	MutationDeletePostInput,
 	mutationDeletePostInputSchema,
@@ -9,10 +10,127 @@ import {
 import { Post } from "~/src/graphql/types/Post/Post";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 
+// Schema for the arguments object
 const mutationDeletePostArgumentsSchema = z.object({
 	input: mutationDeletePostInputSchema,
 });
 
+// Extract and export the resolver logic so it can be imported in your tests.
+export async function deletePostResolver(
+	_parent: unknown,
+	args: z.infer<typeof mutationDeletePostArgumentsSchema>,
+	ctx: GraphQLContext,
+) {
+	if (!ctx.currentClient.isAuthenticated) {
+		throw new TalawaGraphQLError({
+			extensions: { code: "unauthenticated" },
+		});
+	}
+
+	const {
+		data: parsedArgs,
+		error,
+		success,
+	} = mutationDeletePostArgumentsSchema.safeParse(args);
+
+	if (!success) {
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "invalid_arguments",
+				issues: error.issues.map((issue) => ({
+					argumentPath: issue.path,
+					message: issue.message,
+				})),
+			},
+		});
+	}
+
+	const currentUserId = ctx.currentClient.user.id;
+
+	const [currentUser, existingPost] = await Promise.all([
+		ctx.drizzleClient.query.usersTable.findFirst({
+			columns: { role: true },
+			where: (fields, operators: { eq: typeof eq }) =>
+				operators.eq(fields.id, currentUserId),
+		}),
+		ctx.drizzleClient.query.postsTable.findFirst({
+			columns: { creatorId: true },
+			with: {
+				attachmentsWherePost: true,
+				organization: {
+					columns: { countryCode: true },
+					with: {
+						membershipsWhereOrganization: {
+							columns: { role: true },
+							where: (fields, operators: { eq: typeof eq }) =>
+								operators.eq(fields.memberId, currentUserId),
+						},
+					},
+				},
+			},
+			where: eq(postsTable.id, parsedArgs.input.id),
+		}),
+	]);
+
+	if (currentUser === undefined) {
+		throw new TalawaGraphQLError({
+			extensions: { code: "unauthenticated" },
+		});
+	}
+
+	if (existingPost === undefined) {
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "arguments_associated_resources_not_found",
+				issues: [{ argumentPath: ["input", "id"] }],
+			},
+		});
+	}
+
+	if (currentUser.role !== "administrator") {
+		const currentUserOrganizationMembership =
+			existingPost.organization.membershipsWhereOrganization[0];
+
+		if (
+			currentUserOrganizationMembership === undefined ||
+			(currentUserOrganizationMembership.role !== "administrator" &&
+				existingPost.creatorId !== currentUserId)
+		) {
+			throw new TalawaGraphQLError({
+				extensions: {
+					code: "unauthorized_action_on_arguments_associated_resources",
+					issues: [{ argumentPath: ["input", "id"] }],
+				},
+			});
+		}
+	}
+
+	return await ctx.drizzleClient.transaction(async (tx) => {
+		const [deletedPost] = await tx
+			.delete(postsTable)
+			.where(eq(postsTable.id, parsedArgs.input.id))
+			.returning();
+
+		if (deletedPost === undefined) {
+			throw new TalawaGraphQLError({
+				extensions: { code: "unexpected" },
+			});
+		}
+
+		await ctx.minio.client.removeObjects(
+			ctx.minio.bucketName,
+			existingPost.attachmentsWherePost.map(
+				(attachment: { name: string }) => attachment.name,
+			),
+		);
+
+		return Object.assign(deletedPost, {
+			attachments: existingPost.attachmentsWherePost,
+		});
+	});
+}
+
+// Register the mutation resolver with the builder
 builder.mutationField("deletePost", (t) =>
 	t.field({
 		args: {
@@ -23,138 +141,7 @@ builder.mutationField("deletePost", (t) =>
 			}),
 		},
 		description: "Mutation field to delete a post.",
-		resolve: async (_parent, args, ctx) => {
-			if (!ctx.currentClient.isAuthenticated) {
-				throw new TalawaGraphQLError({
-					extensions: {
-						code: "unauthenticated",
-					},
-				});
-			}
-
-			const {
-				data: parsedArgs,
-				error,
-				success,
-			} = mutationDeletePostArgumentsSchema.safeParse(args);
-
-			if (!success) {
-				throw new TalawaGraphQLError({
-					extensions: {
-						code: "invalid_arguments",
-						issues: error.issues.map((issue) => ({
-							argumentPath: issue.path,
-							message: issue.message,
-						})),
-					},
-				});
-			}
-
-			const currentUserId = ctx.currentClient.user.id;
-
-			const [currentUser, existingPost] = await Promise.all([
-				ctx.drizzleClient.query.usersTable.findFirst({
-					columns: {
-						role: true,
-					},
-					where: (fields, operators) => operators.eq(fields.id, currentUserId),
-				}),
-				ctx.drizzleClient.query.postsTable.findFirst({
-					columns: {
-						creatorId: true,
-					},
-					with: {
-						attachmentsWherePost: true,
-						organization: {
-							columns: {
-								countryCode: true,
-							},
-							with: {
-								membershipsWhereOrganization: {
-									columns: {
-										role: true,
-									},
-									where: (fields, operators) =>
-										operators.eq(fields.memberId, currentUserId),
-								},
-							},
-						},
-					},
-					where: (fields, operators) =>
-						operators.eq(fields.id, parsedArgs.input.id),
-				}),
-			]);
-
-			if (currentUser === undefined) {
-				throw new TalawaGraphQLError({
-					extensions: {
-						code: "unauthenticated",
-					},
-				});
-			}
-
-			if (existingPost === undefined) {
-				throw new TalawaGraphQLError({
-					extensions: {
-						code: "arguments_associated_resources_not_found",
-						issues: [
-							{
-								argumentPath: ["input", "id"],
-							},
-						],
-					},
-				});
-			}
-
-			if (currentUser.role !== "administrator") {
-				const currentUserOrganizationMembership =
-					existingPost.organization.membershipsWhereOrganization[0];
-
-				if (
-					currentUserOrganizationMembership === undefined ||
-					(currentUserOrganizationMembership.role !== "administrator" &&
-						existingPost.creatorId !== currentUserId)
-				) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthorized_action_on_arguments_associated_resources",
-							issues: [
-								{
-									argumentPath: ["input", "id"],
-								},
-							],
-						},
-					});
-				}
-			}
-
-			return await ctx.drizzleClient.transaction(async (tx) => {
-				const [deletedPost] = await tx
-					.delete(postsTable)
-					.where(eq(postsTable.id, parsedArgs.input.id))
-					.returning();
-
-				// Deleted post not being returned means that either it was deleted or its `id` column was changed by external entities before this delete operation.
-				if (deletedPost === undefined) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unexpected",
-						},
-					});
-				}
-
-				await ctx.minio.client.removeObjects(
-					ctx.minio.bucketName,
-					existingPost.attachmentsWherePost.map(
-						(attachment) => attachment.name,
-					),
-				);
-
-				return Object.assign(deletedPost, {
-					attachments: existingPost.attachmentsWherePost,
-				});
-			});
-		},
+		resolve: deletePostResolver,
 		type: Post,
 	}),
 );

--- a/src/graphql/types/Mutation/deletePost.ts
+++ b/src/graphql/types/Mutation/deletePost.ts
@@ -130,7 +130,6 @@ export async function deletePostResolver(
 	});
 }
 
-// Register the mutation resolver with the builder
 builder.mutationField("deletePost", (t) =>
 	t.field({
 		args: {

--- a/test/routes/graphql/Mutation/deletePost.test.ts
+++ b/test/routes/graphql/Mutation/deletePost.test.ts
@@ -1,0 +1,293 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import type { CurrentClient, GraphQLContext } from "~/src/graphql/context";
+import { mutationDeletePostInputSchema } from "~/src/graphql/inputs/MutationDeletePostInput";
+import { deletePostResolver } from "~/src/graphql/types/Mutation/deletePost";
+
+interface DeletedPost {
+	id: string;
+	content: string;
+}
+
+interface FakeTx {
+	delete: () => {
+		where: () => {
+			returning: () => Promise<DeletedPost[]>;
+		};
+	};
+}
+
+// Re-create the arguments schema used in the resolver
+const mutationDeletePostArgumentsSchema = z.object({
+	input: mutationDeletePostInputSchema,
+});
+
+// Helper to create a full mock GraphQLContext with dummy values
+const createMockContext = (
+	overrides: Partial<GraphQLContext> = {},
+): GraphQLContext => {
+	return {
+		currentClient: {
+			isAuthenticated: true,
+			user: { id: "user1" },
+		} as CurrentClient,
+		drizzleClient: {
+			query: {
+				usersTable: { findFirst: vi.fn() },
+				postsTable: { findFirst: vi.fn() },
+			},
+			transaction: vi.fn(),
+		},
+		minio: {
+			client: { removeObjects: vi.fn(() => Promise.resolve()) },
+			bucketName: "test-bucket",
+		},
+		envConfig: { API_BASE_URL: "http://localhost" },
+		jwt: { sign: vi.fn() },
+		log: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+		...overrides,
+	} as GraphQLContext;
+};
+
+const testPostId = "123e4567-e89b-12d3-a456-426614174000";
+const validArgs = { input: { id: testPostId } };
+
+// Since the input must include an id, we “force” invalid args via a cast.
+const invalidArgs = { input: {} } as unknown as z.infer<
+	typeof mutationDeletePostArgumentsSchema
+>;
+
+describe("deletePostResolver", () => {
+	let ctx: GraphQLContext;
+
+	beforeEach(() => {
+		ctx = createMockContext();
+	});
+
+	it("should throw an unauthenticated error if the client is not authenticated", async () => {
+		ctx.currentClient.isAuthenticated = false;
+		await expect(
+			deletePostResolver(null, validArgs, ctx),
+		).rejects.toHaveProperty("extensions.code", "unauthenticated");
+	});
+
+	it("should throw an invalid_arguments error if the input arguments are invalid", async () => {
+		await expect(
+			deletePostResolver(null, invalidArgs, ctx),
+		).rejects.toHaveProperty("extensions.code", "invalid_arguments");
+	});
+
+	it("should throw an unauthenticated error if the current user is not found", async () => {
+		// Simulate no user found by returning undefined.
+		ctx.drizzleClient.query.usersTable.findFirst = vi
+			.fn()
+			.mockResolvedValue(undefined);
+		ctx.drizzleClient.query.postsTable.findFirst = vi.fn().mockResolvedValue({
+			creatorId: "user1",
+			attachmentsWherePost: [],
+			organization: { membershipsWhereOrganization: [] },
+		});
+		await expect(
+			deletePostResolver(null, validArgs, ctx),
+		).rejects.toHaveProperty("extensions.code", "unauthenticated");
+	});
+
+	it("should throw an arguments_associated_resources_not_found error if the post is not found", async () => {
+		ctx.drizzleClient.query.usersTable.findFirst = vi
+			.fn()
+			.mockResolvedValue({ role: "administrator" });
+		ctx.drizzleClient.query.postsTable.findFirst = vi
+			.fn()
+			.mockResolvedValue(undefined);
+		await expect(
+			deletePostResolver(null, validArgs, ctx),
+		).rejects.toHaveProperty(
+			"extensions.code",
+			"arguments_associated_resources_not_found",
+		);
+	});
+
+	it("should throw an unauthorized_action_on_arguments_associated_resources error for an unauthorized non-admin user", async () => {
+		// Simulate a non-admin user and a post that the user is neither creator nor organization admin for.
+		ctx.drizzleClient.query.usersTable.findFirst = vi
+			.fn()
+			.mockResolvedValue({ role: "user" });
+		ctx.drizzleClient.query.postsTable.findFirst = vi.fn().mockResolvedValue({
+			creatorId: "someoneElse",
+			attachmentsWherePost: [],
+			organization: { membershipsWhereOrganization: [] },
+		});
+		await expect(
+			deletePostResolver(null, validArgs, ctx),
+		).rejects.toHaveProperty(
+			"extensions.code",
+			"unauthorized_action_on_arguments_associated_resources",
+		);
+	});
+
+	it("should throw an unexpected error if the deletion returns no post", async () => {
+		// Define a fake transaction that returns an empty array.
+		const fakeTransaction = vi.fn(
+			async (fn: (tx: FakeTx) => Promise<unknown>): Promise<unknown> => {
+				const fakeTx: FakeTx = {
+					delete: vi.fn().mockReturnValue({
+						where: vi.fn().mockReturnValue({
+							returning: vi.fn().mockResolvedValue([]), // Simulate no deleted post.
+						}),
+					}),
+				};
+				return await fn(fakeTx);
+			},
+		);
+		ctx.drizzleClient.query.usersTable.findFirst = vi
+			.fn()
+			.mockResolvedValue({ role: "administrator" });
+		ctx.drizzleClient.query.postsTable.findFirst = vi.fn().mockResolvedValue({
+			creatorId: "user1",
+			attachmentsWherePost: [{ name: "file1" }],
+			organization: { membershipsWhereOrganization: [] },
+		});
+		ctx.drizzleClient.transaction =
+			fakeTransaction as unknown as typeof ctx.drizzleClient.transaction;
+		await expect(
+			deletePostResolver(null, validArgs, ctx),
+		).rejects.toHaveProperty("extensions.code", "unexpected");
+	});
+
+	it("should successfully delete a post for an admin user", async () => {
+		const deletedPost: DeletedPost = { id: "post1", content: "some content" };
+		const attachments = [{ name: "file1" }, { name: "file2" }];
+		// Define a fake transaction that returns the deleted post.
+		const fakeTransaction = vi.fn(
+			async (fn: (tx: FakeTx) => Promise<unknown>): Promise<unknown> => {
+				const fakeTx: FakeTx = {
+					delete: vi.fn().mockReturnValue({
+						where: vi.fn().mockReturnValue({
+							returning: vi.fn().mockResolvedValue([deletedPost]),
+						}),
+					}),
+				};
+				return await fn(fakeTx);
+			},
+		);
+		ctx.drizzleClient.query.usersTable.findFirst = vi
+			.fn()
+			.mockResolvedValue({ role: "administrator" });
+		ctx.drizzleClient.query.postsTable.findFirst = vi.fn().mockResolvedValue({
+			creatorId: "someoneElse",
+			attachmentsWherePost: attachments,
+			organization: { membershipsWhereOrganization: [] },
+		});
+		ctx.drizzleClient.transaction =
+			fakeTransaction as unknown as typeof ctx.drizzleClient.transaction;
+		const removeObjectsSpy = vi.fn().mockResolvedValue(undefined);
+		ctx.minio.client.removeObjects = removeObjectsSpy;
+		const result = await deletePostResolver(null, validArgs, ctx);
+		expect(result).toEqual(Object.assign(deletedPost, { attachments }));
+		expect(removeObjectsSpy).toHaveBeenCalledWith(
+			"test-bucket",
+			attachments.map((att) => att.name),
+		);
+	});
+
+	it("should throw an unexpected error if no deleted post is returned", async () => {
+		const fakeTransaction = vi.fn(
+			async (fn: (tx: FakeTx) => Promise<unknown>) => {
+				const fakeTx = {
+					delete: vi.fn().mockReturnValue({
+						where: vi.fn().mockReturnValue({
+							returning: vi.fn().mockResolvedValue([]),
+						}),
+					}),
+				};
+				return await fn(fakeTx);
+			},
+		);
+		// Ensure that the query mocks return valid values.
+		ctx.drizzleClient.query.usersTable.findFirst = vi
+			.fn()
+			.mockResolvedValue({ role: "administrator" });
+		ctx.drizzleClient.query.postsTable.findFirst = vi.fn().mockResolvedValue({
+			creatorId: "user1",
+			attachmentsWherePost: [{ name: "file1" }],
+			organization: { membershipsWhereOrganization: [] },
+		});
+		ctx.drizzleClient.transaction =
+			fakeTransaction as unknown as typeof ctx.drizzleClient.transaction;
+
+		await expect(
+			deletePostResolver(null, validArgs, ctx),
+		).rejects.toHaveProperty("extensions.code", "unexpected");
+	});
+
+	it("should successfully delete a post for a non-admin user with organization admin membership", async () => {
+		const deletedPost: DeletedPost = { id: "post1", content: "some content" };
+		const attachments = [{ name: "file1" }];
+		const fakeTransaction = vi.fn(
+			async (fn: (tx: FakeTx) => Promise<unknown>): Promise<unknown> => {
+				const fakeTx: FakeTx = {
+					delete: vi.fn().mockReturnValue({
+						where: vi.fn().mockReturnValue({
+							returning: vi.fn().mockResolvedValue([deletedPost]),
+						}),
+					}),
+				};
+				return await fn(fakeTx);
+			},
+		);
+		// Non-admin user scenario.
+		ctx.drizzleClient.query.usersTable.findFirst = vi
+			.fn()
+			.mockResolvedValue({ role: "user" });
+		ctx.drizzleClient.query.postsTable.findFirst = vi.fn().mockResolvedValue({
+			creatorId: "otherUser",
+			attachmentsWherePost: attachments,
+			organization: {
+				membershipsWhereOrganization: [{ role: "administrator" }],
+			},
+		});
+		ctx.drizzleClient.transaction =
+			fakeTransaction as unknown as typeof ctx.drizzleClient.transaction;
+		const removeObjectsSpy = vi.fn().mockResolvedValue(undefined);
+		ctx.minio.client.removeObjects = removeObjectsSpy;
+		const result = await deletePostResolver(null, validArgs, ctx);
+		expect(result).toEqual(Object.assign(deletedPost, { attachments }));
+		expect(removeObjectsSpy).toHaveBeenCalledWith(
+			"test-bucket",
+			attachments.map((att) => att.name),
+		);
+	});
+	it("should delete the post, remove objects, and return the deleted post if user is admin", async () => {
+		// This test covers the transaction block (around line 54) and removeObjects call (around line 66).
+		ctx.drizzleClient.query.usersTable.findFirst = vi.fn().mockResolvedValue({
+			role: "administrator",
+		});
+		ctx.drizzleClient.query.postsTable.findFirst = vi.fn().mockResolvedValue({
+			creatorId: "user999",
+			attachmentsWherePost: [{ name: "attachment1" }, { name: "attachment2" }],
+			organization: { membershipsWhereOrganization: [] },
+		});
+
+		ctx.drizzleClient.transaction = vi.fn(async (cb) => {
+			return cb({
+				delete: () => ({
+					where: () => ({
+						returning: async () => [
+							{ id: testPostId, content: "Deleted content" },
+						],
+					}),
+				}),
+			});
+		});
+
+		const result = await deletePostResolver(null, validArgs, ctx);
+
+		expect(ctx.drizzleClient.transaction).toHaveBeenCalled();
+		expect(ctx.minio.client.removeObjects).toHaveBeenCalledWith(
+			ctx.minio.bucketName,
+			["attachment1", "attachment2"],
+		);
+		expect(result.id).toBe(testPostId);
+		expect(result.attachments).toHaveLength(2);
+	});
+});

--- a/test/routes/graphql/Mutation/deletePost.test.ts
+++ b/test/routes/graphql/Mutation/deletePost.test.ts
@@ -55,7 +55,6 @@ const createMockContext = (
 const testPostId = "123e4567-e89b-12d3-a456-426614174000";
 const validArgs = { input: { id: testPostId } };
 
-// Since the input must include an id, we “force” invalid args via a cast.
 const invalidArgs = { input: {} } as unknown as z.infer<
 	typeof mutationDeletePostArgumentsSchema
 >;
@@ -229,7 +228,7 @@ describe("deletePostResolver", () => {
 		);
 	});
 
-	it("should handle concurrent delete attempts gracefully", async () => {
+	it("should succeed on first delete and fail with 'unexpected' error on subsequent attempts due to race condition", async () => {
 		ctx.drizzleClient.query.usersTable.findFirst = vi
 			.fn()
 			.mockResolvedValue({ role: "administrator" });

--- a/test/routes/graphql/Mutation/deletePost.test.ts
+++ b/test/routes/graphql/Mutation/deletePost.test.ts
@@ -231,7 +231,6 @@ describe("deletePostResolver", () => {
 	});
 
 	it("should handle concurrent delete attempts gracefully", async () => {
-		// Setup post and user
 		ctx.drizzleClient.query.usersTable.findFirst = vi
 			.fn()
 			.mockResolvedValue({ role: "administrator" });
@@ -241,7 +240,6 @@ describe("deletePostResolver", () => {
 			organization: { membershipsWhereOrganization: [] },
 		});
 
-		// Simulate a race condition where the post is deleted between check and delete
 		let firstCheck = true;
 		ctx.drizzleClient.transaction = vi.fn(async (fn) => {
 			if (firstCheck) {
@@ -251,7 +249,6 @@ describe("deletePostResolver", () => {
 			throw new Error("Post already deleted");
 		}) as unknown as typeof ctx.drizzleClient.transaction;
 
-		// First delete should succeed
 		await expect(
 			deletePostResolver(null, validArgs, ctx),
 		).resolves.toBeDefined();


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
This PR include the test case for `src/graphql/types/Mutation/deletePost.ts`
and a updated resolver logic for `deletePost.ts`

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:** #3012 

Fixes #<!--Add related issue number here.-->

**Snapshots/Videos:** N/A

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined post deletion functionality by separating resolver logic, enhancing modularity while maintaining existing error handling and authentication checks.
- **Tests**
	- Introduced a comprehensive test suite for the post deletion resolver, covering scenarios such as user authentication, input validation, permission checks, and concurrent deletion handling to ensure robust functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->