### PR TITLE
Restore automated GraphQL schema documentation generation (#3660) wit…

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -30,15 +30,12 @@ pre-commit:
         pnpm format:fix
         git add -- {staged_files}        
         git add docs/
-
     8_check_type_errors:
       run: pnpm typecheck
-
-    # commenting out because postgenerate script is not present in develop branch
-    # 11_generate_docs:
-    #   run: |
-    #     set -e
-    #     pnpm generate:docs
-    #     git add ./docs/docs/docs/auto-schema
+    9_generate_docs: # 👈 ADD THIS BACK
+      run: |
+        set -e
+        pnpm run generate:docs
+        git add ./docs/docs/docs/auto-schema  # adjust path if needed
 
   piped: true

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,7 +2,7 @@
 	"out": "docs/docs/docs/auto-schema",
 	"plugin": ["typedoc-plugin-markdown"],
 	"theme": "markdown",
-	"tsconfig": "tsconfig.docs.json",
+	"tsconfig": "tsconfig.json",
 	"excludePrivate": true,
 	"excludeProtected": true,
 	"excludeExternals": true,


### PR DESCRIPTION
Successfully ran pnpm generate:docs locally, generating documentation without errors.

Pre-commit hook restored by enabling 11_generate_docs step in lefthook.yaml to run documentation generation on commit and stage generated files.



Updated or confirmed tsconfig path as "tsconfig": "tsconfig.json" in the relevant config to ensure proper TypeScript compilation during doc generation.

No regressions or unrelated errors caused elsewhere in the project by these changes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated documentation generation as part of the pre-commit workflow to ensure documentation stays current.
  * Updated documentation build configuration for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->