### PR TITLE
Increased test coverage of `src/graphql/types/Advertisement/createdAt.ts`

### DIFF
--- a/src/graphql/types/Advertisement/createdAt.ts
+++ b/src/graphql/types/Advertisement/createdAt.ts
@@ -48,11 +48,12 @@ export const createdAtResolver = async (
 	const currentUserOrganizationMembership =
 		currentUser.organizationMembershipsWhereMember[0];
 
-	if (
-		currentUser.role !== "administrator" &&
-		(currentUserOrganizationMembership === undefined ||
-			currentUserOrganizationMembership.role !== "administrator")
-	) {
+	const isSystemAdmin = currentUser.role === "administrator";
+	const isOrgAdmin =
+		currentUserOrganizationMembership !== undefined &&
+		currentUserOrganizationMembership.role === "administrator";
+
+	if (!isSystemAdmin && !isOrgAdmin) {
 		throw new TalawaGraphQLError({
 			extensions: {
 				code: "unauthorized_action",

--- a/test/graphql/types/Advertisement/createdAt.test.ts
+++ b/test/graphql/types/Advertisement/createdAt.test.ts
@@ -40,8 +40,7 @@ suite("Advertisement field createdAt - Unit Tests", () => {
 
 		const mockContext: MockContext = {
 			currentClient: {
-				isAuthenticated: false, // Ensure user ID might also be missing
-				// user: undefined // Explicitly undefined or just missing
+				isAuthenticated: false,
 			},
 			drizzleClient: {
 				query: {},


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

refactor + tests: Extracted and exported the `createdAt` resolver for Advertisement and added focused unit tests.

**Issue Number:**

Fixes #3086 

**Snapshots/Videos:**

No UI changes . Behavior is unchanged.

<img width="967" height="80" alt="image" src="https://github.com/user-attachments/assets/54c1ef7f-4a77-43dc-9a8f-ac47aee7193d" />
**If relevant, did you update the documentation?**

No documentation changes required; change is internal and non-breaking.

**Summary**

**Motivation:**

The `createdAt` field resolver for Advertisement was defined inline inside the type implementation, which made it hard to unit-test defensive paths (authentication and authorization checks).  
Integration tests previously could not reach certain defensive branches reliably (they reached ~79% coverage in an earlier attempt).  
To enable robust, isolated unit testing of the resolver logic, the resolver was extracted and exported.

**What I changed:**

- Exported a named resolver function `createdAtResolver` from `createdAt.ts`.  
- Updated the field registration to reference `createdAtResolver` (no behavior change).  
- Added/updated unit tests in `createdAt.test.ts` that import the resolver directly and exercise:
  - unauthenticated client  
  - authenticated user missing from DB  
  - system administrator allowed  
  - organization administrator allowed  
  - regular member / non-member unauthorized cases  
  - DateTime value type/precision and identity/return reference  

**Outcomes:**

- All unit tests pass locally: **8/8 tests.**  
- Coverage for `createdAt.ts` increased to **~86.44% line coverage**, **100% branch coverage.**

**Why this approach:**

- Exporting the resolver is a minimal, low-risk refactor that doesn’t change runtime behavior or the GraphQL schema.  
- Unit tests check the resolver’s logic directly, allowing us to validate all defensive branches (authentication, user existence, authorization).  
- Tests assert on error extension codes rather than fragile error messages (prevents breakage when messages change).

**Does this PR introduce a breaking change?**

No. This is a refactor. The GraphQL schema and runtime behavior are unchanged. The only difference is that the resolver is now exported (which is non-breaking).

---

## Checklist

### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI  
- [x] I have implemented or provided justification for each non-critical suggestion  
- [x] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented  

### Test Coverage
- [x] I have written tests for all new changes/features  
  - Added unit tests in `createdAt.test.ts`  
- [x] I have verified that unit tests pass locally (**8/8**)  
- [x] I have verified that test coverage meets or exceeds 95%  

**Note:**  
Per-file coverage for `createdAt.ts` is **~86.44% line coverage**, **100% branch coverage.**  
Reason coverage is below 95%:
- A few uncovered lines are structural/schema registration code that runs at module load (the `Advertisement.implement({ ... })` block) and an inline arrow function in the DB where clause.
- These are either executed at import time or not properly instrumented by the coverage tool (V8), and contain no additional business logic.
- All actual business logic (authentication and authorization branches) has 100% branch coverage.

**Proposed action for maintainers (optional):**
- Accept the current coverage (86.44% line, 100% branch) since it fully tests the logic.  
- Alternatively, consider adding a small integration test to load the GraphQL server to exercise module-load lines (low ROI, may still be flagged by coverage tooling).

- [x] I have run the test suite locally and all tests pass  

---

**Other information**

**Files changed:**
- `createdAt.ts`  
  - Extracted `createdAtResolver` and exported it.  
  - Updated `Advertisement.implement()` to use `resolve: createdAtResolver`.  

- `createdAt.test.ts`  
  - Added unit tests exercising authentication and authorization branches and DateTime specifics.  
  - Tests assert on `TalawaGraphQLError` extension codes to avoid brittle message checks.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced administrator-only access to the Advertisement creation timestamp field.

* **Tests**
  * Added comprehensive test coverage verifying authorization and date handling for the createdAt field across various user roles and authentication states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->