### PR TITLE
fixed org query for register page #3389

### DIFF
--- a/src/resolvers/Query/organizations.ts
+++ b/src/resolvers/Query/organizations.ts
@@ -2,7 +2,7 @@
  * Resolver for querying organizations.
  * @returns Array of organization objects
  */
-import { QueryResolvers } from "../../types/generatedGraphQLTypes";
+import type { QueryResolvers } from "../../types/generatedGraphQLTypes";
 import { Organization } from "../../models";
 import { errors } from "../../libraries";
 import { ORGANIZATION_NOT_FOUND_ERROR } from "../../constants";
@@ -28,6 +28,6 @@ export const organizations: QueryResolvers["organizations"] = async (_parent, ar
     .sort(sort)
     .select("name description image _id")
     .lean();
-  await cacheOrganizations(orgs);
-  return orgs;
+    await cacheOrganizations(orgs);
+    return orgs;
 };

--- a/src/resolvers/Query/organizations.ts
+++ b/src/resolvers/Query/organizations.ts
@@ -1,3 +1,7 @@
+/**
+ * Resolver for querying organizations.
+ * @returns Array of organization objects
+ */
 import { QueryResolvers } from "../../types/generatedGraphQLTypes";
 import { Organization } from "../../models";
 import { errors } from "../../libraries";
@@ -6,7 +10,7 @@ import { getSort } from "./helperFunctions/getSort";
 import { cacheOrganizations } from "../../services/OrganizationCache/cacheOrganizations";
 import { findOrganizationsInCache } from "../../services/OrganizationCache/findOrganizationsInCache";
 
-export const organizations = async (_parent, args) => {
+export const organizations: QueryResolvers["organizations"] = async (_parent, args) => {
   const sort = getSort(args.orderBy);
   if (args.id) {
     const cached = await findOrganizationsInCache([args.id]);

--- a/src/resolvers/Query/organizations.ts
+++ b/src/resolvers/Query/organizations.ts
@@ -1,53 +1,29 @@
-import type { QueryResolvers } from "../../types/generatedGraphQLTypes";
+import { QueryResolvers } from "../../types/generatedGraphQLTypes";
 import { Organization } from "../../models";
 import { errors } from "../../libraries";
 import { ORGANIZATION_NOT_FOUND_ERROR } from "../../constants";
 import { getSort } from "./helperFunctions/getSort";
 import { cacheOrganizations } from "../../services/OrganizationCache/cacheOrganizations";
 import { findOrganizationsInCache } from "../../services/OrganizationCache/findOrganizationsInCache";
-/**
- * If a 'id' is specified, this query will return an organisation;
- * otherwise, it will return all organisations with a size of limit 100.
- * @param _parent-
- * @param args - An object containing `orderBy` and `id` of the Organization.
- * @returns The organization if valid `id` is provided else return organizations with size limit 100.
- * @remarks `id` in the args is optional.
- */
-export const organizations: QueryResolvers["organizations"] = async (
-  _parent,
-  args,
-) => {
+
+export const organizations = async (_parent, args) => {
   const sort = getSort(args.orderBy);
-
-  let organizationFound;
   if (args.id) {
-    const organizationFoundInCache = await findOrganizationsInCache([args.id]);
-
-    if (!organizationFoundInCache.includes(null)) {
-      return organizationFoundInCache;
-    }
-
-    organizationFound = await Organization.find({
-      _id: args.id,
-    })
+    const cached = await findOrganizationsInCache([args.id]);
+    if (!cached.includes(null)) return cached;
+    const org = await Organization.find({ _id: args.id })
       .sort(sort)
+      .select("name description image _id")
       .lean();
-
-    await cacheOrganizations(organizationFound);
-
-    if (!organizationFound[0]) {
-      throw new errors.NotFoundError(
-        ORGANIZATION_NOT_FOUND_ERROR.DESC,
-        ORGANIZATION_NOT_FOUND_ERROR.CODE,
-        ORGANIZATION_NOT_FOUND_ERROR.PARAM,
-      );
-    }
-
-    return organizationFound;
-  } else {
-    organizationFound = await Organization.find().sort(sort).limit(100).lean();
-    await cacheOrganizations(organizationFound);
+    await cacheOrganizations(org);
+    if (!org[0]) throw new errors.NotFoundError(ORGANIZATION_NOT_FOUND_ERROR.DESC, ORGANIZATION_NOT_FOUND_ERROR.CODE, ORGANIZATION_NOT_FOUND_ERROR.PARAM);
+    return org;
   }
-
-  return organizationFound;
+  const filter = args.filter || "";
+  const orgs = await Organization.find({ name: { $regex: filter, $options: "i" } })
+    .sort(sort)
+    .select("name description image _id")
+    .lean();
+  await cacheOrganizations(orgs);
+  return orgs;
 };


### PR DESCRIPTION
Hey everyone, tweaked the org query so it works for people not signed in, like on the register page. Added a filter for names and kept it to basic stuff (name, desc, image, id). Should fix that empty page issue now, took a bit to sort out but looks good!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added flexible filtering for organization queries, enabling users to search organizations by name using regular expressions.

- **Refactor**
  - Streamlined the organization retrieval process by simplifying the caching and query logic, reducing unnecessary steps and complexity.
  
- **Bug Fixes**
  - Improved error handling for non-existent organizations, now throwing a `NotFoundError` when an organization is not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->