### PR TITLE
Test: Added tests for src/graphql/types/Event/createdAt.ts

### DIFF
--- a/src/graphql/types/Event/createdAt.ts
+++ b/src/graphql/types/Event/createdAt.ts
@@ -1,62 +1,69 @@
+import type { GraphQLContext } from "~/src/graphql/context";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
-import { Event } from "./Event";
+import { Event, type Event as EventType } from "./Event";
+
+export const eventCreatedAtResolver = async (
+	parent: EventType,
+	_args: Record<string, never>,
+	ctx: GraphQLContext,
+) => {
+	if (!ctx.currentClient.isAuthenticated) {
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "unauthenticated",
+			},
+		});
+	}
+
+	const currentUserId = ctx.currentClient.user.id;
+
+	const currentUser = await ctx.drizzleClient.query.usersTable.findFirst({
+		columns: {
+			role: true,
+		},
+		with: {
+			organizationMembershipsWhereMember: {
+				columns: {
+					role: true,
+				},
+				where: (fields, operators) =>
+					operators.eq(fields.organizationId, parent.organizationId),
+			},
+		},
+		where: (fields, operators) => operators.eq(fields.id, currentUserId),
+	});
+
+	if (currentUser === undefined) {
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "unauthenticated",
+			},
+		});
+	}
+
+	const currentUserOrganizationMembership =
+		currentUser.organizationMembershipsWhereMember[0];
+
+	if (
+		currentUser.role !== "administrator" &&
+		(currentUserOrganizationMembership === undefined ||
+			currentUserOrganizationMembership.role !== "administrator")
+	) {
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "unauthorized_action",
+			},
+		});
+	}
+
+	return parent.createdAt;
+};
 
 Event.implement({
 	fields: (t) => ({
 		createdAt: t.field({
 			description: "Date time at the time the event was created.",
-			resolve: async (parent, _args, ctx) => {
-				if (!ctx.currentClient.isAuthenticated) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthenticated",
-						},
-					});
-				}
-
-				const currentUserId = ctx.currentClient.user.id;
-
-				const currentUser = await ctx.drizzleClient.query.usersTable.findFirst({
-					columns: {
-						role: true,
-					},
-					with: {
-						organizationMembershipsWhereMember: {
-							columns: {
-								role: true,
-							},
-							where: (fields, operators) =>
-								operators.eq(fields.organizationId, parent.organizationId),
-						},
-					},
-					where: (fields, operators) => operators.eq(fields.id, currentUserId),
-				});
-
-				if (currentUser === undefined) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthenticated",
-						},
-					});
-				}
-
-				const currentUserOrganizationMembership =
-					currentUser.organizationMembershipsWhereMember[0];
-
-				if (
-					currentUser.role !== "administrator" &&
-					(currentUserOrganizationMembership === undefined ||
-						currentUserOrganizationMembership.role !== "administrator")
-				) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthorized_action",
-						},
-					});
-				}
-
-				return parent.createdAt;
-			},
+			resolve: eventCreatedAtResolver,
 			type: "DateTime",
 		}),
 	}),

--- a/test/graphql/types/Event/createdAt.test.ts
+++ b/test/graphql/types/Event/createdAt.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GraphQLContext } from "~/src/graphql/context";
+import type { Event as EventType } from "~/src/graphql/types/Event/Event";
+import { eventCreatedAtResolver } from "~/src/graphql/types/Event/createdAt";
+import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
+import "~/src/graphql/types/Event/Event";
+import { createMockGraphQLContext } from "test/_Mocks_/mockContextCreator/mockContextCreator";
+
+type MockUser = {
+	id: string;
+	role: string;
+	organizationMembershipsWhereMember: Array<{
+		role: string;
+		organizationId: string;
+	}>;
+};
+
+describe("Event CreatedAt Resolver Tests", () => {
+	let ctx: GraphQLContext;
+	let mockEvent: EventType;
+	let mocks: ReturnType<typeof createMockGraphQLContext>["mocks"];
+
+	beforeEach(() => {
+		const { context, mocks: newMocks } = createMockGraphQLContext(
+			true,
+			"user-123",
+		);
+		ctx = context;
+		mocks = newMocks;
+		mockEvent = {
+			id: "550e8400-e29b-41d4-a716-446655440000",
+			name: "Annual General Meeting",
+			description: "Discussion on yearly progress and future goals.",
+			createdAt: new Date("2024-02-01T10:00:00Z"),
+			updatedAt: new Date("2024-02-05T12:00:00Z"),
+			startAt: new Date("2024-03-10T09:00:00Z"),
+			endAt: new Date("2024-03-10T12:00:00Z"),
+			creatorId: "123e4567-e89b-12d3-a456-426614174000",
+			updaterId: "223e4567-e89b-12d3-a456-426614174001",
+			organizationId: "789e1234-e89b-12d3-a456-426614174002",
+		} as EventType;
+	});
+
+	it("should throw unauthenticated error if user is not logged in", async () => {
+		ctx.currentClient.isAuthenticated = false;
+		await expect(eventCreatedAtResolver(mockEvent, {}, ctx)).rejects.toThrow(
+			new TalawaGraphQLError({ extensions: { code: "unauthenticated" } }),
+		);
+	});
+
+	it("should throw unauthenticated error if current user does not exist", async () => {
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue(undefined);
+		await expect(eventCreatedAtResolver(mockEvent, {}, ctx)).rejects.toThrow(
+			new TalawaGraphQLError({ extensions: { code: "unauthenticated" } }),
+		);
+	});
+
+	it("should throw unauthorized_action error if user is not an administrator", async () => {
+		const mockUserData: MockUser = {
+			id: "user-123",
+			role: "member",
+			organizationMembershipsWhereMember: [
+				{ role: "member", organizationId: mockEvent.organizationId },
+			],
+		};
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue(
+			mockUserData,
+		);
+		await expect(eventCreatedAtResolver(mockEvent, {}, ctx)).rejects.toThrow(
+			new TalawaGraphQLError({ extensions: { code: "unauthorized_action" } }),
+		);
+	});
+
+	it("should return createdAt if user is system administrator", async () => {
+		const mockUserData: MockUser = {
+			id: "user-123",
+			role: "administrator",
+			organizationMembershipsWhereMember: [],
+		};
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue(
+			mockUserData,
+		);
+		const result = await eventCreatedAtResolver(mockEvent, {}, ctx);
+		expect(result).toBe(mockEvent.createdAt);
+	});
+
+	it("should return createdAt if user is organization administrator", async () => {
+		const mockUserData: MockUser = {
+			id: "user-123",
+			role: "member",
+			organizationMembershipsWhereMember: [
+				{ role: "administrator", organizationId: mockEvent.organizationId },
+			],
+		};
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue(
+			mockUserData,
+		);
+		const result = await eventCreatedAtResolver(mockEvent, {}, ctx);
+		expect(result).toBe(mockEvent.createdAt);
+	});
+
+	it("should handle database query failures", async () => {
+		mocks.drizzleClient.query.usersTable.findFirst.mockRejectedValue(
+			new Error("Database error"),
+		);
+		await expect(eventCreatedAtResolver(mockEvent, {}, ctx)).rejects.toThrow(
+			new Error("Database error"),
+		);
+	});
+
+	it("should query the database with the correct organizationId filter", async () => {
+		const mockUserData: MockUser = {
+			id: "user-123",
+			role: "member",
+			organizationMembershipsWhereMember: [
+				{ role: "administrator", organizationId: mockEvent.organizationId },
+			],
+		};
+
+		// Mock implementation to verify if organizationId filter is used
+		(
+			mocks.drizzleClient.query.usersTable.findFirst as ReturnType<typeof vi.fn>
+		).mockImplementation(({ with: withClause }) => {
+			expect(withClause).toBeDefined();
+
+			const mockFields = {
+				organizationId: "550e8400-e29b-41d4-a716-446655440000",
+			};
+			const mockOperators = { eq: vi.fn((a, b) => ({ [a]: b })) };
+
+			// Verify the inner where clause inside withClause
+			const innerWhereResult =
+				withClause.organizationMembershipsWhereMember.where(
+					mockFields,
+					mockOperators,
+				);
+			expect(innerWhereResult).toEqual(
+				expect.objectContaining({
+					[mockFields.organizationId]: mockEvent.organizationId, // Ensure organizationId filter is applied
+				}),
+			);
+			return Promise.resolve(mockUserData);
+		});
+
+		const result = await eventCreatedAtResolver(mockEvent, {}, ctx);
+		expect(result).toEqual(mockEvent.createdAt);
+	});
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR will add the test file for `src/graphql/types/Event/createdAt.ts`
Code coverage is also 100%
No `/* istanbul ignore */` or equivalent statements are present

**Issue Number:**
Fixes #3088

**Snapshots/Videos:**
<img width="919" alt="Screenshot 2025-03-17 at 22 45 45" src="https://github.com/user-attachments/assets/879d8913-e936-498a-8854-3fce9c40a4c5" />


**If relevant, did you update the documentation?**
N/A

**Summary**
**Does this PR introduce a breaking change?**
No

## Checklist

### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [x] I have implemented or provided justification for each non-critical suggestion
- [x] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass


**Other information**
N/A

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved event data handling by streamlining authentication and permission checks, ensuring reliable access to event details.
  
- **Tests**
  - Added comprehensive automated tests to verify robust error handling for both unauthorized and properly authorized access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->