### PR TITLE
Detachable Server Execution

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -70,7 +70,7 @@
 	"initializeCommand": "/bin/sh -c '[ ! -f .env ] && cp ./envFiles/.env.devcontainer ./.env || true'",
 	"name": "talawa_api",
 	"overrideCommand": true,
-	"postCreateCommand": "sudo chown talawa:talawa ./.pnpm-store ./node_modules && fnm install && fnm use && corepack enable npm && corepack enable && corepack install && pnpm install && pnpm start_development_server",
+	"postCreateCommand": "sudo chown talawa:talawa ./.pnpm-store ./node_modules && fnm install && fnm use && corepack enable npm && corepack enable && corepack install && pnpm install",
 	"postStartCommand": "pnpm install",
 	"remoteUser": "talawa",
 	"service": "api",

--- a/docs/docs/docs/developer-resources/testing.md
+++ b/docs/docs/docs/developer-resources/testing.md
@@ -819,6 +819,7 @@ Sometimes you may want to start all over again from scratch. These steps will re
    ```bash
    devcontainer build --workspace-folder .
    devcontainer up --workspace-folder .
+   docker exec talawa-api-1 /bin/bash -c 'pnpm run start_development_server'
    ```
 
 Now you can resume your development work.

--- a/docs/docs/docs/getting-started/installation.md
+++ b/docs/docs/docs/getting-started/installation.md
@@ -307,18 +307,13 @@ devcontainer build --workspace-folder .
 devcontainer up --workspace-folder .
 ```
 
-12. When the startup is complete, the last line of out put should look like this:
+12. When the container installation is complete, the last line of out put should look like this:
 
 ```
 ...
 ...
 ...
-[19:53:14.113] INFO (166): Server listening at http://127.0.0.1:4000
-[19:53:14.113] INFO (166): Server listening at http://172.23.0.3:4000
-[19:53:14.113] INFO (166): Server listening at http://172.20.0.2:4000
-[19:53:14.113] INFO (166): Server listening at http://172.19.0.3:4000
-[19:53:14.113] INFO (166): Server listening at http://172.21.0.3:4000
-[19:53:14.113] INFO (166): Server listening at http://172.22.0.4:4000
+{"outcome":"success","containerId":"81306766f2aeeb851c8ebb844702d39ad2adc09419508b736ef2ee5a03eb8e34","composeProjectName":"talawa","remoteUser":"talawa","remoteWorkspaceFolder":"/home/talawa/api"}
 ```
 
 All done!
@@ -333,12 +328,19 @@ docker compose down
 
 #### CLI Startup (Development)
 
-After a successful installation, use these commands in sequence to start the dev container.
+After a successful installation, use these commands to start the dev container.
 
-```
-devcontainer build --workspace-folder .
-devcontainer up --workspace-folder .
-```
+1. Attached Mode
+
+   ```
+   docker exec talawa-api-1 /bin/bash -c 'pnpm run start_development_server'
+   ```
+
+2. Detached Mode
+
+   ```
+   docker exec talawa-api-1 /bin/bash -c 'nohup pnpm run start_development_server > /devnull 2>&1 &'
+   ```
 
 #### Importing Sample Data
 

--- a/docs/docs/docs/getting-started/installation.md
+++ b/docs/docs/docs/getting-started/installation.md
@@ -312,7 +312,6 @@ devcontainer up --workspace-folder .
 ```
 ...
 ...
-...
 {"outcome":"success","containerId":"81306766f2aeeb851c8ebb844702d39ad2adc09419508b736ef2ee5a03eb8e34","composeProjectName":"talawa","remoteUser":"talawa","remoteWorkspaceFolder":"/home/talawa/api"}
 ```
 
@@ -339,7 +338,7 @@ After a successful installation, use these commands to start the dev container.
 2. Detached Mode
 
    ```
-   docker exec talawa-api-1 /bin/bash -c 'nohup pnpm run start_development_server > /devnull 2>&1 &'
+   docker exec talawa-api-1 /bin/bash -c 'nohup pnpm run start_development_server > /dev/null 2>&1 &'
    ```
 
 #### Importing Sample Data


### PR DESCRIPTION
### Overview

Depricating pnpm run start_development_server from postCreateCommand to gain complete control how server is start.
This allows us to start server inside docker and detach cli from it safely.

Recommended cron job:

`cd /home/talawa-api/talawa-api && docker compose down --rmi all --volumes && docker compose down --rmi all --volumes && git checkout --force develop-postgres && git fetch upstream && git reset upstream/develop-postgres --hard && rm -rf node_modules && pnpm install && cp -f envFiles/.env.devcontainer .env && sed -i "s|MAPPED_PORT=80|MAPPED_PORT=8080|g" .env && sed -i "s|MAPPED_PORT=443|MAPPED_PORT=8443|g" .env && devcontainer build --workspace-folder . && devcontainer up --workspace-folder . && docker exec talawa-api-1 /bin/bash -c 'nohup pnpm run start_development_server > /dev/null 2>&1 &'`

For sample data it remains same

### Note: **This ensures successful execution provided cron has access to crud operation and deamon/pnpm, also docker service is running**

### Screenshots

<img width="1383" alt="image" src="https://github.com/user-attachments/assets/6a7b558f-9aea-498f-bd01-e1d721670afa" />

This was run with above command , we can notice that in the end it does not struck to server listening but that in run inside docker in the back and detached safely 

<img width="1383" alt="image" src="https://github.com/user-attachments/assets/69b3e454-06e0-489a-b520-b1cfbbd2a8e5" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the environment setup process by removing the automatic start of the development server, streamlining post-setup tasks.

- **Documentation**
  - Enhanced the developer guides with clearer instructions for resetting the Docker environment.
  - Provided revised directions detailing two distinct modes for launching the development container and a more informative installation output format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->