### PR TITLE
Fix: Atomic Event Registration and EventAttendance Type #3569

### DIFF
--- a/src/graphql/types/EventAttendance/EventAttendance.ts
+++ b/src/graphql/types/EventAttendance/EventAttendance.ts
@@ -1,0 +1,45 @@
+import type { eventAttendancesTable } from "~/src/drizzle/tables/eventAttendances";
+import { builder } from "~/src/graphql/builder";
+
+export type EventAttendanceType = typeof eventAttendancesTable.$inferSelect;
+
+export const EventAttendance =
+	builder.objectRef<EventAttendanceType>("EventAttendance");
+
+EventAttendance.implement({
+	description: "Represents an event attendance record.",
+	fields: (t) => ({
+		eventId: t.string({
+			description: "Event ID",
+			resolve: (attendance) => attendance.eventId,
+		}),
+		attendeeId: t.string({
+			description: "User ID of attendee",
+			resolve: (attendance) => attendance.attendeeId,
+		}),
+		creatorId: t.string({
+			description: "User ID of creator",
+			resolve: (attendance) => attendance.creatorId,
+		}),
+		createdAt: t.field({
+			type: "DateTime",
+			resolve: (obj) => obj.createdAt,
+		}),
+		updatedAt: t.field({
+			type: "DateTime",
+			nullable: true,
+			resolve: (obj) => obj.updatedAt,
+		}),
+		checkInAt: t.field({
+			type: "DateTime",
+			nullable: true,
+			resolve: (obj) => obj.checkInAt,
+		}),
+		checkOutAt: t.field({
+			type: "DateTime",
+			nullable: true,
+			resolve: (obj) => obj.checkOutAt,
+		}),
+		updaterId: t.exposeID("updaterId", { nullable: true }),
+	}),
+});

--- a/src/graphql/types/Mutation/registerForEvent.ts
+++ b/src/graphql/types/Mutation/registerForEvent.ts
@@ -1,0 +1,111 @@
+import { sql } from "drizzle-orm";
+import { eventAttendancesTable } from "../../../drizzle/tables/eventAttendances";
+// import { eventsTable } from "../../../drizzle/tables/events"; // removed unused import
+// import { z } from "zod";
+import { builder } from "../../builder";
+import { EventAttendance } from "../EventAttendance/EventAttendance";
+import { TalawaGraphQLError } from "../../../utilities/TalawaGraphQLError";
+
+const RegisterForEventInput = builder.inputType("RegisterForEventInput", {
+	fields: (t) => ({
+		eventId: t.string({
+			required: true,
+			description: "ID of the event to register for",
+		}),
+	}),
+});
+
+builder.mutationField("registerForEvent", (t) =>
+	t.field({
+		type: EventAttendance,
+		args: {
+			input: t.arg({ type: RegisterForEventInput, required: true }),
+		},
+		description: "Register the current user for an event, enforcing capacity.",
+		resolve: async (_parent, args, ctx) => {
+			if (!ctx.currentClient.isAuthenticated) {
+				throw new TalawaGraphQLError({
+					extensions: { code: "unauthenticated" },
+				});
+			}
+			const userId = ctx.currentClient.user.id;
+			const eventId = args.input?.eventId;
+			if (!eventId) {
+				throw new TalawaGraphQLError({
+					extensions: {
+						code: "invalid_arguments",
+						message: "Missing eventId",
+						issues: [{ argumentPath: ["eventId"], message: "Missing eventId" }],
+					},
+				});
+			}
+			return await ctx.drizzleClient.transaction(async (tx) => {
+				// Lock the event row for update to prevent race conditions
+				const [eventRaw] = await tx.execute(
+					sql`SELECT * FROM events WHERE id = ${eventId} FOR UPDATE`,
+				);
+				const event = eventRaw as
+					| { isRegisterable: boolean; capacity: number }
+					| undefined;
+				if (!event) {
+					throw new TalawaGraphQLError({
+						extensions: {
+							code: "arguments_associated_resources_not_found",
+							issues: [{ argumentPath: ["eventId"] }],
+							message: "Event not found",
+						},
+					});
+				}
+				if (!event.isRegisterable) {
+					throw new TalawaGraphQLError({
+						extensions: {
+							code: "forbidden_action",
+							message: "Event is not open for registration",
+						},
+					});
+				}
+				// Count current attendances
+				const countResult = await tx.execute(
+					sql`SELECT COUNT(*)::int AS count FROM event_attendances WHERE event_id = ${eventId}`,
+				);
+				const rawCount =
+					Array.isArray(countResult) &&
+					countResult.length > 0 &&
+					typeof countResult[0]?.count !== "undefined"
+						? countResult[0].count
+						: 0;
+				const count = Number(rawCount);
+				if (count >= Number(event.capacity)) {
+					throw new TalawaGraphQLError({
+						extensions: {
+							code: "forbidden_action",
+							message: "Event is full. No seats available.",
+						},
+					});
+				}
+				// Check if user already registered
+				const [existing] = await tx
+					.select()
+					.from(eventAttendancesTable)
+					.where(
+						({ eventId: eid, attendeeId }) =>
+							sql`${eid} = ${eventId} AND ${attendeeId} = ${userId}`,
+					);
+				if (existing) {
+					throw new TalawaGraphQLError({
+						extensions: {
+							code: "forbidden_action",
+							message: "User already registered for this event",
+						},
+					});
+				}
+				// Register user
+				const [attendance] = await tx
+					.insert(eventAttendancesTable)
+					.values({ eventId, attendeeId: userId, creatorId: userId })
+					.returning();
+				return attendance ?? null;
+			});
+		},
+	}),
+);


### PR DESCRIPTION
Implements atomic event registration logic in registerForEvent.ts to strictly enforce event capacity and prevent race conditions during concurrent registrations.
Defines and exports the EventAttendance GraphQL object type for correct mutation output and schema consistency.
Updates import paths to use relative references for compatibility.
Applies Biome formatting and code quality standards to both files.     fixes: #3569 