### PR TITLE
enforcing pagination limits for USER_LIST and ORGANIZATION_CONNECTION_LIST query

### DIFF
--- a/src/graphql/types/Organization/organizationResolvers.ts
+++ b/src/graphql/types/Organization/organizationResolvers.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+import { builder } from "~/src/graphql/builder";
+import { Organization } from "~/src/graphql/types/Organization/Organization";
+import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
+
+const organizationConnectionListArgumentsSchema = z.object({
+	first: z.number().min(1).max(100).default(10),
+	skip: z.number().min(0).default(0),
+});
+
+builder.queryField("organizationConnectionList", (t) =>
+	t.field({
+		args: {
+			first: t.arg({ type: "Int", required: false }),
+			skip: t.arg({ type: "Int", required: false }),
+		},
+		type: [Organization],
+		resolve: async (_parent, args, ctx) => {
+			const {
+				data: parsedArgs,
+				error,
+				success,
+			} = organizationConnectionListArgumentsSchema.safeParse(args);
+
+			if (!success) {
+				throw new TalawaGraphQLError({
+					extensions: {
+						code: "invalid_arguments",
+						issues: error.issues.map((issue) => ({
+							argumentPath: issue.path,
+							message: issue.message,
+						})),
+					},
+				});
+			}
+
+			const { first, skip } = parsedArgs;
+
+			// Fetch organizations with pagination
+			const organizations =
+				await ctx.drizzleClient.query.organizationsTable.findMany({
+					limit: first,
+					offset: skip,
+				});
+
+			return organizations;
+		},
+	}),
+);

--- a/src/graphql/types/User/userResolvers.ts
+++ b/src/graphql/types/User/userResolvers.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import { builder } from "~/src/graphql/builder";
+import { User } from "~/src/graphql/types/User/User";
+import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
+
+const userListArgumentsSchema = z.object({
+	first: z.number().min(1).max(100).default(10),
+	skip: z.number().min(0).default(0),
+});
+
+builder.queryField("userList", (t) =>
+	t.field({
+		args: {
+			first: t.arg({ type: "Int", required: false }),
+			skip: t.arg({ type: "Int", required: false }),
+		},
+		type: [User],
+		resolve: async (_parent, args, ctx) => {
+			const {
+				data: parsedArgs,
+				error,
+				success,
+			} = userListArgumentsSchema.safeParse(args);
+
+			if (!success) {
+				throw new TalawaGraphQLError({
+					extensions: {
+						code: "invalid_arguments",
+						issues: error.issues.map((issue) => ({
+							argumentPath: issue.path,
+							message: issue.message,
+						})),
+					},
+				});
+			}
+
+			const { first, skip } = parsedArgs;
+
+			// Fetch users with pagination
+			const users = await ctx.drizzleClient.query.usersTable.findMany({
+				limit: first,
+				offset: skip,
+			});
+
+			return users;
+		},
+	}),
+);

--- a/test/graphql/types/organizationResolvers.test.ts
+++ b/test/graphql/types/organizationResolvers.test.ts
@@ -41,7 +41,7 @@ describe("organizationConnectionList Query", () => {
 		mockContext.drizzleClient.query.organizationsTable.findMany.mockResolvedValue(
 			sampleOrganizations,
 		);
-		
+
 		const query = `
 			query {
 				organizationConnectionList {
@@ -62,8 +62,8 @@ describe("organizationConnectionList Query", () => {
 		expect(
 			mockContext.drizzleClient.query.organizationsTable.findMany,
 		).toHaveBeenCalledWith({
-			limit: 10,  // default value
-			offset: 0,  // default value
+			limit: 10, // default value
+			offset: 0, // default value
 		});
 	});
 
@@ -72,7 +72,7 @@ describe("organizationConnectionList Query", () => {
 		mockContext.drizzleClient.query.organizationsTable.findMany.mockResolvedValue(
 			sampleOrganizations,
 		);
-		
+
 		const query = `
 			query($first: Int, $skip: Int) {
 				organizationConnectionList(first: $first, skip: $skip) {

--- a/test/graphql/types/organizationResolvers.test.ts
+++ b/test/graphql/types/organizationResolvers.test.ts
@@ -1,8 +1,8 @@
-import { execute, parse } from 'graphql';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { schema } from '~/src/graphql/schema';
+import { execute, parse } from "graphql";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { schema } from "~/src/graphql/schema";
 
-describe('organizationConnectionList Query', () => {
+describe("organizationConnectionList Query", () => {
 	// Mock context
 	const mockContext = {
 		drizzleClient: {
@@ -16,9 +16,9 @@ describe('organizationConnectionList Query', () => {
 
 	// Sample organization data
 	const sampleOrganizations = [
-		{ id: 1, name: 'Org 1' },
-		{ id: 2, name: 'Org 2' },
-		{ id: 3, name: 'Org 3' },
+		{ id: 1, name: "Org 1" },
+		{ id: 2, name: "Org 2" },
+		{ id: 3, name: "Org 3" },
 	];
 
 	beforeEach(() => {
@@ -36,11 +36,11 @@ describe('organizationConnectionList Query', () => {
 		});
 	};
 
-	it('should return organizations with default pagination values', async () => {
+	it("should return organizations with default pagination values", async () => {
 		// Arrange
 		mockContext.drizzleClient.query.organizationsTable.findMany.mockResolvedValue(
-      sampleOrganizations,
-    );
+			sampleOrganizations,
+		);
 		
 		const query = `
 			query {
@@ -57,21 +57,21 @@ describe('organizationConnectionList Query', () => {
 		// Assert
 		expect(result.errors).toBeUndefined();
 		expect(result.data?.organizationConnectionList).toEqual(
-      sampleOrganizations,
-    );
+			sampleOrganizations,
+		);
 		expect(
-      mockContext.drizzleClient.query.organizationsTable.findMany,
-    ).toHaveBeenCalledWith({
+			mockContext.drizzleClient.query.organizationsTable.findMany,
+		).toHaveBeenCalledWith({
 			limit: 10,  // default value
 			offset: 0,  // default value
 		});
 	});
 
-	it('should return organizations with custom pagination values', async () => {
+	it("should return organizations with custom pagination values", async () => {
 		// Arrange
 		mockContext.drizzleClient.query.organizationsTable.findMany.mockResolvedValue(
-      sampleOrganizations,
-    );
+			sampleOrganizations,
+		);
 		
 		const query = `
 			query($first: Int, $skip: Int) {
@@ -88,17 +88,17 @@ describe('organizationConnectionList Query', () => {
 		// Assert
 		expect(result.errors).toBeUndefined();
 		expect(result.data?.organizationConnectionList).toEqual(
-      sampleOrganizations,
-    );
+			sampleOrganizations,
+		);
 		expect(
-      mockContext.drizzleClient.query.organizationsTable.findMany,
-    ).toHaveBeenCalledWith({
+			mockContext.drizzleClient.query.organizationsTable.findMany,
+		).toHaveBeenCalledWith({
 			limit: 5,
 			offset: 10,
 		});
 	});
 
-	it('should throw error when first argument is less than 1', async () => {
+	it("should throw error when first argument is less than 1", async () => {
 		// Arrange
 		const query = `
 			query {
@@ -116,13 +116,15 @@ describe('organizationConnectionList Query', () => {
 		expect(result.errors).toBeDefined();
 		expect(result.errors?.[0]).toMatchObject({
 			extensions: {
-				code: 'invalid_arguments',
+				code: "invalid_arguments",
 			},
 		});
-		expect(mockContext.drizzleClient.query.organizationsTable.findMany).not.toHaveBeenCalled();
+		expect(
+			mockContext.drizzleClient.query.organizationsTable.findMany,
+		).not.toHaveBeenCalled();
 	});
 
-	it('should throw error when first argument is greater than 100', async () => {
+	it("should throw error when first argument is greater than 100", async () => {
 		// Arrange
 		const query = `
 			query {
@@ -140,13 +142,15 @@ describe('organizationConnectionList Query', () => {
 		expect(result.errors).toBeDefined();
 		expect(result.errors?.[0]).toMatchObject({
 			extensions: {
-				code: 'invalid_arguments',
+				code: "invalid_arguments",
 			},
 		});
-		expect(mockContext.drizzleClient.query.organizationsTable.findMany).not.toHaveBeenCalled();
+		expect(
+			mockContext.drizzleClient.query.organizationsTable.findMany,
+		).not.toHaveBeenCalled();
 	});
 
-	it('should throw error when skip argument is negative', async () => {
+	it("should throw error when skip argument is negative", async () => {
 		// Arrange
 		const query = `
 			query {
@@ -164,16 +168,20 @@ describe('organizationConnectionList Query', () => {
 		expect(result.errors).toBeDefined();
 		expect(result.errors?.[0]).toMatchObject({
 			extensions: {
-				code: 'invalid_arguments',
+				code: "invalid_arguments",
 			},
 		});
-		expect(mockContext.drizzleClient.query.organizationsTable.findMany).not.toHaveBeenCalled();
+		expect(
+			mockContext.drizzleClient.query.organizationsTable.findMany,
+		).not.toHaveBeenCalled();
 	});
 
-	it('should handle database errors gracefully', async () => {
+	it("should handle database errors gracefully", async () => {
 		// Arrange
-		const dbError = new Error('Database connection failed');
-		mockContext.drizzleClient.query.organizationsTable.findMany.mockRejectedValue(dbError);
+		const dbError = new Error("Database connection failed");
+		mockContext.drizzleClient.query.organizationsTable.findMany.mockRejectedValue(
+			dbError,
+		);
 
 		const query = `
 			query {
@@ -189,10 +197,10 @@ describe('organizationConnectionList Query', () => {
 
 		// Assert
 		expect(result.errors).toBeDefined();
-		expect(result.errors?.[0].message).toBe('Database connection failed');
+		expect(result.errors?.[0]?.message).toBe("Database connection failed");
 	});
 
-	it('should verify error object structure when validation fails', async () => {
+	it("should verify error object structure when validation fails", async () => {
 		// Arrange
 		const query = `
 			query {
@@ -210,7 +218,7 @@ describe('organizationConnectionList Query', () => {
 		expect(result.errors).toBeDefined();
 		expect(result.errors?.[0]).toMatchObject({
 			extensions: {
-				code: 'invalid_arguments',
+				code: "invalid_arguments",
 				issues: expect.arrayContaining([
 					expect.objectContaining({
 						argumentPath: expect.any(Array),

--- a/test/graphql/types/organizationResolvers.test.ts
+++ b/test/graphql/types/organizationResolvers.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { execute, parse } from 'graphql';
+import { schema } from '~/src/graphql/schema';  // You'll need to export your schema
+
+describe('organizationConnectionList Query', () => {
+  // Mock context
+  const mockContext = {
+    drizzleClient: {
+      query: {
+        organizationsTable: {
+          findMany: vi.fn(),
+        },
+      },
+    },
+  };
+
+  // Sample organization data
+  const sampleOrganizations = [
+    { id: 1, name: 'Org 1' },
+    { id: 2, name: 'Org 2' },
+    { id: 3, name: 'Org 3' },
+  ];
+
+  beforeEach(() => {
+    // Reset all mocks before each test
+    vi.clearAllMocks();
+    mockContext.drizzleClient.query.organizationsTable.findMany.mockReset();
+  });
+
+  const executeQuery = async (query: string, variables = {}) => {
+    return execute({
+      schema,
+      document: parse(query),
+      contextValue: mockContext,
+      variableValues: variables,
+    });
+  };
+
+  it('should return organizations with default pagination values', async () => {
+    // Arrange
+    mockContext.drizzleClient.query.organizationsTable.findMany.mockResolvedValue(sampleOrganizations);
+    
+    const query = `
+      query {
+        organizationConnectionList {
+          id
+          name
+        }
+      }
+    `;
+
+    // Act
+    const result = await executeQuery(query);
+
+    // Assert
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.organizationConnectionList).toEqual(sampleOrganizations);
+    expect(mockContext.drizzleClient.query.organizationsTable.findMany).toHaveBeenCalledWith({
+      limit: 10,  // default value
+      offset: 0,  // default value
+    });
+  });
+
+  it('should return organizations with custom pagination values', async () => {
+    // Arrange
+    mockContext.drizzleClient.query.organizationsTable.findMany.mockResolvedValue(sampleOrganizations);
+    
+    const query = `
+      query($first: Int, $skip: Int) {
+        organizationConnectionList(first: $first, skip: $skip) {
+          id
+          name
+        }
+      }
+    `;
+
+    // Act
+    const result = await executeQuery(query, { first: 5, skip: 10 });
+
+    // Assert
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.organizationConnectionList).toEqual(sampleOrganizations);
+    expect(mockContext.drizzleClient.query.organizationsTable.findMany).toHaveBeenCalledWith({
+      limit: 5,
+      offset: 10,
+    });
+  });
+
+  it('should throw error when first argument is less than 1', async () => {
+    // Arrange
+    const query = `
+      query {
+        organizationConnectionList(first: 0) {
+          id
+          name
+        }
+      }
+    `;
+
+    // Act
+    const result = await executeQuery(query);
+
+    // Assert
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.[0]).toMatchObject({
+      extensions: {
+        code: 'invalid_arguments',
+      },
+    });
+    expect(mockContext.drizzleClient.query.organizationsTable.findMany).not.toHaveBeenCalled();
+  });
+
+  it('should throw error when first argument is greater than 100', async () => {
+    // Arrange
+    const query = `
+      query {
+        organizationConnectionList(first: 101) {
+          id
+          name
+        }
+      }
+    `;
+
+    // Act
+    const result = await executeQuery(query);
+
+    // Assert
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.[0]).toMatchObject({
+      extensions: {
+        code: 'invalid_arguments',
+      },
+    });
+    expect(mockContext.drizzleClient.query.organizationsTable.findMany).not.toHaveBeenCalled();
+  });
+
+  it('should throw error when skip argument is negative', async () => {
+    // Arrange
+    const query = `
+      query {
+        organizationConnectionList(skip: -1) {
+          id
+          name
+        }
+      }
+    `;
+
+    // Act
+    const result = await executeQuery(query);
+
+    // Assert
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.[0]).toMatchObject({
+      extensions: {
+        code: 'invalid_arguments',
+      },
+    });
+    expect(mockContext.drizzleClient.query.organizationsTable.findMany).not.toHaveBeenCalled();
+  });
+
+  it('should handle database errors gracefully', async () => {
+    // Arrange
+    const dbError = new Error('Database connection failed');
+    mockContext.drizzleClient.query.organizationsTable.findMany.mockRejectedValue(dbError);
+
+    const query = `
+      query {
+        organizationConnectionList {
+          id
+          name
+        }
+      }
+    `;
+
+    // Act
+    const result = await executeQuery(query);
+
+    // Assert
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.[0]).toBe('Database connection failed');
+  });
+
+  it('should verify error object structure when validation fails', async () => {
+    // Arrange
+    const query = `
+      query {
+        organizationConnectionList(first: 0, skip: -1) {
+          id
+          name
+        }
+      }
+    `;
+
+    // Act
+    const result = await executeQuery(query);
+
+    // Assert
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.[0]).toMatchObject({
+      extensions: {
+        code: 'invalid_arguments',
+        issues: expect.arrayContaining([
+          expect.objectContaining({
+            argumentPath: expect.any(Array),
+            message: expect.any(String),
+          }),
+        ]),
+      },
+    });
+  });
+});

--- a/test/graphql/types/organizationResolvers.test.ts
+++ b/test/graphql/types/organizationResolvers.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { execute, parse } from 'graphql';
 import { schema } from '~/src/graphql/schema';  // You'll need to export your schema
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('organizationConnectionList Query', () => {
   // Mock context

--- a/test/graphql/types/organizationResolvers.test.ts
+++ b/test/graphql/types/organizationResolvers.test.ts
@@ -1,211 +1,223 @@
 import { execute, parse } from 'graphql';
-import { schema } from '~/src/graphql/schema';  // You'll need to export your schema
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { schema } from '~/src/graphql/schema';
 
 describe('organizationConnectionList Query', () => {
-  // Mock context
-  const mockContext = {
-    drizzleClient: {
-      query: {
-        organizationsTable: {
-          findMany: vi.fn(),
-        },
-      },
-    },
-  };
+	// Mock context
+	const mockContext = {
+		drizzleClient: {
+			query: {
+				organizationsTable: {
+					findMany: vi.fn(),
+				},
+			},
+		},
+	};
 
-  // Sample organization data
-  const sampleOrganizations = [
-    { id: 1, name: 'Org 1' },
-    { id: 2, name: 'Org 2' },
-    { id: 3, name: 'Org 3' },
-  ];
+	// Sample organization data
+	const sampleOrganizations = [
+		{ id: 1, name: 'Org 1' },
+		{ id: 2, name: 'Org 2' },
+		{ id: 3, name: 'Org 3' },
+	];
 
-  beforeEach(() => {
-    // Reset all mocks before each test
-    vi.clearAllMocks();
-    mockContext.drizzleClient.query.organizationsTable.findMany.mockReset();
-  });
+	beforeEach(() => {
+		// Reset all mocks before each test
+		vi.clearAllMocks();
+		mockContext.drizzleClient.query.organizationsTable.findMany.mockReset();
+	});
 
-  const executeQuery = async (query: string, variables = {}) => {
-    return execute({
-      schema,
-      document: parse(query),
-      contextValue: mockContext,
-      variableValues: variables,
-    });
-  };
+	const executeQuery = async (query: string, variables = {}) => {
+		return execute({
+			schema,
+			document: parse(query),
+			contextValue: mockContext,
+			variableValues: variables,
+		});
+	};
 
-  it('should return organizations with default pagination values', async () => {
-    // Arrange
-    mockContext.drizzleClient.query.organizationsTable.findMany.mockResolvedValue(sampleOrganizations);
-    
-    const query = `
-      query {
-        organizationConnectionList {
-          id
-          name
-        }
-      }
-    `;
+	it('should return organizations with default pagination values', async () => {
+		// Arrange
+		mockContext.drizzleClient.query.organizationsTable.findMany.mockResolvedValue(
+      sampleOrganizations,
+    );
+		
+		const query = `
+			query {
+				organizationConnectionList {
+					id
+					name
+				}
+			}
+		`;
 
-    // Act
-    const result = await executeQuery(query);
+		// Act
+		const result = await executeQuery(query);
 
-    // Assert
-    expect(result.errors).toBeUndefined();
-    expect(result.data?.organizationConnectionList).toEqual(sampleOrganizations);
-    expect(mockContext.drizzleClient.query.organizationsTable.findMany).toHaveBeenCalledWith({
-      limit: 10,  // default value
-      offset: 0,  // default value
-    });
-  });
+		// Assert
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.organizationConnectionList).toEqual(
+      sampleOrganizations,
+    );
+		expect(
+      mockContext.drizzleClient.query.organizationsTable.findMany,
+    ).toHaveBeenCalledWith({
+			limit: 10,  // default value
+			offset: 0,  // default value
+		});
+	});
 
-  it('should return organizations with custom pagination values', async () => {
-    // Arrange
-    mockContext.drizzleClient.query.organizationsTable.findMany.mockResolvedValue(sampleOrganizations);
-    
-    const query = `
-      query($first: Int, $skip: Int) {
-        organizationConnectionList(first: $first, skip: $skip) {
-          id
-          name
-        }
-      }
-    `;
+	it('should return organizations with custom pagination values', async () => {
+		// Arrange
+		mockContext.drizzleClient.query.organizationsTable.findMany.mockResolvedValue(
+      sampleOrganizations,
+    );
+		
+		const query = `
+			query($first: Int, $skip: Int) {
+				organizationConnectionList(first: $first, skip: $skip) {
+					id
+					name
+				}
+			}
+		`;
 
-    // Act
-    const result = await executeQuery(query, { first: 5, skip: 10 });
+		// Act
+		const result = await executeQuery(query, { first: 5, skip: 10 });
 
-    // Assert
-    expect(result.errors).toBeUndefined();
-    expect(result.data?.organizationConnectionList).toEqual(sampleOrganizations);
-    expect(mockContext.drizzleClient.query.organizationsTable.findMany).toHaveBeenCalledWith({
-      limit: 5,
-      offset: 10,
-    });
-  });
+		// Assert
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.organizationConnectionList).toEqual(
+      sampleOrganizations,
+    );
+		expect(
+      mockContext.drizzleClient.query.organizationsTable.findMany,
+    ).toHaveBeenCalledWith({
+			limit: 5,
+			offset: 10,
+		});
+	});
 
-  it('should throw error when first argument is less than 1', async () => {
-    // Arrange
-    const query = `
-      query {
-        organizationConnectionList(first: 0) {
-          id
-          name
-        }
-      }
-    `;
+	it('should throw error when first argument is less than 1', async () => {
+		// Arrange
+		const query = `
+			query {
+				organizationConnectionList(first: 0) {
+					id
+					name
+				}
+			}
+		`;
 
-    // Act
-    const result = await executeQuery(query);
+		// Act
+		const result = await executeQuery(query);
 
-    // Assert
-    expect(result.errors).toBeDefined();
-    expect(result.errors?.[0]).toMatchObject({
-      extensions: {
-        code: 'invalid_arguments',
-      },
-    });
-    expect(mockContext.drizzleClient.query.organizationsTable.findMany).not.toHaveBeenCalled();
-  });
+		// Assert
+		expect(result.errors).toBeDefined();
+		expect(result.errors?.[0]).toMatchObject({
+			extensions: {
+				code: 'invalid_arguments',
+			},
+		});
+		expect(mockContext.drizzleClient.query.organizationsTable.findMany).not.toHaveBeenCalled();
+	});
 
-  it('should throw error when first argument is greater than 100', async () => {
-    // Arrange
-    const query = `
-      query {
-        organizationConnectionList(first: 101) {
-          id
-          name
-        }
-      }
-    `;
+	it('should throw error when first argument is greater than 100', async () => {
+		// Arrange
+		const query = `
+			query {
+				organizationConnectionList(first: 101) {
+					id
+					name
+				}
+			}
+		`;
 
-    // Act
-    const result = await executeQuery(query);
+		// Act
+		const result = await executeQuery(query);
 
-    // Assert
-    expect(result.errors).toBeDefined();
-    expect(result.errors?.[0]).toMatchObject({
-      extensions: {
-        code: 'invalid_arguments',
-      },
-    });
-    expect(mockContext.drizzleClient.query.organizationsTable.findMany).not.toHaveBeenCalled();
-  });
+		// Assert
+		expect(result.errors).toBeDefined();
+		expect(result.errors?.[0]).toMatchObject({
+			extensions: {
+				code: 'invalid_arguments',
+			},
+		});
+		expect(mockContext.drizzleClient.query.organizationsTable.findMany).not.toHaveBeenCalled();
+	});
 
-  it('should throw error when skip argument is negative', async () => {
-    // Arrange
-    const query = `
-      query {
-        organizationConnectionList(skip: -1) {
-          id
-          name
-        }
-      }
-    `;
+	it('should throw error when skip argument is negative', async () => {
+		// Arrange
+		const query = `
+			query {
+				organizationConnectionList(skip: -1) {
+					id
+					name
+				}
+			}
+		`;
 
-    // Act
-    const result = await executeQuery(query);
+		// Act
+		const result = await executeQuery(query);
 
-    // Assert
-    expect(result.errors).toBeDefined();
-    expect(result.errors?.[0]).toMatchObject({
-      extensions: {
-        code: 'invalid_arguments',
-      },
-    });
-    expect(mockContext.drizzleClient.query.organizationsTable.findMany).not.toHaveBeenCalled();
-  });
+		// Assert
+		expect(result.errors).toBeDefined();
+		expect(result.errors?.[0]).toMatchObject({
+			extensions: {
+				code: 'invalid_arguments',
+			},
+		});
+		expect(mockContext.drizzleClient.query.organizationsTable.findMany).not.toHaveBeenCalled();
+	});
 
-  it('should handle database errors gracefully', async () => {
-    // Arrange
-    const dbError = new Error('Database connection failed');
-    mockContext.drizzleClient.query.organizationsTable.findMany.mockRejectedValue(dbError);
+	it('should handle database errors gracefully', async () => {
+		// Arrange
+		const dbError = new Error('Database connection failed');
+		mockContext.drizzleClient.query.organizationsTable.findMany.mockRejectedValue(dbError);
 
-    const query = `
-      query {
-        organizationConnectionList {
-          id
-          name
-        }
-      }
-    `;
+		const query = `
+			query {
+				organizationConnectionList {
+					id
+					name
+				}
+			}
+		`;
 
-    // Act
-    const result = await executeQuery(query);
+		// Act
+		const result = await executeQuery(query);
 
-    // Assert
-    expect(result.errors).toBeDefined();
-    expect(result.errors?.[0]).toBe('Database connection failed');
-  });
+		// Assert
+		expect(result.errors).toBeDefined();
+		expect(result.errors?.[0].message).toBe('Database connection failed');
+	});
 
-  it('should verify error object structure when validation fails', async () => {
-    // Arrange
-    const query = `
-      query {
-        organizationConnectionList(first: 0, skip: -1) {
-          id
-          name
-        }
-      }
-    `;
+	it('should verify error object structure when validation fails', async () => {
+		// Arrange
+		const query = `
+			query {
+				organizationConnectionList(first: 0, skip: -1) {
+					id
+					name
+				}
+			}
+		`;
 
-    // Act
-    const result = await executeQuery(query);
+		// Act
+		const result = await executeQuery(query);
 
-    // Assert
-    expect(result.errors).toBeDefined();
-    expect(result.errors?.[0]).toMatchObject({
-      extensions: {
-        code: 'invalid_arguments',
-        issues: expect.arrayContaining([
-          expect.objectContaining({
-            argumentPath: expect.any(Array),
-            message: expect.any(String),
-          }),
-        ]),
-      },
-    });
-  });
+		// Assert
+		expect(result.errors).toBeDefined();
+		expect(result.errors?.[0]).toMatchObject({
+			extensions: {
+				code: 'invalid_arguments',
+				issues: expect.arrayContaining([
+					expect.objectContaining({
+						argumentPath: expect.any(Array),
+						message: expect.any(String),
+					}),
+				]),
+			},
+		});
+	});
 });

--- a/test/graphql/types/userResolver.test.ts
+++ b/test/graphql/types/userResolver.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { execute, parse } from 'graphql';
+import { schema } from '~/src/graphql/schema';
+
+describe('userList Query', () => {
+  // Mock context
+  const mockContext = {
+    drizzleClient: {
+      query: {
+        usersTable: {
+          findMany: vi.fn(),
+        },
+      },
+    },
+  };
+
+  // Sample user data
+  const sampleUsers = [
+    { id: 1, name: 'John Doe', email: 'john@example.com' },
+    { id: 2, name: 'Jane Smith', email: 'jane@example.com' },
+    { id: 3, name: 'Bob Johnson', email: 'bob@example.com' },
+  ];
+
+  beforeEach(() => {
+    // Reset all mocks before each test
+    vi.clearAllMocks();
+    mockContext.drizzleClient.query.usersTable.findMany.mockReset();
+  });
+
+  const executeQuery = async (query: string, variables = {}) => {
+    return execute({
+      schema,
+      document: parse(query),
+      contextValue: mockContext,
+      variableValues: variables,
+    });
+  };
+
+  it('should return users with default pagination values', async () => {
+    // Arrange
+    mockContext.drizzleClient.query.usersTable.findMany.mockResolvedValue(sampleUsers);
+    
+    const query = `
+      query {
+        userList {
+          id
+          name
+          email
+        }
+      }
+    `;
+
+    // Act
+    const result = await executeQuery(query);
+
+    // Assert
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.userList).toEqual(sampleUsers);
+    expect(mockContext.drizzleClient.query.usersTable.findMany).toHaveBeenCalledWith({
+      limit: 10,  // default value
+      offset: 0,  // default value
+    });
+  });
+
+  it('should return users with custom pagination values', async () => {
+    // Arrange
+    mockContext.drizzleClient.query.usersTable.findMany.mockResolvedValue(sampleUsers);
+    
+    const query = `
+      query($first: Int, $skip: Int) {
+        userList(first: $first, skip: $skip) {
+          id
+          name
+          email
+        }
+      }
+    `;
+
+    // Act
+    const result = await executeQuery(query, { first: 5, skip: 10 });
+
+    // Assert
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.userList).toEqual(sampleUsers);
+    expect(mockContext.drizzleClient.query.usersTable.findMany).toHaveBeenCalledWith({
+      limit: 5,
+      offset: 10,
+    });
+  });
+
+  it('should throw error when first argument is less than 1', async () => {
+    // Arrange
+    const query = `
+      query {
+        userList(first: 0) {
+          id
+          name
+          email
+        }
+      }
+    `;
+
+    // Act
+    const result = await executeQuery(query);
+
+    // Assert
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.[0]).toMatchObject({
+      extensions: {
+        code: 'invalid_arguments',
+      },
+    });
+    expect(mockContext.drizzleClient.query.usersTable.findMany).not.toHaveBeenCalled();
+  });
+
+  it('should throw error when first argument is greater than 100', async () => {
+    // Arrange
+    const query = `
+      query {
+        userList(first: 101) {
+          id
+          name
+          email
+        }
+      }
+    `;
+
+    // Act
+    const result = await executeQuery(query);
+
+    // Assert
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.[0]).toMatchObject({
+      extensions: {
+        code: 'invalid_arguments',
+      },
+    });
+    expect(mockContext.drizzleClient.query.usersTable.findMany).not.toHaveBeenCalled();
+  });
+
+  it('should throw error when skip argument is negative', async () => {
+    // Arrange
+    const query = `
+      query {
+        userList(skip: -1) {
+          id
+          name
+          email
+        }
+      }
+    `;
+
+    // Act
+    const result = await executeQuery(query);
+
+    // Assert
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.[0]).toMatchObject({
+      extensions: {
+        code: 'invalid_arguments',
+      },
+    });
+    expect(mockContext.drizzleClient.query.usersTable.findMany).not.toHaveBeenCalled();
+  });
+
+  it('should handle database errors gracefully', async () => {
+    // Arrange
+    const dbError = new Error('Database connection failed');
+    mockContext.drizzleClient.query.usersTable.findMany.mockRejectedValue(dbError);
+
+    const query = `
+      query {
+        userList {
+          id
+          name
+          email
+        }
+      }
+    `;
+
+    // Act
+    const result = await executeQuery(query);
+
+    // Assert
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.[0]).toBe('Database connection failed');
+  });
+
+  it('should verify error object structure when validation fails', async () => {
+    // Arrange
+    const query = `
+      query {
+        userList(first: 0, skip: -1) {
+          id
+          name
+          email
+        }
+      }
+    `;
+
+    // Act
+    const result = await executeQuery(query);
+
+    // Assert
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.[0]).toMatchObject({
+      extensions: {
+        code: 'invalid_arguments',
+        issues: expect.arrayContaining([
+          expect.objectContaining({
+            argumentPath: expect.any(Array),
+            message: expect.any(String),
+          }),
+        ]),
+      },
+    });
+  });
+});

--- a/test/graphql/types/userResolver.test.ts
+++ b/test/graphql/types/userResolver.test.ts
@@ -1,7 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { execute, parse } from 'graphql';
 import { schema } from '~/src/graphql/schema';
-
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 describe('userList Query', () => {
   // Mock context
   const mockContext = {

--- a/test/graphql/types/userResolver.test.ts
+++ b/test/graphql/types/userResolver.test.ts
@@ -38,7 +38,9 @@ describe("userList Query", () => {
 
 	it("should return users with default pagination values", async () => {
 		// Arrange
-		mockContext.drizzleClient.query.usersTable.findMany.mockResolvedValue(sampleUsers);
+		mockContext.drizzleClient.query.usersTable.findMany.mockResolvedValue(
+			sampleUsers,
+		);
 
 		const query = `
 			query {
@@ -56,7 +58,9 @@ describe("userList Query", () => {
 		// Assert
 		expect(result.errors).toBeUndefined();
 		expect(result.data?.userList).toEqual(sampleUsers);
-		expect(mockContext.drizzleClient.query.usersTable.findMany).toHaveBeenCalledWith({
+		expect(
+			mockContext.drizzleClient.query.usersTable.findMany,
+		).toHaveBeenCalledWith({
 			limit: 10, // default value
 			offset: 0, // default value
 		});
@@ -64,7 +68,9 @@ describe("userList Query", () => {
 
 	it("should return users with custom pagination values", async () => {
 		// Arrange
-		mockContext.drizzleClient.query.usersTable.findMany.mockResolvedValue(sampleUsers);
+		mockContext.drizzleClient.query.usersTable.findMany.mockResolvedValue(
+			sampleUsers,
+		);
 
 		const query = `
 			query($first: Int, $skip: Int) {
@@ -82,7 +88,9 @@ describe("userList Query", () => {
 		// Assert
 		expect(result.errors).toBeUndefined();
 		expect(result.data?.userList).toEqual(sampleUsers);
-		expect(mockContext.drizzleClient.query.usersTable.findMany).toHaveBeenCalledWith({
+		expect(
+			mockContext.drizzleClient.query.usersTable.findMany,
+		).toHaveBeenCalledWith({
 			limit: 5,
 			offset: 10,
 		});
@@ -110,7 +118,9 @@ describe("userList Query", () => {
 				code: "invalid_arguments",
 			},
 		});
-		expect(mockContext.drizzleClient.query.usersTable.findMany).not.toHaveBeenCalled();
+		expect(
+			mockContext.drizzleClient.query.usersTable.findMany,
+		).not.toHaveBeenCalled();
 	});
 
 	it("should throw error when first argument is greater than 100", async () => {
@@ -135,7 +145,9 @@ describe("userList Query", () => {
 				code: "invalid_arguments",
 			},
 		});
-		expect(mockContext.drizzleClient.query.usersTable.findMany).not.toHaveBeenCalled();
+		expect(
+			mockContext.drizzleClient.query.usersTable.findMany,
+		).not.toHaveBeenCalled();
 	});
 
 	it("should throw error when skip argument is negative", async () => {
@@ -160,13 +172,17 @@ describe("userList Query", () => {
 				code: "invalid_arguments",
 			},
 		});
-		expect(mockContext.drizzleClient.query.usersTable.findMany).not.toHaveBeenCalled();
+		expect(
+			mockContext.drizzleClient.query.usersTable.findMany,
+		).not.toHaveBeenCalled();
 	});
 
 	it("should handle database errors gracefully", async () => {
 		// Arrange
 		const dbError = new Error("Database connection failed");
-		mockContext.drizzleClient.query.usersTable.findMany.mockRejectedValue(dbError);
+		mockContext.drizzleClient.query.usersTable.findMany.mockRejectedValue(
+			dbError,
+		);
 
 		const query = `
 			query {
@@ -183,7 +199,7 @@ describe("userList Query", () => {
 
 		// Assert
 		expect(result.errors).toBeDefined();
-		expect(result.errors?.[0].message).toBe("Database connection failed");
+		expect(result.errors?.[0]?.message).toBe("Database connection failed");
 	});
 
 	it("should verify error object structure when validation fails", async () => {

--- a/test/graphql/types/userResolver.test.ts
+++ b/test/graphql/types/userResolver.test.ts
@@ -1,217 +1,218 @@
-import { execute, parse } from 'graphql';
-import { schema } from '~/src/graphql/schema';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-describe('userList Query', () => {
-  // Mock context
-  const mockContext = {
-    drizzleClient: {
-      query: {
-        usersTable: {
-          findMany: vi.fn(),
-        },
-      },
-    },
-  };
+import { execute, parse } from "graphql";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { schema } from "~/src/graphql/schema";
 
-  // Sample user data
-  const sampleUsers = [
-    { id: 1, name: 'John Doe', email: 'john@example.com' },
-    { id: 2, name: 'Jane Smith', email: 'jane@example.com' },
-    { id: 3, name: 'Bob Johnson', email: 'bob@example.com' },
-  ];
+describe("userList Query", () => {
+	// Mock context
+	const mockContext = {
+		drizzleClient: {
+			query: {
+				usersTable: {
+					findMany: vi.fn(),
+				},
+			},
+		},
+	};
 
-  beforeEach(() => {
-    // Reset all mocks before each test
-    vi.clearAllMocks();
-    mockContext.drizzleClient.query.usersTable.findMany.mockReset();
-  });
+	// Sample user data
+	const sampleUsers = [
+		{ id: 1, name: "John Doe", email: "john@example.com" },
+		{ id: 2, name: "Jane Smith", email: "jane@example.com" },
+		{ id: 3, name: "Bob Johnson", email: "bob@example.com" },
+	];
 
-  const executeQuery = async (query: string, variables = {}) => {
-    return execute({
-      schema,
-      document: parse(query),
-      contextValue: mockContext,
-      variableValues: variables,
-    });
-  };
+	beforeEach(() => {
+		// Reset all mocks before each test
+		vi.clearAllMocks();
+		mockContext.drizzleClient.query.usersTable.findMany.mockReset();
+	});
 
-  it('should return users with default pagination values', async () => {
-    // Arrange
-    mockContext.drizzleClient.query.usersTable.findMany.mockResolvedValue(sampleUsers);
-    
-    const query = `
-      query {
-        userList {
-          id
-          name
-          email
-        }
-      }
-    `;
+	const executeQuery = async (query: string, variables = {}) => {
+		return execute({
+			schema,
+			document: parse(query),
+			contextValue: mockContext,
+			variableValues: variables,
+		});
+	};
 
-    // Act
-    const result = await executeQuery(query);
+	it("should return users with default pagination values", async () => {
+		// Arrange
+		mockContext.drizzleClient.query.usersTable.findMany.mockResolvedValue(sampleUsers);
 
-    // Assert
-    expect(result.errors).toBeUndefined();
-    expect(result.data?.userList).toEqual(sampleUsers);
-    expect(mockContext.drizzleClient.query.usersTable.findMany).toHaveBeenCalledWith({
-      limit: 10,  // default value
-      offset: 0,  // default value
-    });
-  });
+		const query = `
+			query {
+				userList {
+					id
+					name
+					email
+				}
+			}
+		`;
 
-  it('should return users with custom pagination values', async () => {
-    // Arrange
-    mockContext.drizzleClient.query.usersTable.findMany.mockResolvedValue(sampleUsers);
-    
-    const query = `
-      query($first: Int, $skip: Int) {
-        userList(first: $first, skip: $skip) {
-          id
-          name
-          email
-        }
-      }
-    `;
+		// Act
+		const result = await executeQuery(query);
 
-    // Act
-    const result = await executeQuery(query, { first: 5, skip: 10 });
+		// Assert
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.userList).toEqual(sampleUsers);
+		expect(mockContext.drizzleClient.query.usersTable.findMany).toHaveBeenCalledWith({
+			limit: 10, // default value
+			offset: 0, // default value
+		});
+	});
 
-    // Assert
-    expect(result.errors).toBeUndefined();
-    expect(result.data?.userList).toEqual(sampleUsers);
-    expect(mockContext.drizzleClient.query.usersTable.findMany).toHaveBeenCalledWith({
-      limit: 5,
-      offset: 10,
-    });
-  });
+	it("should return users with custom pagination values", async () => {
+		// Arrange
+		mockContext.drizzleClient.query.usersTable.findMany.mockResolvedValue(sampleUsers);
 
-  it('should throw error when first argument is less than 1', async () => {
-    // Arrange
-    const query = `
-      query {
-        userList(first: 0) {
-          id
-          name
-          email
-        }
-      }
-    `;
+		const query = `
+			query($first: Int, $skip: Int) {
+				userList(first: $first, skip: $skip) {
+					id
+					name
+					email
+				}
+			}
+		`;
 
-    // Act
-    const result = await executeQuery(query);
+		// Act
+		const result = await executeQuery(query, { first: 5, skip: 10 });
 
-    // Assert
-    expect(result.errors).toBeDefined();
-    expect(result.errors?.[0]).toMatchObject({
-      extensions: {
-        code: 'invalid_arguments',
-      },
-    });
-    expect(mockContext.drizzleClient.query.usersTable.findMany).not.toHaveBeenCalled();
-  });
+		// Assert
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.userList).toEqual(sampleUsers);
+		expect(mockContext.drizzleClient.query.usersTable.findMany).toHaveBeenCalledWith({
+			limit: 5,
+			offset: 10,
+		});
+	});
 
-  it('should throw error when first argument is greater than 100', async () => {
-    // Arrange
-    const query = `
-      query {
-        userList(first: 101) {
-          id
-          name
-          email
-        }
-      }
-    `;
+	it("should throw error when first argument is less than 1", async () => {
+		// Arrange
+		const query = `
+			query {
+				userList(first: 0) {
+					id
+					name
+					email
+				}
+			}
+		`;
 
-    // Act
-    const result = await executeQuery(query);
+		// Act
+		const result = await executeQuery(query);
 
-    // Assert
-    expect(result.errors).toBeDefined();
-    expect(result.errors?.[0]).toMatchObject({
-      extensions: {
-        code: 'invalid_arguments',
-      },
-    });
-    expect(mockContext.drizzleClient.query.usersTable.findMany).not.toHaveBeenCalled();
-  });
+		// Assert
+		expect(result.errors).toBeDefined();
+		expect(result.errors?.[0]).toMatchObject({
+			extensions: {
+				code: "invalid_arguments",
+			},
+		});
+		expect(mockContext.drizzleClient.query.usersTable.findMany).not.toHaveBeenCalled();
+	});
 
-  it('should throw error when skip argument is negative', async () => {
-    // Arrange
-    const query = `
-      query {
-        userList(skip: -1) {
-          id
-          name
-          email
-        }
-      }
-    `;
+	it("should throw error when first argument is greater than 100", async () => {
+		// Arrange
+		const query = `
+			query {
+				userList(first: 101) {
+					id
+					name
+					email
+				}
+			}
+		`;
 
-    // Act
-    const result = await executeQuery(query);
+		// Act
+		const result = await executeQuery(query);
 
-    // Assert
-    expect(result.errors).toBeDefined();
-    expect(result.errors?.[0]).toMatchObject({
-      extensions: {
-        code: 'invalid_arguments',
-      },
-    });
-    expect(mockContext.drizzleClient.query.usersTable.findMany).not.toHaveBeenCalled();
-  });
+		// Assert
+		expect(result.errors).toBeDefined();
+		expect(result.errors?.[0]).toMatchObject({
+			extensions: {
+				code: "invalid_arguments",
+			},
+		});
+		expect(mockContext.drizzleClient.query.usersTable.findMany).not.toHaveBeenCalled();
+	});
 
-  it('should handle database errors gracefully', async () => {
-    // Arrange
-    const dbError = new Error('Database connection failed');
-    mockContext.drizzleClient.query.usersTable.findMany.mockRejectedValue(dbError);
+	it("should throw error when skip argument is negative", async () => {
+		// Arrange
+		const query = `
+			query {
+				userList(skip: -1) {
+					id
+					name
+					email
+				}
+			}
+		`;
 
-    const query = `
-      query {
-        userList {
-          id
-          name
-          email
-        }
-      }
-    `;
+		// Act
+		const result = await executeQuery(query);
 
-    // Act
-    const result = await executeQuery(query);
+		// Assert
+		expect(result.errors).toBeDefined();
+		expect(result.errors?.[0]).toMatchObject({
+			extensions: {
+				code: "invalid_arguments",
+			},
+		});
+		expect(mockContext.drizzleClient.query.usersTable.findMany).not.toHaveBeenCalled();
+	});
 
-    // Assert
-    expect(result.errors).toBeDefined();
-    expect(result.errors?.[0]).toBe('Database connection failed');
-  });
+	it("should handle database errors gracefully", async () => {
+		// Arrange
+		const dbError = new Error("Database connection failed");
+		mockContext.drizzleClient.query.usersTable.findMany.mockRejectedValue(dbError);
 
-  it('should verify error object structure when validation fails', async () => {
-    // Arrange
-    const query = `
-      query {
-        userList(first: 0, skip: -1) {
-          id
-          name
-          email
-        }
-      }
-    `;
+		const query = `
+			query {
+				userList {
+					id
+					name
+					email
+				}
+			}
+		`;
 
-    // Act
-    const result = await executeQuery(query);
+		// Act
+		const result = await executeQuery(query);
 
-    // Assert
-    expect(result.errors).toBeDefined();
-    expect(result.errors?.[0]).toMatchObject({
-      extensions: {
-        code: 'invalid_arguments',
-        issues: expect.arrayContaining([
-          expect.objectContaining({
-            argumentPath: expect.any(Array),
-            message: expect.any(String),
-          }),
-        ]),
-      },
-    });
-  });
+		// Assert
+		expect(result.errors).toBeDefined();
+		expect(result.errors?.[0].message).toBe("Database connection failed");
+	});
+
+	it("should verify error object structure when validation fails", async () => {
+		// Arrange
+		const query = `
+			query {
+				userList(first: 0, skip: -1) {
+					id
+					name
+					email
+				}
+			}
+		`;
+
+		// Act
+		const result = await executeQuery(query);
+
+		// Assert
+		expect(result.errors).toBeDefined();
+		expect(result.errors?.[0]).toMatchObject({
+			extensions: {
+				code: "invalid_arguments",
+				issues: expect.arrayContaining([
+					expect.objectContaining({
+						argumentPath: expect.any(Array),
+						message: expect.any(String),
+					}),
+				]),
+			},
+		});
+	});
 });


### PR DESCRIPTION

**What kind of change does this PR introduce?**

bugfix

**Issue Number:**

Fixes #3143 

**Snapshots/Videos:**

NA


**Summary**

This PR addresses issue [https://github.com/https://github.com/PalisadoesFoundation/talawa-api/issues/3143] by enforcing pagination limits on the first and skip parameters for the USER_LIST and ORGANIZATION_CONNECTION_LIST GraphQL queries. This prevents clients from requesting excessively large datasets, which could lead to potential denial-of-service (DoS) attacks by overwhelming server resources.


## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

1.The changes have been manually tested to ensure they work as expected.
2.Test cases have been added in this PR.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new GraphQL queries for fetching lists of organizations and users with pagination support, allowing flexible data retrieval.
- **Tests**
	- Added comprehensive tests to verify pagination functionality, input validations, and proper error handling under various conditions for both `organizationConnectionList` and `userList` queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->