### PR TITLE
Docker Shells configuration

### DIFF
--- a/docker/api.Containerfile
+++ b/docker/api.Containerfile
@@ -32,11 +32,18 @@ RUN groupmod -n talawa vscode \
 && touch /commandhistory/.bash_history \
 && chown -R talawa /commandhistory \
 && echo "export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" >> /home/talawa/.bashrc
+# Create a global profile script that both login and non-interactive shells load
+RUN echo '#!/bin/sh' > /etc/profile.d/fnm.sh \
+    && echo 'export PATH="/home/talawa/.local/share/fnm:$PATH"' >> /etc/profile.d/fnm.sh \
+    && echo 'eval "$(fnm env --corepack-enabled --resolve-engines --use-on-cd --version-file-strategy=recursive)"' >> /etc/profile.d/fnm.sh \
+    && chmod +x /etc/profile.d/fnm.sh
+# Ensure non-interactive bash sessions load the script
+ENV BASH_ENV=/etc/profile.d/fnm.sh
+# Also, have the talawa login shell source it explicitly by appending to its .bashrc
+RUN echo "source /etc/profile.d/fnm.sh" >> /home/talawa/.bashrc
 USER talawa
 # Installs fnm.
-RUN curl -fsSL https://fnm.vercel.app/install | bash -s -- --skip-shell \ 
-# Appends the fnm configuration to `/home/talawa/.bashrc` file.
-&& echo eval \"\$\(fnm env --corepack-enabled --resolve-engines --use-on-cd --version-file-strategy=recursive\)\" >> /home/talawa/.bashrc
+RUN curl -fsSL https://fnm.vercel.app/install | bash -s -- --skip-shell 
 ENV PATH=/home/talawa/.local/share/fnm:${PATH}
 WORKDIR /home/talawa/api
   


### PR DESCRIPTION
Related issue #3214 

### Description

Configure docker login shells and bash non interactive shells to use fnm.

- Bash Non-Interactive (New) (Main requirement of issue)
- Bash Login (New)
- Bash Interactive (Already Supported)
- Sh Login (Was used by initializeCommand by default)

Conclusion: Bash can we widely used as per needs.

Following can be used to at ease now as one line commands directly from cli:

1. Non-Interactive Shells

`docker exec talawa-api-1 /bin/bash -c 'pnpm run add:sample_data && exit'`

2. Login Shells 

`docker exec talawa-api-1 /bin/bash -l -c 'pnpm run add:sample_data && exit'`

`docker exec talawa-api-1 /bin/sh -l -c 'pnpm run add:sample_data && exit'`

3. Interactive Shells

`docker exec talawa-api-1 /bin/bash -i -c 'pnpm run add:sample_data && exit'`

### Key Changes

- Configured environment before handing over to talawa.
- Updated Docs

### Using reset:data script (interactive)

1. `docker exec -it talawa-api-1 /bin/bash`
2. `pnpm reset:data`

### Next Steps For issue

Improve code coverage for helpers script.
