### PR TITLE
addedSupport for edit of AdvertisementAttachment

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -2051,6 +2051,9 @@ input MutationSignUpInput {
 
 """"""
 input MutationUpdateAdvertisementInput {
+  """Attachments of the advertisement."""
+  attachments: [Upload!]
+
   """Custom information about the advertisement."""
   description: String
 

--- a/src/graphql/types/Mutation/updateAdvertisement.ts
+++ b/src/graphql/types/Mutation/updateAdvertisement.ts
@@ -1,5 +1,9 @@
 import { eq } from "drizzle-orm";
+import type { FileUpload } from "graphql-upload-minimal";
+import { ulid } from "ulidx";
 import { z } from "zod";
+import { advertisementAttachmentMimeTypeEnum } from "~/src/drizzle/enums/advertisementAttachmentMimeType";
+import { advertisementAttachmentsTable } from "~/src/drizzle/schema";
 import { advertisementsTable } from "~/src/drizzle/tables/advertisements";
 import { builder } from "~/src/graphql/builder";
 import {
@@ -10,7 +14,41 @@ import { Advertisement } from "~/src/graphql/types/Advertisement/Advertisement";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 
 const mutationUpdateAdvertisementArgumentsSchema = z.object({
-	input: mutationUpdateAdvertisementInputSchema,
+	input: mutationUpdateAdvertisementInputSchema.transform(async (arg, ctx) => {
+		let attachments:
+			| (FileUpload & {
+					mimetype: z.infer<typeof advertisementAttachmentMimeTypeEnum>;
+			  })[]
+			| undefined;
+		if (arg.attachments !== undefined) {
+			const rawAttachments = await Promise.all(arg.attachments);
+			const { data, error, success } = advertisementAttachmentMimeTypeEnum
+				.array()
+				.safeParse(rawAttachments.map((attachment) => attachment.mimetype));
+
+			if (!success) {
+				for (const issue of error.issues) {
+					if (typeof issue.path[0] === "number") {
+						ctx.addIssue({
+							code: "custom",
+							path: ["attachments", issue.path[0]],
+							message: `Mime type "${rawAttachments[issue.path[0]]?.mimetype}" is not allowed.`,
+						});
+					}
+				}
+			} else {
+				attachments = rawAttachments.map((attachment, index) =>
+					Object.assign(attachment, {
+						mimetype: data[index],
+					}),
+				);
+			}
+		}
+		return {
+			...arg,
+			attachments,
+		};
+	}),
 });
 
 builder.mutationField("updateAdvertisement", (t) =>
@@ -36,7 +74,7 @@ builder.mutationField("updateAdvertisement", (t) =>
 				data: parsedArgs,
 				error,
 				success,
-			} = mutationUpdateAdvertisementArgumentsSchema.safeParse(args);
+			} = await mutationUpdateAdvertisementArgumentsSchema.safeParseAsync(args);
 
 			if (!success) {
 				throw new TalawaGraphQLError({
@@ -51,7 +89,6 @@ builder.mutationField("updateAdvertisement", (t) =>
 			}
 
 			const currentUserId = ctx.currentClient.user.id;
-
 			const [currentUser, existingAdvertisement] = await Promise.all([
 				ctx.drizzleClient.query.usersTable.findFirst({
 					columns: {
@@ -196,7 +233,6 @@ builder.mutationField("updateAdvertisement", (t) =>
 					},
 				});
 			}
-
 			const [updatedAdvertisement] = await ctx.drizzleClient
 				.update(advertisementsTable)
 				.set({
@@ -210,8 +246,10 @@ builder.mutationField("updateAdvertisement", (t) =>
 				.where(eq(advertisementsTable.id, parsedArgs.input.id))
 				.returning();
 
-			// Updated advertisement not being returned means that either it was deleted or its `id` column was changed by external entities before this update operation could take place.
 			if (updatedAdvertisement === undefined) {
+				ctx.log.error(
+					"Postgres insert operation unexpectedly returned an empty array instead of throwing an error.",
+				);
 				throw new TalawaGraphQLError({
 					extensions: {
 						code: "unexpected",
@@ -219,9 +257,40 @@ builder.mutationField("updateAdvertisement", (t) =>
 				});
 			}
 
-			return Object.assign(updatedAdvertisement, {
-				attachments: existingAdvertisement.attachmentsWhereAdvertisement,
-			});
+			if (parsedArgs.input.attachments !== undefined) {
+				const attachments = parsedArgs.input.attachments;
+				const updatedAdvertisementAttachments = await ctx.drizzleClient
+					.insert(advertisementAttachmentsTable)
+					.values(
+						attachments.map((attachment) => ({
+							advertisementId: updatedAdvertisement.id,
+							creatorId: currentUserId,
+							mimeType: attachment.mimetype,
+							name: ulid(),
+						})),
+					)
+					.onConflictDoNothing()
+					.returning();
+
+				if (Array.isArray(updatedAdvertisementAttachments)) {
+					await Promise.all(
+						updatedAdvertisementAttachments.map((attachment, index) => {
+							if (attachments[index] !== undefined) {
+								return ctx.minio.client.putObject(
+									ctx.minio.bucketName,
+									attachment.name,
+									attachments[index].createReadStream(),
+									undefined,
+									{
+										"content-type": attachments[index].mimetype,
+									},
+								);
+							}
+						}),
+					);
+				}
+			}
+			return updatedAdvertisement as Advertisement;
 		},
 		type: Advertisement,
 	}),


### PR DESCRIPTION
**What kind of change does this PR introduce?**

refactoring

**Issue Number:**

In response to updatedPR #3293 

**Snapshots/Videos:**
https://www.loom.com/share/7988c722116945b892a7f7ddf8cd174b?sid=fed21822-8831-41ce-9637-707ba51a4a61

**If relevant, did you update the documentation?**
No

**Summary**

Earlier we were not able to edit advertisement due to no minio client in updateAdvertisment.ts
I added the necessary changes for people to edit advertsement.

**Does this PR introduce a breaking change?**

No

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Advertisement updates now support multiple file attachments, allowing users to include several files during the update process.
  - The file upload experience has been enhanced with improved validations to ensure only supported file types are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->