### PR TITLE
Minor Update -> reset:data

### DIFF
--- a/scripts/dbManagement/addSampleData.ts
+++ b/scripts/dbManagement/addSampleData.ts
@@ -1,11 +1,6 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-	disconnect,
-	ensureAdministratorExists,
-	insertCollections,
-	pingDB,
-} from "./helpers";
+import { disconnect, insertCollections, pingDB } from "./helpers";
 
 type Collection =
 	| "users"
@@ -35,16 +30,6 @@ export async function main(): Promise<void> {
 	} catch (error: unknown) {
 		throw new Error(`Database connection failed: ${error}`);
 	}
-	try {
-		await ensureAdministratorExists();
-		console.log("\x1b[32mSuccess:\x1b[0m Administrator setup complete\n");
-	} catch (error: unknown) {
-		console.error("\nError: Administrator creation failed", error);
-		throw new Error(
-			"\n\x1b[31mAdministrator access may be lost, try reimporting sample DB to restore access\x1b[0m\n",
-		);
-	}
-
 	try {
 		await insertCollections(collections);
 		console.log("\n\x1b[32mSuccess:\x1b[0m Sample Data added to the database");

--- a/scripts/dbManagement/helpers.ts
+++ b/scripts/dbManagement/helpers.ts
@@ -2,7 +2,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import readline from "node:readline";
 import { fileURLToPath } from "node:url";
-import { hash } from "@node-rs/argon2";
 import { sql } from "drizzle-orm";
 import type { AnyPgColumn, PgTable } from "drizzle-orm/pg-core";
 import { drizzle } from "drizzle-orm/postgres-js";
@@ -15,7 +14,6 @@ import {
 	envConfigSchema,
 	envSchemaAjv,
 } from "src/envConfigSchema";
-import { uuidv7 } from "uuidv7";
 
 const envConfig = envSchema<EnvConfig>({
 	ajv: envSchemaAjv,

--- a/scripts/dbManagement/resetData.ts
+++ b/scripts/dbManagement/resetData.ts
@@ -4,7 +4,6 @@ import {
 	askUserToContinue,
 	disconnect,
 	emptyMinioBucket,
-	ensureAdministratorExists,
 	formatDatabase,
 	pingDB,
 } from "./helpers";
@@ -26,6 +25,7 @@ export async function main(): Promise<void> {
 		try {
 			await formatDatabase();
 			console.log("\n\x1b[32mSuccess:\x1b[0m Database formatted successfully");
+			console.log("\x1b[32mSuccess:\x1b[0m Administrator access preserved\n");
 		} catch (error: unknown) {
 			console.error(
 				"\n\x1b[31mError: Database formatting failed\n\x1b[0m",
@@ -41,15 +41,6 @@ export async function main(): Promise<void> {
 			console.error(
 				"\n\x1b[31mError: Bucket formatting failed\n\x1b[0m",
 				error,
-			);
-		}
-		try {
-			await ensureAdministratorExists();
-			console.log("\x1b[32mSuccess:\x1b[0m Administrator access restored\n");
-		} catch (error: unknown) {
-			console.error("\nError: Administrator creation failed", error);
-			console.error(
-				"\n\x1b[31mAdministrator access may be lost, try reformatting DB to restore access\x1b[0m\n",
 			);
 		}
 	} else {

--- a/scripts/dbManagement/resetData.ts
+++ b/scripts/dbManagement/resetData.ts
@@ -25,14 +25,13 @@ export async function main(): Promise<void> {
 		try {
 			await formatDatabase();
 			console.log("\n\x1b[32mSuccess:\x1b[0m Database formatted successfully");
-			console.log("\x1b[32mSuccess:\x1b[0m Administrator access preserved\n");
+			console.log("\x1b[32mSuccess:\x1b[0m Administrator preserved\n");
 		} catch (error: unknown) {
 			console.error(
 				"\n\x1b[31mError: Database formatting failed\n\x1b[0m",
 				error,
 			);
 			console.error("\n\x1b[33mRolled back to previous state\x1b[0m");
-			console.error("\n\x1b[33mPreserving administrator access\x1b[0m");
 		}
 		try {
 			await emptyMinioBucket();

--- a/test/scripts/dbManagement/addSampleData.test.ts
+++ b/test/scripts/dbManagement/addSampleData.test.ts
@@ -38,9 +38,6 @@ suite("addSampleData main function tests", () => {
 			expect.stringContaining("Database connected successfully"),
 		);
 		expect(consoleLogSpy).toHaveBeenCalledWith(
-			expect.stringContaining("Administrator setup complete"),
-		);
-		expect(consoleLogSpy).toHaveBeenCalledWith(
 			expect.stringContaining("Sample Data added to the database"),
 		);
 	});
@@ -57,7 +54,7 @@ suite("addSampleData main function tests", () => {
 	});
 
 	test("should throw an error when insertCollections fails", async () => {
-		// Arrange: pingDB and ensureAdministratorExists succeed, but insertCollections fails.
+		// Arrange: pingDB succeed, but insertCollections fails.
 		vi.spyOn(helpers, "pingDB").mockResolvedValue(true);
 		const errorMsg = "insert error";
 		vi.spyOn(helpers, "insertCollections").mockRejectedValue(

--- a/test/scripts/dbManagement/addSampleData.test.ts
+++ b/test/scripts/dbManagement/addSampleData.test.ts
@@ -10,9 +10,6 @@ suite("addSampleData main function tests", () => {
 	test("should execute all operations successfully", async () => {
 		// Arrange: simulate successful operations.
 		const pingDBSpy = vi.spyOn(helpers, "pingDB").mockResolvedValue(true);
-		const ensureAdminSpy = vi
-			.spyOn(helpers, "ensureAdministratorExists")
-			.mockResolvedValue(true);
 		const insertCollectionsSpy = vi
 			.spyOn(helpers, "insertCollections")
 			.mockResolvedValue(true);
@@ -25,7 +22,6 @@ suite("addSampleData main function tests", () => {
 
 		// Assert: verify that each helper was called as expected.
 		expect(pingDBSpy).toHaveBeenCalled();
-		expect(ensureAdminSpy).toHaveBeenCalled();
 		expect(insertCollectionsSpy).toHaveBeenCalledWith([
 			"users",
 			"organizations",
@@ -60,24 +56,9 @@ suite("addSampleData main function tests", () => {
 		);
 	});
 
-	test("should throw an error when ensureAdministratorExists fails", async () => {
-		// Arrange: pingDB succeeds, but ensureAdministratorExists fails.
-		vi.spyOn(helpers, "pingDB").mockResolvedValue(true);
-		const errorMsg = "admin error";
-		vi.spyOn(helpers, "ensureAdministratorExists").mockRejectedValue(
-			new Error(errorMsg),
-		);
-
-		// Act & Assert: main() should throw the specific error message.
-		await expect(mainModule.main()).rejects.toThrow(
-			"\n\x1b[31mAdministrator access may be lost, try reimporting sample DB to restore access\x1b[0m\n",
-		);
-	});
-
 	test("should throw an error when insertCollections fails", async () => {
 		// Arrange: pingDB and ensureAdministratorExists succeed, but insertCollections fails.
 		vi.spyOn(helpers, "pingDB").mockResolvedValue(true);
-		vi.spyOn(helpers, "ensureAdministratorExists").mockResolvedValue(true);
 		const errorMsg = "insert error";
 		vi.spyOn(helpers, "insertCollections").mockRejectedValue(
 			new Error(errorMsg),

--- a/test/scripts/dbManagement/resetDB.test.ts
+++ b/test/scripts/dbManagement/resetDB.test.ts
@@ -32,7 +32,7 @@ suite("resetData main function tests", () => {
 		);
 	});
 
-	test("should log errors for failing formatDatabase, emptyMinioBucket, and ensureAdministratorExists, but not throw", async () => {
+	test("should log errors for failing formatDatabase, emptyMinioBucket but not throw", async () => {
 		// Arrange: simulate user confirming and pingDB succeeding.
 		vi.spyOn(helpers, "askUserToContinue").mockResolvedValue(true);
 		vi.spyOn(helpers, "pingDB").mockResolvedValue(true);
@@ -66,20 +66,8 @@ suite("resetData main function tests", () => {
 			expect.stringContaining("Rolled back to previous state"),
 		);
 		expect(consoleErrorSpy).toHaveBeenCalledWith(
-			expect.stringContaining("Preserving administrator access"),
-		);
-		expect(consoleErrorSpy).toHaveBeenCalledWith(
 			expect.stringContaining("Error: Bucket formatting failed"),
 			expect.any(Error),
-		);
-		expect(consoleErrorSpy).toHaveBeenCalledWith(
-			expect.stringContaining("Error: Administrator creation failed"),
-			expect.any(Error),
-		);
-		expect(consoleErrorSpy).toHaveBeenCalledWith(
-			expect.stringContaining(
-				"Administrator access may be lost, try reformatting DB to restore access",
-			),
 		);
 	});
 

--- a/test/scripts/dbManagement/resetDB.test.ts
+++ b/test/scripts/dbManagement/resetDB.test.ts
@@ -43,9 +43,6 @@ suite("resetData main function tests", () => {
 		vi.spyOn(helpers, "emptyMinioBucket").mockRejectedValue(
 			new Error("minio error"),
 		);
-		vi.spyOn(helpers, "ensureAdministratorExists").mockRejectedValue(
-			new Error("admin error"),
-		);
 
 		const consoleErrorSpy = vi
 			.spyOn(console, "error")
@@ -92,7 +89,6 @@ suite("resetData main function tests", () => {
 		vi.spyOn(helpers, "pingDB").mockResolvedValue(true);
 		vi.spyOn(helpers, "formatDatabase").mockResolvedValue(true);
 		vi.spyOn(helpers, "emptyMinioBucket").mockResolvedValue(true);
-		vi.spyOn(helpers, "ensureAdministratorExists").mockResolvedValue(true);
 
 		const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
@@ -108,9 +104,6 @@ suite("resetData main function tests", () => {
 		);
 		expect(consoleLogSpy).toHaveBeenCalledWith(
 			expect.stringContaining("Bucket formatted successfully"),
-		);
-		expect(consoleLogSpy).toHaveBeenCalledWith(
-			expect.stringContaining("Administrator access restored"),
 		);
 	});
 });


### PR DESCRIPTION
### Overview

Based on discussion about testing the scripts with xoldd, it came into light that we don't need to reset administrator and recreate (similar to what seedInitialData does), we should ignore this since it remains unaffected from users. 

This PR introduces minor change in script to skip deleting administrator from DB and skip checking or recreation of administrator in both reset:data or add:sample_data since it is absolute that administrator always exist in any situation even after a db reset.

Related Issue: #3214 

### Future Steps
Since we are close to resolving issue regarding conflicts that might occur during parallel vitest, this PR will be followed by adding new tests and correcting old ones to avoid conflict while running in parallel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined database initialization and cleanup by removing explicit administrator setup checks.
	- Adjusted logging to now simply confirm that administrator access is preserved after database operations.
- **Tests**
	- Updated test cases to align with the simplified database processes, eliminating scenarios related to administrator verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->