### PR TITLE
feat:test to FundCampaign/updatedAt.ts

### DIFF
--- a/src/graphql/types/FundCampaign/updatedAt.ts
+++ b/src/graphql/types/FundCampaign/updatedAt.ts
@@ -2,6 +2,20 @@ import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 import type { GraphQLContext } from "../../context";
 import { FundCampaign } from "./FundCampaign";
 
+/**
+ * Resolver for the updatedAt field of FundCampaign type.
+ * Validates user authentication and authorization before returning the last update timestamp.
+ * Only administrators and organization admins have access to this field.
+ *
+ * @param parent - The parent FundCampaign object containing the updatedAt field
+ * @param args - GraphQL arguments (unused)
+ * @param ctx - GraphQL context containing authentication and database clients
+ * @returns {Promise<Date>} The timestamp when the fund campaign was last updated
+ * @throws {TalawaGraphQLError} With code 'unauthenticated' if user is not logged in
+ * @throws {TalawaGraphQLError} With code 'unauthorized_action' if user lacks required permissions
+ * @throws {TalawaGraphQLError} With code 'unexpected' for database or other runtime errors
+ */
+
 export const updatedAtResolver = async (
 	parent: FundCampaign,
 	args: unknown,

--- a/src/graphql/types/FundCampaign/updatedAt.ts
+++ b/src/graphql/types/FundCampaign/updatedAt.ts
@@ -83,14 +83,12 @@ export const updatedAtResolver = async (
 			});
 		}
 
-		const currentUserOrganizationMembership =
-			existingFund.organization.membershipsWhereOrganization[0];
+		const hasAdminRole =
+			existingFund.organization.membershipsWhereOrganization.some(
+				(membership) => membership.role === "administrator",
+			);
 
-		if (
-			currentUser.role !== "administrator" &&
-			(currentUserOrganizationMembership === undefined ||
-				currentUserOrganizationMembership.role !== "administrator")
-		) {
+		if (currentUser.role !== "administrator" && !hasAdminRole) {
 			throw new TalawaGraphQLError({
 				extensions: {
 					code: "unauthorized_action",

--- a/src/graphql/types/FundCampaign/updatedAt.ts
+++ b/src/graphql/types/FundCampaign/updatedAt.ts
@@ -1,93 +1,109 @@
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
+import type { GraphQLContext } from "../../context";
 import { FundCampaign } from "./FundCampaign";
+
+export const updatedAtResolver = async (
+	parent: FundCampaign,
+	args: unknown,
+	ctx: GraphQLContext,
+) => {
+	try {
+		if (!ctx.currentClient.isAuthenticated) {
+			throw new TalawaGraphQLError({
+				extensions: {
+					code: "unauthenticated",
+				},
+			});
+		}
+
+		const currentUserId = ctx.currentClient.user.id;
+
+		const [currentUser, existingFund] = await Promise.all([
+			ctx.drizzleClient.query.usersTable.findFirst({
+				columns: {
+					role: true,
+				},
+				where: (fields, operators) => operators.eq(fields.id, currentUserId),
+			}),
+			ctx.drizzleClient.query.fundsTable.findFirst({
+				columns: {
+					isTaxDeductible: true,
+				},
+				with: {
+					organization: {
+						columns: {
+							countryCode: true,
+						},
+						with: {
+							membershipsWhereOrganization: {
+								columns: {
+									role: true,
+								},
+								where: (fields, operators) =>
+									operators.eq(fields.memberId, currentUserId),
+							},
+						},
+					},
+				},
+				where: (fields, operators) => operators.eq(fields.id, currentUserId),
+			}),
+		]);
+
+		if (currentUser === undefined) {
+			throw new TalawaGraphQLError({
+				extensions: {
+					code: "unauthenticated",
+				},
+			});
+		}
+
+		if (existingFund === undefined) {
+			ctx.log.error(
+				"Postgres select operation returned an empty array for a fund campaign's fund id that isn't null.",
+			);
+
+			throw new TalawaGraphQLError({
+				extensions: {
+					code: "unexpected",
+				},
+			});
+		}
+
+		const currentUserOrganizationMembership =
+			existingFund.organization.membershipsWhereOrganization[0];
+
+		if (
+			currentUser.role !== "administrator" &&
+			(currentUserOrganizationMembership === undefined ||
+				currentUserOrganizationMembership.role !== "administrator")
+		) {
+			throw new TalawaGraphQLError({
+				extensions: {
+					code: "unauthorized_action",
+				},
+			});
+		}
+
+		return parent.updatedAt;
+	} catch (error) {
+		if (error instanceof TalawaGraphQLError) {
+			throw error;
+		}
+
+		ctx.log.error("Error in updatedAtResolver:", error);
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "unexpected",
+			},
+		});
+	}
+};
 
 FundCampaign.implement({
 	fields: (t) => ({
 		updatedAt: t.field({
 			description: "Date time at the time the fund campaign was last updated.",
-			resolve: async (parent, _args, ctx) => {
-				if (!ctx.currentClient.isAuthenticated) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthenticated",
-						},
-					});
-				}
-
-				const currentUserId = ctx.currentClient.user.id;
-
-				const [currentUser, existingFund] = await Promise.all([
-					ctx.drizzleClient.query.usersTable.findFirst({
-						columns: {
-							role: true,
-						},
-
-						where: (fields, operators) =>
-							operators.eq(fields.id, currentUserId),
-					}),
-					ctx.drizzleClient.query.fundsTable.findFirst({
-						columns: {
-							isTaxDeductible: true,
-						},
-						with: {
-							organization: {
-								columns: {
-									countryCode: true,
-								},
-								with: {
-									membershipsWhereOrganization: {
-										columns: {
-											role: true,
-										},
-										where: (fields, operators) =>
-											operators.eq(fields.memberId, currentUserId),
-									},
-								},
-							},
-						},
-						where: (fields, operators) =>
-							operators.eq(fields.id, currentUserId),
-					}),
-				]);
-
-				if (currentUser === undefined) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthenticated",
-						},
-					});
-				}
-
-				// Fund id existing but the associated fund not existing is a business logic error and probably means that the corresponding data in the database is in a corrupted state. It must be investigated and fixed as soon as possible to prevent additional data corruption.
-				if (existingFund === undefined) {
-					ctx.log.error(
-						"Postgres select operation returned an empty array for a fund campaign's fund id that isn't null.",
-					);
-
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unexpected",
-						},
-					});
-				}
-
-				const currentUserOrganizationMembership =
-					existingFund.organization.membershipsWhereOrganization[0];
-
-				if (
-					currentUser.role !== "administrator" &&
-					(currentUserOrganizationMembership === undefined ||
-						currentUserOrganizationMembership.role !== "administrator")
-				) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthorized_action",
-						},
-					});
-				}
-
-				return parent.updatedAt;
-			},
+			resolve: updatedAtResolver,
 			type: "DateTime",
 		}),
 	}),

--- a/test/graphql/types/FundCampaign/updatedAt.test.ts
+++ b/test/graphql/types/FundCampaign/updatedAt.test.ts
@@ -1,0 +1,233 @@
+import { vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { CurrentClient, GraphQLContext } from "~/src/graphql/context";
+import type { FundCampaign } from "~/src/graphql/types/FundCampaign/FundCampaign";
+import { updatedAtResolver } from "~/src/graphql/types/FundCampaign/updatedAt";
+import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
+
+const mockFundCampaign: FundCampaign = {
+	id: "fund-123",
+	createdAt: new Date("2024-02-01T09:00:00Z"),
+	name: "Test Campaign",
+	creatorId: "creator-123",
+	updatedAt: new Date("2024-02-01T10:00:00Z"),
+	updaterId: "updater-123",
+	currencyCode: "USD",
+	endAt: new Date("2024-12-31T23:59:59Z"),
+	fundId: "fund-456",
+	goalAmount: 10000,
+	startAt: new Date("2024-02-01T00:00:00Z"),
+};
+
+const createMockContext = () => {
+	const mockContext = {
+		currentClient: {
+			isAuthenticated: true,
+			user: { id: "user-123" },
+		} as CurrentClient,
+		drizzleClient: {
+			query: {
+				usersTable: { findFirst: vi.fn() },
+				fundsTable: { findFirst: vi.fn() },
+			},
+		},
+		log: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+		envConfig: { API_BASE_URL: "mock url" },
+		jwt: { sign: vi.fn() },
+		minio: { presignedUrl: vi.fn(), putObject: vi.fn(), getObject: vi.fn() },
+	};
+	return mockContext as unknown as GraphQLContext;
+};
+
+describe("updatedAtResolver", () => {
+	let ctx: GraphQLContext;
+
+	beforeEach(() => {
+		ctx = createMockContext();
+	});
+
+	it("should throw unauthenticated error if user is not logged in", async () => {
+		ctx.currentClient.isAuthenticated = false;
+		await expect(updatedAtResolver(mockFundCampaign, {}, ctx)).rejects.toThrow(
+			new TalawaGraphQLError({ extensions: { code: "unauthenticated" } }),
+		);
+	});
+
+	it("should throw unauthenticated error if current user does not exist", async () => {
+		(
+			ctx.drizzleClient.query.usersTable.findFirst as ReturnType<typeof vi.fn>
+		).mockResolvedValue(undefined);
+		await expect(updatedAtResolver(mockFundCampaign, {}, ctx)).rejects.toThrow(
+			new TalawaGraphQLError({ extensions: { code: "unauthenticated" } }),
+		);
+	});
+
+	it("should throw unexpected error if fund does not exist", async () => {
+		(
+			ctx.drizzleClient.query.usersTable.findFirst as ReturnType<typeof vi.fn>
+		).mockResolvedValue({ role: "member" });
+		(
+			ctx.drizzleClient.query.fundsTable.findFirst as ReturnType<typeof vi.fn>
+		).mockResolvedValue(undefined);
+		await expect(updatedAtResolver(mockFundCampaign, {}, ctx)).rejects.toThrow(
+			new TalawaGraphQLError({ extensions: { code: "unexpected" } }),
+		);
+		expect(ctx.log.error).toHaveBeenCalled();
+	});
+
+	it("should throw unauthorized_action error if user is not an admin and not an organization admin", async () => {
+		const mockUser = { role: "member" };
+		const mockFund = {
+			isTaxDeductible: true,
+			organization: {
+				countryCode: "US",
+				membershipsWhereOrganization: [],
+			},
+		};
+		(
+			ctx.drizzleClient.query.usersTable.findFirst as ReturnType<typeof vi.fn>
+		).mockResolvedValue(mockUser);
+		(
+			ctx.drizzleClient.query.fundsTable.findFirst as ReturnType<typeof vi.fn>
+		).mockResolvedValue(mockFund);
+		await expect(updatedAtResolver(mockFundCampaign, {}, ctx)).rejects.toThrow(
+			new TalawaGraphQLError({ extensions: { code: "unauthorized_action" } }),
+		);
+	});
+
+	it("should return updatedAt if user is an admin", async () => {
+		const mockUser = { role: "administrator" };
+		const mockFund = {
+			isTaxDeductible: true,
+			organization: {
+				countryCode: "US",
+				membershipsWhereOrganization: [],
+			},
+		};
+		(
+			ctx.drizzleClient.query.usersTable.findFirst as ReturnType<typeof vi.fn>
+		).mockResolvedValue(mockUser);
+		(
+			ctx.drizzleClient.query.fundsTable.findFirst as ReturnType<typeof vi.fn>
+		).mockResolvedValue(mockFund);
+		const result = await updatedAtResolver(mockFundCampaign, {}, ctx);
+		expect(result).toEqual(mockFundCampaign.updatedAt);
+	});
+
+	it("should return updatedAt if user is an organization admin", async () => {
+		const mockUser = { role: "member" };
+		const mockFund = {
+			isTaxDeductible: true,
+			organization: {
+				countryCode: "US",
+				membershipsWhereOrganization: [{ role: "administrator" }],
+			},
+		};
+		(
+			ctx.drizzleClient.query.usersTable.findFirst as ReturnType<typeof vi.fn>
+		).mockResolvedValue(mockUser);
+		(
+			ctx.drizzleClient.query.fundsTable.findFirst as ReturnType<typeof vi.fn>
+		).mockResolvedValue(mockFund);
+		const result = await updatedAtResolver(mockFundCampaign, {}, ctx);
+		expect(result).toEqual(mockFundCampaign.updatedAt);
+	});
+
+	it("should handle database connection error", async () => {
+		(
+			ctx.drizzleClient.query.usersTable.findFirst as ReturnType<typeof vi.fn>
+		).mockRejectedValue(new Error("ECONNREFUSED"));
+		await expect(updatedAtResolver(mockFundCampaign, {}, ctx)).rejects.toThrow(
+			new TalawaGraphQLError({ extensions: { code: "unexpected" } }),
+		);
+		expect(ctx.log.error).toHaveBeenCalled();
+	});
+
+	it("should handle database timeout error", async () => {
+		(
+			ctx.drizzleClient.query.usersTable.findFirst as ReturnType<typeof vi.fn>
+		).mockRejectedValue(new Error("Query timeout"));
+		await expect(updatedAtResolver(mockFundCampaign, {}, ctx)).rejects.toThrow(
+			new TalawaGraphQLError({ extensions: { code: "unexpected" } }),
+		);
+		expect(ctx.log.error).toHaveBeenCalled();
+	});
+
+	it("should handle database constraint violation", async () => {
+		(
+			ctx.drizzleClient.query.usersTable.findFirst as ReturnType<typeof vi.fn>
+		).mockRejectedValue(new Error("violates foreign key constraint"));
+		await expect(updatedAtResolver(mockFundCampaign, {}, ctx)).rejects.toThrow(
+			new TalawaGraphQLError({ extensions: { code: "unexpected" } }),
+		);
+		expect(ctx.log.error).toHaveBeenCalled();
+	});
+
+	it("should handle database query syntax error", async () => {
+		(
+			ctx.drizzleClient.query.usersTable.findFirst as ReturnType<typeof vi.fn>
+		).mockRejectedValue(new Error("syntax error in SQL statement"));
+		await expect(updatedAtResolver(mockFundCampaign, {}, ctx)).rejects.toThrow(
+			new TalawaGraphQLError({ extensions: { code: "unexpected" } }),
+		);
+		expect(ctx.log.error).toHaveBeenCalled();
+	});
+
+	it("should handle concurrent updates to the same fund", async () => {
+		(
+			ctx.drizzleClient.query.usersTable.findFirst as ReturnType<typeof vi.fn>
+		).mockRejectedValueOnce(new Error("Database lock timeout"));
+
+		await expect(updatedAtResolver(mockFundCampaign, {}, ctx)).rejects.toThrow(
+			new TalawaGraphQLError({ extensions: { code: "unexpected" } }),
+		);
+		expect(ctx.log.error).toHaveBeenCalled();
+	});
+
+	it("should handle database error during concurrent access", async () => {
+		(
+			ctx.drizzleClient.query.usersTable.findFirst as ReturnType<typeof vi.fn>
+		).mockRejectedValueOnce(
+			new Error("Database error during concurrent access"),
+		);
+
+		await expect(updatedAtResolver(mockFundCampaign, {}, ctx)).rejects.toThrow(
+			new TalawaGraphQLError({ extensions: { code: "unexpected" } }),
+		);
+		expect(ctx.log.error).toHaveBeenCalled();
+	});
+
+	it("should pass through TalawaGraphQLError without wrapping", async () => {
+		const originalError = new TalawaGraphQLError({
+			message: "Custom error",
+			extensions: { code: "unexpected" },
+		});
+		(
+			ctx.drizzleClient.query.usersTable.findFirst as ReturnType<typeof vi.fn>
+		).mockRejectedValue(originalError);
+		await expect(updatedAtResolver(mockFundCampaign, {}, ctx)).rejects.toThrow(
+			originalError,
+		);
+		expect(ctx.log.error).not.toHaveBeenCalled();
+	});
+
+	it("should handle missing organization membership gracefully", async () => {
+		const mockUser = { role: "member" };
+		const mockFund = {
+			isTaxDeductible: true,
+			organization: {
+				countryCode: "US",
+				membershipsWhereOrganization: [],
+			},
+		};
+		(
+			ctx.drizzleClient.query.usersTable.findFirst as ReturnType<typeof vi.fn>
+		).mockResolvedValue(mockUser);
+		(
+			ctx.drizzleClient.query.fundsTable.findFirst as ReturnType<typeof vi.fn>
+		).mockResolvedValue(mockFund);
+		await expect(updatedAtResolver(mockFundCampaign, {}, ctx)).rejects.toThrow(
+			new TalawaGraphQLError({ extensions: { code: "unauthorized_action" } }),
+		);
+	});
+});


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Tests for src/graphql/types/FundCampaign/updatedAt.ts
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number: 2922**

Fixes : #3063 

**Snapshots/Videos:**
![Screenshot 2025-02-13 211738](https://github.com/user-attachments/assets/cff5d813-1d77-467c-be7e-3473c4fe0654)




<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**
Added test for updateAt.ts
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the management of the `updatedAt` field for Fund Campaigns, improving error handling and ensuring that only authorized users can access this information.

- **Tests**
  - Introduced a comprehensive suite of unit tests for the `updatedAtResolver`, validating authentication, authorization, and various error handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->