### PR TITLE
Port Check script doc

### DIFF
--- a/docs/docs/docs/developer-resources/troubleshooting.md
+++ b/docs/docs/docs/developer-resources/troubleshooting.md
@@ -49,6 +49,14 @@ You can get information on each of the headings by using filters like this:
 1. PORTS: `docker ps --format '{{.Ports}}'`
 1. NAMES: `docker ps --format '{{.Names}}'`
 
+### Checking Running Ports
+
+To quickly check which application ports are running and which are not, you can use the provided port check script:
+
+```bash
+bash scripts/port-check/port.sh
+```
+
 ### Accessing The Container CLI
 
 You can access the CLI of each container using the docker interactive TTY mode flags `-it`.


### PR DESCRIPTION

**What kind of change does this PR introduce?**

 feature

**Issue Number:**

Fixes #3588

**Snapshots/Videos:**
<img width="1215" height="462" alt="image" src="https://github.com/user-attachments/assets/86d5363e-4a48-4df8-88d1-870f58e1f2c3" />

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**
This PR updates the documentation to cover the newly added port-check.sh script.

The script allows contributors to:

- Check a list of required ports (configurable at the top of the script).
- Print out which ports are in use and their corresponding process/container.
- Exit with a non-zero status if any required port is occupied (for use as a pre-hook).
- This helps new contributors and users avoid common port conflicts during setup.

**Does this PR introduce a breaking change?**
No

## Checklist

### CodeRabbit AI Review
- [X] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [X] I have implemented or provided justification for each non-critical suggestion
- [X] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [X] I have written tests for all new changes/features
- [X] I have verified that test coverage meets or exceeds 95%
- [X] I have run the test suite locally and all tests pass


**Other information**
None

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes