### PR TITLE
Improve Test Coverage for src/graphql/types/Query/post.ts

### DIFF
--- a/test/routes/graphql/Query/post.test.ts
+++ b/test/routes/graphql/Query/post.test.ts
@@ -1,0 +1,341 @@
+import { faker } from "@faker-js/faker";
+import { hash } from "@node-rs/argon2";
+import { eq } from "drizzle-orm";
+import { organizationsTable, postsTable, usersTable } from "src/drizzle/schema";
+import { uuidv7 } from "uuidv7";
+import { beforeEach, expect, suite, test } from "vitest";
+import type {
+	ArgumentsAssociatedResourcesNotFoundExtensions,
+	InvalidArgumentsExtensions,
+	TalawaGraphQLFormattedError,
+	UnauthenticatedExtensions,
+	UnauthorizedActionOnArgumentsAssociatedResourcesExtensions,
+} from "~/src/utilities/TalawaGraphQLError";
+import { server } from "../../../server";
+import { mercuriusClient } from "../client";
+import { Query_post, Query_signIn } from "../documentNodes";
+
+suite("Query field post", () => {
+	let adminUserId: string;
+
+	// Add the helper function for creating test users
+	const createTestUser = async (
+		role: "regular" | "administrator" = "regular",
+	) => {
+		const testEmail = `test.user.${faker.string.ulid()}@email.com`;
+		const testPassword = "password";
+
+		const hashedPassword = await hash(testPassword);
+
+		const [userRow] = await server.drizzleClient
+			.insert(usersTable)
+			.values({
+				emailAddress: testEmail,
+				passwordHash: hashedPassword,
+				role,
+				name: faker.person.fullName(),
+				isEmailAddressVerified: true,
+			})
+			.returning({
+				id: usersTable.id,
+			});
+
+		if (!userRow) throw new Error("Failed to create test user"); // throws an error
+
+		return { userId: userRow.id, email: testEmail, password: testPassword };
+	};
+
+	beforeEach(async () => {
+		// Create admin user if it doesn't exist
+		const [adminUser] = await server.drizzleClient
+			.insert(usersTable)
+			.values({
+				emailAddress: server.envConfig.API_ADMINISTRATOR_USER_EMAIL_ADDRESS,
+				passwordHash: server.envConfig.API_ADMINISTRATOR_USER_PASSWORD,
+				role: "administrator",
+				name: server.envConfig.API_ADMINISTRATOR_USER_NAME,
+				isEmailAddressVerified: true,
+			})
+			.onConflictDoNothing()
+			.returning({ id: usersTable.id });
+
+		if (adminUser) {
+			adminUserId = adminUser.id;
+		} else {
+			// If user already exists, get their ID
+			const [existingAdmin] = await server.drizzleClient
+				.select({ id: usersTable.id })
+				.from(usersTable)
+				.where(
+					eq(
+						usersTable.emailAddress,
+						server.envConfig.API_ADMINISTRATOR_USER_EMAIL_ADDRESS,
+					),
+				)
+				.limit(1);
+
+			//Throw error if user doesn't exist
+			if (!existingAdmin)
+				throw new Error("Failed to find or create admin user");
+			adminUserId = existingAdmin.id;
+		}
+	});
+
+	const getAuthToken = async () => {
+		const signInResult = await mercuriusClient.query(Query_signIn, {
+			variables: {
+				input: {
+					emailAddress: server.envConfig.API_ADMINISTRATOR_USER_EMAIL_ADDRESS,
+					password: server.envConfig.API_ADMINISTRATOR_USER_PASSWORD,
+				},
+			},
+		});
+		return signInResult.data.signIn?.authenticationToken;
+	};
+
+	const createTestPost = async (creatorId: string) => {
+		const [organizationRow] = await server.drizzleClient
+			.insert(organizationsTable)
+			.values({
+				name: faker.company.name(),
+				countryCode: "us",
+			})
+			.returning({ id: organizationsTable.id });
+
+		const organizationId = organizationRow?.id;
+		if (!organizationId) throw new Error("Failed to create organization.");
+
+		const [postRow] = await server.drizzleClient
+			.insert(postsTable)
+			.values({
+				caption: faker.lorem.paragraph(),
+				creatorId,
+				organizationId,
+			})
+			.returning({ id: postsTable.id });
+
+		const postId = postRow?.id;
+		if (!postId) throw new Error("Failed to create post.");
+
+		return { postId, organizationId };
+	};
+
+	suite(
+		`results in a graphql error with "unauthenticated" extensions code in the "errors" field and "null" as the value of "data.post" field if`,
+		() => {
+			test("client triggering the graphql operation is not authenticated.", async () => {
+				const result = await mercuriusClient.query(Query_post, {
+					variables: {
+						input: {
+							id: uuidv7(),
+						},
+					},
+				});
+
+				expect(result.data.post).toEqual(null);
+				expect(result.errors).toEqual(
+					expect.arrayContaining<TalawaGraphQLFormattedError>([
+						expect.objectContaining<TalawaGraphQLFormattedError>({
+							extensions: expect.objectContaining<UnauthenticatedExtensions>({
+								code: "unauthenticated",
+							}),
+							message: expect.any(String),
+							path: ["post"],
+						}),
+					]),
+				);
+			});
+		},
+	);
+
+	suite(
+		`results in a graphql error with "invalid_arguments" extensions code in the "errors" field and "null" as the value of "data.post" field if`,
+		() => {
+			test("the provided post ID is not a valid UUID.", async () => {
+				const authToken = await getAuthToken();
+
+				const result = await mercuriusClient.query(Query_post, {
+					headers: {
+						authorization: `bearer ${authToken}`,
+					},
+					variables: {
+						input: {
+							id: "not-a-uuid",
+						},
+					},
+				});
+
+				expect(result.data.post).toEqual(null);
+				expect(result.errors).toEqual(
+					expect.arrayContaining<TalawaGraphQLFormattedError>([
+						expect.objectContaining<TalawaGraphQLFormattedError>({
+							extensions: expect.objectContaining<InvalidArgumentsExtensions>({
+								code: "invalid_arguments",
+								issues: expect.arrayContaining([
+									{
+										argumentPath: ["input", "id"],
+										message: expect.any(String),
+									},
+								]),
+							}),
+							message: expect.any(String),
+							path: ["post"],
+						}),
+					]),
+				);
+			});
+		},
+	);
+
+	suite(
+		`results in a graphql error with "arguments_associated_resources_not_found" extensions code in the "errors" field and "null" as the value of "data.post" field if`,
+		() => {
+			test(`value of the "input.id" does not correspond to an existing post.`, async () => {
+				const authToken = await getAuthToken();
+
+				const result = await mercuriusClient.query(Query_post, {
+					headers: {
+						authorization: `bearer ${authToken}`,
+					},
+					variables: {
+						input: {
+							id: uuidv7(),
+						},
+					},
+				});
+
+				expect(result.data.post).toEqual(null);
+				expect(result.errors).toEqual(
+					expect.arrayContaining<TalawaGraphQLFormattedError>([
+						expect.objectContaining<TalawaGraphQLFormattedError>({
+							extensions:
+								expect.objectContaining<ArgumentsAssociatedResourcesNotFoundExtensions>(
+									{
+										code: "arguments_associated_resources_not_found",
+										issues: expect.arrayContaining<
+											ArgumentsAssociatedResourcesNotFoundExtensions["issues"][number]
+										>([
+											{
+												argumentPath: ["input", "id"],
+											},
+										]),
+									},
+								),
+							message: expect.any(String),
+							path: ["post"],
+						}),
+					]),
+				);
+			});
+		},
+	);
+
+	suite(
+		`results in a graphql error with "unauthenticated" extensions code in the "errors" field and "null" as the value of "data.post" field if`,
+		() => {
+			test("authenticated user exists in token but not in database.", async () => {
+				const authToken = await getAuthToken();
+
+				await server.drizzleClient
+					.delete(usersTable)
+					.where(
+						eq(
+							usersTable.emailAddress,
+							server.envConfig.API_ADMINISTRATOR_USER_EMAIL_ADDRESS,
+						),
+					);
+
+				const result = await mercuriusClient.query(Query_post, {
+					headers: {
+						authorization: `bearer ${authToken}`,
+					},
+					variables: {
+						input: {
+							id: uuidv7(),
+						},
+					},
+				});
+
+				expect(result.data.post).toEqual(null);
+				expect(result.errors).toEqual(
+					expect.arrayContaining<TalawaGraphQLFormattedError>([
+						expect.objectContaining<TalawaGraphQLFormattedError>({
+							extensions: expect.objectContaining<UnauthenticatedExtensions>({
+								code: "unauthenticated",
+							}),
+							message: expect.any(String),
+							path: ["post"],
+						}),
+					]),
+				);
+			});
+		},
+	);
+
+	suite(
+		`results in a graphql error with "unauthorized_action_on_arguments_associated_resources" extensions code in the "errors" field and "null" as the value of "data.post" field if`,
+		() => {
+			test("regular user attempts to access a post from an organization they are not a member of", async () => {
+				// Create test user using the helper function
+				const { email, password } = await createTestUser();
+
+				// Create a different user's post
+				const { postId } = await createTestPost(adminUserId);
+
+				// Sign in with plain password
+				const signInResult = await mercuriusClient.query(Query_signIn, {
+					variables: {
+						input: {
+							emailAddress: email,
+							password: password,
+						},
+					},
+				});
+
+				const authToken = signInResult.data?.signIn?.authenticationToken;
+
+				// validation for authentication token
+				if (!authToken) {
+					console.error(
+						"SignIn Result:",
+						JSON.stringify(signInResult, null, 2),
+					);
+					throw new Error("Failed to get authentication token");
+				}
+
+				// Attempt to access post
+				const result = await mercuriusClient.query(Query_post, {
+					headers: {
+						authorization: `bearer ${authToken}`,
+					},
+					variables: {
+						input: {
+							id: postId,
+						},
+					},
+				});
+
+				expect(result.data.post).toEqual(null);
+				expect(result.errors).toEqual(
+					expect.arrayContaining<TalawaGraphQLFormattedError>([
+						expect.objectContaining<TalawaGraphQLFormattedError>({
+							extensions:
+								expect.objectContaining<UnauthorizedActionOnArgumentsAssociatedResourcesExtensions>(
+									{
+										code: "unauthorized_action_on_arguments_associated_resources",
+										issues: expect.arrayContaining([
+											{
+												argumentPath: ["input", "id"],
+											},
+										]),
+									},
+								),
+							message: expect.any(String),
+							path: ["post"],
+						}),
+					]),
+				);
+			});
+		},
+	);
+});

--- a/test/routes/graphql/Query/post.test.ts
+++ b/test/routes/graphql/Query/post.test.ts
@@ -235,8 +235,9 @@ suite("Query field post", () => {
 		() => {
 			test("authenticated user exists in token but not in database.", async () => {
 				// Create a new admin user specifically for this test
-				const { userId, email, password } = await createTestUser("administrator");
-				
+				const { userId, email, password } =
+					await createTestUser("administrator");
+
 				// Sign in with the new admin user
 				const signInResult = await mercuriusClient.query(Query_signIn, {
 					variables: {
@@ -246,15 +247,15 @@ suite("Query field post", () => {
 						},
 					},
 				});
-				
+
 				const authToken = signInResult.data?.signIn?.authenticationToken;
 				if (!authToken) throw new Error("Failed to get authentication token");
-			
+
 				// Delete the newly created admin user
 				await server.drizzleClient
 					.delete(usersTable)
 					.where(eq(usersTable.id, userId));
-			
+
 				const result = await mercuriusClient.query(Query_post, {
 					headers: {
 						authorization: `bearer ${authToken}`,
@@ -265,7 +266,7 @@ suite("Query field post", () => {
 						},
 					},
 				});
-			
+
 				expect(result.data.post).toEqual(null);
 				expect(result.errors).toEqual(
 					expect.arrayContaining<TalawaGraphQLFormattedError>([

--- a/test/routes/graphql/Query/post.test.ts
+++ b/test/routes/graphql/Query/post.test.ts
@@ -240,7 +240,10 @@ suite("Query field post", () => {
 				});
 
 				const authToken = signInResult.data?.signIn?.authenticationToken;
-				if (!authToken) throw new Error("vfdv");
+				if (!authToken)
+					throw new Error(
+						"Failed to get authentication token from sign-in result",
+					);
 
 				await server.drizzleClient
 					.delete(usersTable)


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Enhancement: Adds test coverage for the post.ts file in the GraphQL Query Types.

**Issue Number:**

Fixes #3043 

**Snapshots/Videos:**

N/A

**If relevant, did you update the documentation?**

N/A

**Summary**

This PR improves the test coverage for the src/graphql/types/Query/post.ts file by adding new test cases. The objective is to ensure that all code paths within this file are thoroughly tested, achieving 100% test coverage

**Does this PR introduce a breaking change?**

No

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

None

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Introduced a comprehensive test suite for the GraphQL post query.
	- Validates error messaging for various scenarios including unauthenticated access, invalid input, non-existent resources, and unauthorized actions.
	- Added helper functions for user and post creation to streamline testing processes.
	- Implemented authentication token retrieval and admin user setup in the test environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->