### PR TITLE
Test: Added test file for src/graphql/types/Venue/updater.ts

### DIFF
--- a/src/graphql/types/Venue/updater.ts
+++ b/src/graphql/types/Venue/updater.ts
@@ -1,89 +1,95 @@
+import type { GraphQLContext } from "~/src/graphql/context";
 import { User } from "~/src/graphql/types/User/User";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 import { Venue } from "./Venue";
+import type { Venue as VenueType } from "./Venue";
+
+export const resolveUpdater = async (
+	parent: VenueType,
+	_args: Record<string, never>,
+	ctx: GraphQLContext,
+): Promise<User | null> => {
+	if (!ctx.currentClient.isAuthenticated) {
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "unauthenticated",
+			},
+		});
+	}
+
+	const currentUserId = ctx.currentClient.user.id;
+
+	const currentUser = await ctx.drizzleClient.query.usersTable.findFirst({
+		with: {
+			organizationMembershipsWhereMember: {
+				columns: {
+					role: true,
+				},
+				where: (fields, operators) =>
+					operators.eq(fields.organizationId, parent.organizationId),
+			},
+		},
+		where: (fields, operators) => operators.eq(fields.id, currentUserId),
+	});
+
+	if (currentUser === undefined) {
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "unauthenticated",
+			},
+		});
+	}
+
+	const currentUserOrganizationMembership =
+		currentUser.organizationMembershipsWhereMember[0];
+
+	if (
+		currentUser.role !== "administrator" &&
+		(currentUserOrganizationMembership === undefined ||
+			currentUserOrganizationMembership.role !== "administrator")
+	) {
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "unauthorized_action",
+			},
+		});
+	}
+
+	if (parent.updaterId === null) {
+		return null;
+	}
+
+	if (parent.updaterId === currentUserId) {
+		return currentUser;
+	}
+
+	const updaterId = parent.updaterId;
+
+	const existingUser = await ctx.drizzleClient.query.usersTable.findFirst({
+		where: (fields, operators) => operators.eq(fields.id, updaterId),
+	});
+
+	// Updater id existing but the associated user not existing is a business logic error and probably means that the corresponding data in the database is in a corrupted state. It must be investigated and fixed as soon as possible to prevent additional data corruption.
+	if (existingUser === undefined) {
+		ctx.log.error(
+			"Postgres select operation returned an empty array for a venue's updater id that isn't null.",
+		);
+
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "unexpected",
+			},
+		});
+	}
+
+	return existingUser;
+};
 
 Venue.implement({
 	fields: (t) => ({
 		updater: t.field({
 			description: "User who last updated the venue.",
-			resolve: async (parent, _args, ctx) => {
-				if (!ctx.currentClient.isAuthenticated) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthenticated",
-						},
-					});
-				}
-
-				const currentUserId = ctx.currentClient.user.id;
-
-				const currentUser = await ctx.drizzleClient.query.usersTable.findFirst({
-					with: {
-						organizationMembershipsWhereMember: {
-							columns: {
-								role: true,
-							},
-							where: (fields, operators) =>
-								operators.eq(fields.organizationId, parent.organizationId),
-						},
-					},
-					where: (fields, operators) => operators.eq(fields.id, currentUserId),
-				});
-
-				if (currentUser === undefined) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthenticated",
-						},
-					});
-				}
-
-				const currentUserOrganizationMembership =
-					currentUser.organizationMembershipsWhereMember[0];
-
-				if (
-					currentUser.role !== "administrator" &&
-					(currentUserOrganizationMembership === undefined ||
-						currentUserOrganizationMembership.role !== "administrator")
-				) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthorized_action",
-						},
-					});
-				}
-
-				if (parent.updaterId === null) {
-					return null;
-				}
-
-				if (parent.updaterId === currentUserId) {
-					return currentUser;
-				}
-
-				const updaterId = parent.updaterId;
-
-				const existingUser = await ctx.drizzleClient.query.usersTable.findFirst(
-					{
-						where: (fields, operators) => operators.eq(fields.id, updaterId),
-					},
-				);
-
-				// Updater id existing but the associated user not existing is a business logic error and probably means that the corresponding data in the database is in a corrupted state. It must be investigated and fixed as soon as possible to prevent additional data corruption.
-				if (existingUser === undefined) {
-					ctx.log.error(
-						"Postgres select operation returned an empty array for a venue's updater id that isn't null.",
-					);
-
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unexpected",
-						},
-					});
-				}
-
-				return existingUser;
-			},
+			resolve: resolveUpdater,
 			type: User,
 		}),
 	}),

--- a/test/graphql/types/Venue/updater.test.ts
+++ b/test/graphql/types/Venue/updater.test.ts
@@ -1,0 +1,239 @@
+import type { FastifyInstance, FastifyReply } from "fastify";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GraphQLContext } from "~/src/graphql/context";
+import type { Venue as VenueType } from "~/src/graphql/types/Venue/Venue";
+import { resolveUpdater } from "~/src/graphql/types/Venue/updater";
+import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
+
+interface CurrentClient {
+	isAuthenticated: boolean;
+	user?: {
+		id: string;
+		role: string;
+	};
+}
+
+// Create mock Fastify instance
+const mockApp = {
+	addHook: vi.fn(),
+	decorate: vi.fn(),
+	get: vi.fn(),
+	post: vi.fn(),
+} as unknown as FastifyInstance;
+
+// Create mock Fastify reply
+const mockReply = {
+	code: vi.fn(),
+	send: vi.fn(),
+	header: vi.fn(),
+} as unknown as FastifyReply;
+
+const createMockContext = () => {
+	const mockContext = {
+		currentClient: {
+			isAuthenticated: true,
+			user: { id: "user-123", role: "administrator" },
+		} as CurrentClient,
+		drizzleClient: { query: { usersTable: { findFirst: vi.fn() } } },
+		envConfig: { API_BASE_URL: "mock url" },
+		jwt: { sign: vi.fn() },
+		log: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+		app: mockApp,
+		reply: mockReply,
+		__currentQuery: "query { test }", // Mock GraphQL query string
+		minio: { presignedUrl: vi.fn(), putObject: vi.fn(), getObject: vi.fn() },
+	};
+	return mockContext as unknown as GraphQLContext;
+};
+
+describe("Venue Resolver - Updater Field", () => {
+	let ctx: GraphQLContext;
+	let mockVenue: VenueType;
+
+	beforeEach(() => {
+		mockVenue = {
+			id: "venue-123",
+			name: "Test Venue",
+			description: "Test Description",
+			updaterId: "user-123",
+			organizationId: "org-123",
+		} as VenueType;
+
+		ctx = createMockContext();
+	});
+
+	it("should throw unauthenticated error if user is not logged in", async () => {
+		const testCtx = {
+			...ctx,
+			currentClient: {
+				isAuthenticated: false,
+				user: undefined,
+			},
+		} as unknown as GraphQLContext;
+
+		await expect(async () => {
+			await resolveUpdater(mockVenue, {}, testCtx);
+		}).rejects.toThrow(
+			new TalawaGraphQLError({
+				extensions: { code: "unauthenticated" },
+			}),
+		);
+	});
+
+	it("should throw unauthenticated error if current user is not found", async () => {
+		(
+			ctx.drizzleClient.query.usersTable.findFirst as ReturnType<typeof vi.fn>
+		).mockResolvedValue(undefined);
+
+		await expect(async () => {
+			await resolveUpdater(mockVenue, {}, ctx);
+		}).rejects.toThrow(
+			new TalawaGraphQLError({
+				extensions: { code: "unauthenticated" },
+			}),
+		);
+	});
+
+	it("should allow access if user is system administrator", async () => {
+		const mockUser = {
+			id: "user-123",
+			role: "administrator",
+			organizationMembershipsWhereMember: [],
+		};
+		(
+			ctx.drizzleClient.query.usersTable.findFirst as ReturnType<typeof vi.fn>
+		).mockResolvedValueOnce(mockUser);
+
+		const result = await resolveUpdater(mockVenue, {}, ctx);
+		expect(result).toEqual(mockUser);
+	});
+
+	it("should allow access if user is organization administrator", async () => {
+		const mockUser = {
+			id: "user-123",
+			role: "member",
+			organizationMembershipsWhereMember: [
+				{
+					role: "administrator",
+				},
+			],
+		};
+		(
+			ctx.drizzleClient.query.usersTable.findFirst as ReturnType<typeof vi.fn>
+		).mockResolvedValueOnce(mockUser);
+
+		const result = await resolveUpdater(mockVenue, {}, ctx);
+		expect(result).toEqual(mockUser);
+	});
+
+	it("should throw unauthorized error if user is not an administrator", async () => {
+		const mockUser = {
+			id: "user-123",
+			role: "member",
+			organizationMembershipsWhereMember: [
+				{
+					role: "member",
+				},
+			],
+		};
+		(
+			ctx.drizzleClient.query.usersTable.findFirst as ReturnType<typeof vi.fn>
+		).mockResolvedValueOnce(mockUser);
+
+		await expect(async () => {
+			await resolveUpdater(mockVenue, {}, ctx);
+		}).rejects.toThrow(
+			new TalawaGraphQLError({
+				extensions: { code: "unauthorized_action" },
+			}),
+		);
+	});
+
+	it("should return null if venue has no updater", async () => {
+		mockVenue.updaterId = null;
+		const mockUser = {
+			id: "user-123",
+			role: "administrator",
+			organizationMembershipsWhereMember: [],
+		};
+		(
+			ctx.drizzleClient.query.usersTable.findFirst as ReturnType<typeof vi.fn>
+		).mockResolvedValueOnce(mockUser);
+
+		const result = await resolveUpdater(mockVenue, {}, ctx);
+		expect(result).toBeNull();
+	});
+
+	it("should return current user if they are the updater", async () => {
+		const mockUser = {
+			id: "user-123",
+			role: "administrator",
+			organizationMembershipsWhereMember: [],
+		};
+		(
+			ctx.drizzleClient.query.usersTable.findFirst as ReturnType<typeof vi.fn>
+		).mockResolvedValueOnce(mockUser);
+
+		const result = await resolveUpdater(mockVenue, {}, ctx);
+		expect(result).toEqual(mockUser);
+	});
+
+	it("should fetch and return updater if different from current user", async () => {
+		const currentUser = {
+			id: "user-123",
+			role: "administrator",
+			organizationMembershipsWhereMember: [],
+		};
+		const updaterUser = {
+			id: "updater-456",
+			role: "member",
+			organizationMembershipsWhereMember: [],
+		};
+
+		mockVenue.updaterId = "updater-456";
+		(ctx.drizzleClient.query.usersTable.findFirst as ReturnType<typeof vi.fn>)
+			.mockResolvedValueOnce(currentUser)
+			.mockResolvedValueOnce(updaterUser);
+
+		const result = await resolveUpdater(mockVenue, {}, ctx);
+		expect(result).toEqual(updaterUser);
+	});
+
+	it("should handle empty organization memberships array", async () => {
+		const mockUser = {
+			id: "user-123",
+			role: "member",
+			organizationMembershipsWhereMember: [],
+		};
+		(
+			ctx.drizzleClient.query.usersTable.findFirst as ReturnType<typeof vi.fn>
+		).mockResolvedValueOnce(mockUser);
+
+		await expect(async () => {
+			await resolveUpdater(mockVenue, {}, ctx);
+		}).rejects.toThrow(
+			new TalawaGraphQLError({
+				extensions: { code: "unauthorized_action" },
+			}),
+		);
+	});
+
+	it("should handle undefined organization membership role", async () => {
+		const mockUser = {
+			id: "user-123",
+			role: "member",
+			organizationMembershipsWhereMember: [{ role: undefined }],
+		};
+		(
+			ctx.drizzleClient.query.usersTable.findFirst as ReturnType<typeof vi.fn>
+		).mockResolvedValueOnce(mockUser);
+
+		await expect(async () => {
+			await resolveUpdater(mockVenue, {}, ctx);
+		}).rejects.toThrow(
+			new TalawaGraphQLError({
+				extensions: { code: "unauthorized_action" },
+			}),
+		);
+	});
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR will add the test file containing the test cases for `src/graphql/types/Venue/updater.ts`.

**Issue Number:**
#3077

**Snapshots/Videos:**
<img width="889" alt="Screenshot 2025-02-25 at 21 11 16" src="https://github.com/user-attachments/assets/5c7e06c6-f274-4bf5-9d01-743114cf8f96" />


**If relevant, did you update the documentation?**
N/A

**Summary**
**Does this PR introduce a breaking change?**
No

## Checklist

### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [x] I have implemented or provided justification for each non-critical suggestion
- [x] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass


**Other information**
No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the resolver for the venue updater field, enhancing readability while maintaining original logic and error handling.

- **Tests**
  - Implemented a comprehensive suite of unit tests to validate user authentication and authorization scenarios for accessing the venue updater field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->