### PR TITLE
Organizations Access

### DIFF
--- a/src/graphql/types/Query/organizations.ts
+++ b/src/graphql/types/Query/organizations.ts
@@ -7,7 +7,7 @@ import type {
 	ImplicitMercuriusContext,
 } from "~/src/graphql/context";
 import { Organization } from "~/src/graphql/types/Organization/Organization";
-import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
+
 // Define type for organization model
 type OrganizationType = InferSelectModel<typeof organizationsTable>;
 
@@ -27,13 +27,6 @@ export const resolveOrganizations = async (
 	args: OrganizationsArgs,
 	ctx: ContextType,
 ): Promise<OrganizationType[]> => {
-	if (!ctx.currentClient.isAuthenticated) {
-		throw new TalawaGraphQLError({
-			extensions: {
-				code: "unauthenticated",
-			},
-		});
-	}
 	const { filter } = args;
 	try {
 		const organizations =

--- a/test/graphql/types/Query/organizations.test.ts
+++ b/test/graphql/types/Query/organizations.test.ts
@@ -5,7 +5,6 @@ import type {
 	ImplicitMercuriusContext,
 } from "~/src/graphql/context";
 import { resolveOrganizations } from "~/src/graphql/types/Query/organizations";
-import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 
 type ContextType = ExplicitGraphQLContext & ImplicitMercuriusContext;
 
@@ -30,7 +29,7 @@ describe("resolveOrganizations", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
-	
+
 	test("returns organizations array if user is not authenticated", async () => {
 		const unauthenticatedCtx = {
 			...baseMockCtx,

--- a/test/graphql/types/Query/organizations.test.ts
+++ b/test/graphql/types/Query/organizations.test.ts
@@ -31,15 +31,33 @@ describe("resolveOrganizations", () => {
 		vi.clearAllMocks();
 	});
 
-	test("throws an unauthenticated error if user is not authenticated", async () => {
+	test("do not throws an unauthenticated error if user is not authenticated", async () => {
 		const unauthenticatedCtx = {
 			...baseMockCtx,
 			currentClient: { isAuthenticated: false },
 		} as unknown as ContextType;
 
-		await expect(
-			resolveOrganizations(null, { filter: null }, unauthenticatedCtx),
-		).rejects.toThrow(TalawaGraphQLError);
+		const orgs = [
+			{ id: "org1", name: "Organization 1" },
+			{ id: "org2", name: "Organization 2" },
+		];
+		mockDrizzleClient.query.organizationsTable.findMany.mockResolvedValue(orgs);
+
+		const result = await resolveOrganizations(
+			null,
+			{ filter: null },
+			unauthenticatedCtx,
+		);
+		expect(result).toEqual(orgs);
+
+		expect(
+			mockDrizzleClient.query.organizationsTable.findMany,
+		).toHaveBeenCalledWith(
+			expect.objectContaining({
+				limit: 20,
+				offset: 0,
+			}),
+		);
 	});
 
 	test("returns organizations array on successful query", async () => {

--- a/test/graphql/types/Query/organizations.test.ts
+++ b/test/graphql/types/Query/organizations.test.ts
@@ -30,8 +30,8 @@ describe("resolveOrganizations", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
-
-	test("do not throws an unauthenticated error if user is not authenticated", async () => {
+	
+	test("returns organizations array if user is not authenticated", async () => {
 		const unauthenticatedCtx = {
 			...baseMockCtx,
 			currentClient: { isAuthenticated: false },


### PR DESCRIPTION
### Overview

This PR ensures only details about all available organizations are available without authentication.

### Working Query

```
query AllOrganizations($filter: String) {
    organizations(filter: $filter) {
      id
      name
      addressLine1
      description
      avatarURL
    }
}
```

Note: The above query is already available in admin at 
<img width="426" alt="image" src="https://github.com/user-attachments/assets/6ea8b8e4-a163-44f8-a798-51837847ab2a" />


### Solution implemented

- Removed check for unauthorized ctx to query organizations.
- Modified linked test cases