### PR TITLE
chore: added the test for test/graphql/types/Organization/postsCount

### DIFF
--- a/test/graphql/types/Organization/postsCount.test.ts
+++ b/test/graphql/types/Organization/postsCount.test.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import { beforeAll, expect, suite, test, vi } from "vitest";
+import { afterEach, beforeAll, expect, suite, test, vi } from "vitest";
 import { assertToBeNonNullish } from "../../../helpers";
 import { server } from "../../../server";
 import { mercuriusClient } from "../client";
@@ -10,6 +10,7 @@ import {
 } from "../documentNodes";
 
 let authToken: string;
+
 // Sign in once before tests
 beforeAll(async () => {
 	const signInResult = await mercuriusClient.query(Query_signIn, {
@@ -24,6 +25,10 @@ beforeAll(async () => {
 	assertToBeNonNullish(signInResult.data.signIn.authenticationToken);
 	authToken = signInResult.data.signIn.authenticationToken;
 	assertToBeNonNullish(authToken);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
 });
 
 const OrganizationPostsCountQuery = `
@@ -231,7 +236,7 @@ suite("Organization postsCount Field", () => {
 		const orgId = createOrgResult.data?.createOrganization?.id;
 		assertToBeNonNullish(orgId);
 
-		const originalFindFirst = vi
+		const findFirstSpy = vi
 			.spyOn(server.drizzleClient.query.usersTable, "findFirst")
 			.mockResolvedValueOnce(undefined);
 
@@ -251,7 +256,7 @@ suite("Organization postsCount Field", () => {
 				]),
 			);
 		} finally {
-			originalFindFirst.mockRestore();
+			findFirstSpy.mockRestore();
 		}
 	});
 


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
#3082

Fixes #<!--Add related issue number here.-->

**Snapshots/Videos:**

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end GraphQL tests for Organization.postsCount covering:
    * Unauthenticated access returns an authentication error.
    * Admins see correct counts after creating posts.
    * Non-admin/non-member access is unauthorized.
    * Missing current user is treated as unauthenticated.
    * Empty or missing post selections fall back to zero.
    * Error propagation and edge cases validated, including mocked scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->