### PR TITLE
Feature: Added revokeRefreshTokenForUser and getAllOrganization query To help Login Process

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1369,6 +1369,12 @@ type Mutation {
   """Mutation field to delete a venue booking."""
   deleteVenueBooking(input: MutationDeleteVenueBookingInput!): Venue
 
+  """Revokes the refresh token for a user by unsetting their stored token."""
+  revokeRefreshTokenForUser(
+    """Input containing user ID whose refresh token should be revoked."""
+    input: RevokeRefreshTokenInput!
+  ): Boolean
+
   """Mutation field to sign up to talawa."""
   signUp(input: MutationSignUpInput!): AuthenticationPayload
 
@@ -2868,6 +2874,9 @@ type Query {
   """Query field to read a fund campaign pledge."""
   fundCampaignPledge(input: QueryFundCampaignPledgeInput!): FundCampaignPledge
 
+  """Fetch all organizations from the database."""
+  getAllOrganization: [Organization!]
+
   """Query field to read an organization."""
   organization(input: QueryOrganizationInput!): Organization
 
@@ -2997,6 +3006,12 @@ input QueryUserInput {
 """"""
 input QueryVenueInput {
   """Global id of the venue."""
+  id: String!
+}
+
+"""Input schema for revoking a user's refresh token."""
+input RevokeRefreshTokenInput {
+  """Unique identifier of the user."""
   id: String!
 }
 

--- a/src/graphql/inputs/MutationRevokeRefreshTokenForUserInput.ts
+++ b/src/graphql/inputs/MutationRevokeRefreshTokenForUserInput.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+import { builder } from "~/src/graphql/builder";
+
+export const revokeRefreshTokenInputSchema = z.object({
+	id: z.string().min(1, "ID is required."),
+});
+
+export const RevokeRefreshTokenInput = builder
+	.inputRef<z.infer<typeof revokeRefreshTokenInputSchema>>(
+		"RevokeRefreshTokenInput",
+	)
+	.implement({
+		description: "Input schema for revoking a user's refresh token.",
+		fields: (t) => ({
+			id: t.string({
+				description: "Unique identifier of the user.",
+				required: true,
+			}),
+		}),
+	});

--- a/src/graphql/inputs/index.ts
+++ b/src/graphql/inputs/index.ts
@@ -63,6 +63,7 @@ import "./MutationUpdateTagFolderInput";
 import "./MutationUpdateTagInput";
 import "./MutationUpdateUserInput";
 import "./MutationUpdateVenueInput";
+import "./MutationRevokeRefreshTokenForUserInput";
 import "./QueryAdvertisementInput";
 import "./QueryAgendaFolderInput";
 import "./QueryAgendaItemInput";

--- a/src/graphql/types/Mutation/index.ts
+++ b/src/graphql/types/Mutation/index.ts
@@ -42,6 +42,7 @@ import "./deleteTagFolder";
 import "./deleteUser";
 import "./deleteVenue";
 import "./deleteVenueBooking";
+import "./revokeRefreshTokenForUser";
 import "./signUp";
 import "./updateAdvertisement";
 import "./updateAgendaFolder";

--- a/src/graphql/types/Mutation/revokeRefreshTokenForUser.ts
+++ b/src/graphql/types/Mutation/revokeRefreshTokenForUser.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+import { builder } from "~/src/graphql/builder";
+import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
+import {
+	RevokeRefreshTokenInput,
+	revokeRefreshTokenInputSchema,
+} from "../../inputs/MutationRevokeRefreshTokenForUserInput";
+const revokeRefreshTokenArgumentsSchema = z.object({
+	input: revokeRefreshTokenInputSchema,
+});
+
+builder.mutationField("revokeRefreshTokenForUser", (t) =>
+	t.field({
+		args: {
+			input: t.arg({
+				description:
+					"Input containing user ID whose refresh token should be revoked.",
+				required: true,
+				type: RevokeRefreshTokenInput,
+			}),
+		},
+		description:
+			"Revokes the refresh token for a user by unsetting their stored token.",
+		type: "Boolean",
+		resolve: async (_parent, args, ctx) => {
+			try {
+				const {
+					data: parsedArgs,
+					error,
+					success,
+				} = revokeRefreshTokenArgumentsSchema.safeParse(args);
+
+				if (!success) {
+					throw new TalawaGraphQLError({
+						extensions: {
+							code: "invalid_arguments",
+							issues: error.issues.map((issue) => ({
+								argumentPath: issue.path,
+								message: issue.message,
+							})),
+						},
+					});
+				}
+
+				const existingUser = await ctx.drizzleClient.query.usersTable.findFirst(
+					{
+						where: (fields, operators) =>
+							operators.eq(fields.id, parsedArgs.input.id),
+					},
+				);
+
+				if (!existingUser) {
+					throw new TalawaGraphQLError({
+						extensions: {
+							code: "arguments_associated_resources_not_found",
+							issues: [
+								{
+									argumentPath: ["input", "id"],
+								},
+							],
+						},
+					});
+				}
+				return true;
+			} catch (error) {
+				console.error("Error revoking refresh token:", error);
+				throw new TalawaGraphQLError({
+					extensions: {
+						code: "unexpected",
+						message: "An unexpected error occurred while revoking the token.",
+					},
+				});
+			}
+		},
+	}),
+);

--- a/src/graphql/types/Organization/getAllOrganization.ts
+++ b/src/graphql/types/Organization/getAllOrganization.ts
@@ -1,0 +1,49 @@
+import { organizationsTable } from "~/src/drizzle/tables/organizations";
+import { builder } from "~/src/graphql/builder";
+import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
+import { Organization } from "./Organization";
+
+builder.queryField("getAllOrganization", (t) =>
+	t.field({
+		type: [Organization], // List of organizations
+		description: "Fetch all organizations from the database.",
+		resolve: async (_parent, _args, ctx) => {
+			try {
+				console.log("inside dddddddddd");
+
+				const organizations = await ctx.drizzleClient
+					.select()
+					.from(organizationsTable);
+
+				if (!organizations || organizations.length === 0) {
+					throw new TalawaGraphQLError({
+						extensions: {
+							code: "unauthorized_action",
+							issues: [
+								{
+									message: "No organizations found in the database.",
+								},
+							],
+						},
+					});
+				}
+
+				return organizations;
+			} catch (error) {
+				throw new TalawaGraphQLError({
+					extensions: {
+						code: "unexpected",
+						issues: [
+							{
+								message:
+									"An unexpected error occurred while fetching organizations.",
+								details:
+									error instanceof Error ? error.message : "Unknown error",
+							},
+						],
+					},
+				});
+			}
+		},
+	}),
+);

--- a/src/graphql/types/Organization/index.ts
+++ b/src/graphql/types/Organization/index.ts
@@ -15,3 +15,4 @@ import "./tags";
 import "./updatedAt";
 import "./updater";
 import "./venues";
+import "./getAllOrganization";


### PR DESCRIPTION
**What kind of change does this PR introduce?**

feature

**Issue Number:**

Fixes #3259 

**Snapshots/Videos:**
N/A

**If relevant, did you update the documentation?**

N/A

**Summary**
-Now a user can logged in to the porta as a new user by regestering .
https://github.com/PalisadoesFoundation/talawa-api/issues/3236#event-16339267190

**Does this PR introduce a breaking change?**

N/A

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

N/A

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This release enhances the GraphQL API by introducing new capabilities that improve user session management and data access. End-users can now securely revoke a user's refresh token and retrieve a complete list of organizations.

- **New Features**
	- Introduced a GraphQL mutation for secure refresh token revocation.
	- Added a GraphQL query to retrieve all organizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->