### PR TITLE
Fix: Added organization membership sample data for API_ADMINISTRATOR_USER

### DIFF
--- a/sample_data/organization_memberships.json
+++ b/sample_data/organization_memberships.json
@@ -96,5 +96,33 @@
     "role": "regular",
     "createdAt": "2023-04-13T04:53:17.742Z",
     "creatorId": "0194e194-c6b3-7802-b074-362efea24dbc"
+  },
+  {
+    "organizationId": "ab1c2d3e-4f5b-6a7c-8d9e-0f1a2b3c4d5e",
+    "memberId": "0194e562-0a52-70f3-9e7b-2e789a5aebdc",
+    "role": "administrator",
+    "createdAt": "2023-04-13T04:53:17.742Z",
+    "creatorId": "0194e562-0a52-70f3-9e7b-2e789a5aebdc"
+  },
+  {
+    "organizationId": "ab1c2d3e-4f5b-6a7c-8d9e-0f1a2b3c4d5f",
+    "memberId": "0194e562-0a52-70f3-9e7b-2e789a5aebdc",
+    "role": "administrator",
+    "createdAt": "2023-04-13T04:53:17.742Z",
+    "creatorId": "0194e562-0a52-70f3-9e7b-2e789a5aebdc"
+  },
+  {
+    "organizationId": "cd3e4f5b-6a7c-8d9e-0f1a-2b3c4d5e6f7a",
+    "memberId": "0194e562-0a52-70f3-9e7b-2e789a5aebdc",
+    "role": "administrator",
+    "createdAt": "2023-04-13T04:53:17.742Z",
+    "creatorId": "0194e562-0a52-70f3-9e7b-2e789a5aebdc"
+  },
+  {
+    "organizationId": "bc2d3e4f-5a6b-7c8d-9e0f-1a2b3c4d5e6f",
+    "memberId": "0194e562-0a52-70f3-9e7b-2e789a5aebdc",
+    "role": "administrator",
+    "createdAt": "2023-04-13T04:53:17.742Z",
+    "creatorId": "0194e562-0a52-70f3-9e7b-2e789a5aebdc"
   }
 ]

--- a/src/plugins/seedInitialData.ts
+++ b/src/plugins/seedInitialData.ts
@@ -2,7 +2,6 @@ import { hash } from "@node-rs/argon2";
 import { eq } from "drizzle-orm";
 import type { FastifyPluginAsync } from "fastify";
 import fastifyPlugin from "fastify-plugin";
-import { uuidv7 } from "uuidv7";
 import type { z } from "zod";
 import {
 	communitiesTable,
@@ -85,7 +84,8 @@ const plugin: FastifyPluginAsync = async (fastify) => {
 			"Administrator user does not exist in the database. Creating the administrator.",
 		);
 
-		const userId = uuidv7();
+		// Administrator is assigned fixed UUIDv7 id to load the sample data with this id.
+		const userId = "0194e562-0a52-70f3-9e7b-2e789a5aebdc";
 		const input: z.infer<typeof usersTableInsertSchema> = {
 			addressLine1: null,
 			addressLine2: null,


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR will add the `organization_memberships` records for `API_ADMINISTRATOR_USER_EMAIL_ADDRESS` user.

**Issue Number:**
Fixes #3178

**Snapshots/Videos:**
<img width="1470" alt="Screenshot 2025-02-09 at 09 19 57" src="https://github.com/user-attachments/assets/9aef546d-24ce-4590-a567-753b9da14571" />

**If relevant, did you update the documentation?**
N/A

**Summary**
A fixed user_Id is assigned to `API_ADMINISTRATOR_USER_EMAIL_ADDRESS` user in `seedInitialData.ts`, using this id we added some more records in `organization_memberships` table. This fix and and show the organizations on login with `API_ADMINISTRATOR_USER_EMAIL_ADDRESS` after loading sample data.

**Does this PR introduce a breaking change?**
No

## Checklist

### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [x] I have implemented or provided justification for each non-critical suggestion
- [x] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass


**Other information**
N/A

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features  
  - Added new administrative memberships across multiple organizations, enhancing role assignments and oversight.

- Chores  
  - Refined the administrator account setup by using a consistent identifier, ensuring reliable initialization and improved data integrity.

These updates streamline administrative functions and promote greater system consistency and reliability for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->