### PR TITLE
Feat: Refactor updater resolver to export and add comprehensive test …

### DIFF
--- a/src/graphql/types/FundCampaign/updater.ts
+++ b/src/graphql/types/FundCampaign/updater.ts
@@ -1,120 +1,127 @@
+import type { GraphQLContext } from "~/src/graphql/context";
 import { User } from "~/src/graphql/types/User/User";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 import envConfig from "~/src/utilities/graphqLimits";
-import { FundCampaign } from "./FundCampaign";
+import {
+	FundCampaign,
+	type FundCampaign as FundCampaignType,
+} from "./FundCampaign";
+
+export const updaterResolver = async (
+	parent: FundCampaignType,
+	_args: Record<string, never>,
+	ctx: GraphQLContext,
+) => {
+	if (!ctx.currentClient.isAuthenticated) {
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "unauthenticated",
+			},
+		});
+	}
+
+	const currentUserId = ctx.currentClient.user.id;
+
+	const [currentUser, existingFund] = await Promise.all([
+		ctx.drizzleClient.query.usersTable.findFirst({
+			where: (fields, operators) => operators.eq(fields.id, currentUserId),
+		}),
+		ctx.drizzleClient.query.fundsTable.findFirst({
+			columns: {
+				isTaxDeductible: true,
+			},
+			with: {
+				organization: {
+					columns: {
+						countryCode: true,
+					},
+					with: {
+						membershipsWhereOrganization: {
+							columns: {
+								role: true,
+							},
+							where: (fields, operators) =>
+								operators.eq(fields.memberId, currentUserId),
+						},
+					},
+				},
+			},
+			where: (fields, operators) => operators.eq(fields.id, currentUserId),
+		}),
+	]);
+
+	if (currentUser === undefined) {
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "unauthenticated",
+			},
+		});
+	}
+
+	// Fund id existing but the associated fund not existing is a business logic error and probably means that the corresponding data in the database is in a corrupted state. It must be investigated and fixed as soon as possible to prevent additional data corruption.
+	if (existingFund === undefined) {
+		ctx.log.error(
+			"Postgres select operation returned an empty array for a fund campaign's fund id that isn't null.",
+		);
+
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "unexpected",
+			},
+		});
+	}
+
+	const currentUserOrganizationMembership =
+		existingFund.organization.membershipsWhereOrganization[0];
+
+	if (
+		currentUser.role !== "administrator" &&
+		(currentUserOrganizationMembership === undefined ||
+			currentUserOrganizationMembership.role !== "administrator")
+	) {
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "unauthorized_action",
+			},
+		});
+	}
+
+	if (parent.updaterId === null) {
+		return null;
+	}
+
+	if (parent.updaterId === currentUserId) {
+		return currentUser;
+	}
+
+	const updaterId = parent.updaterId;
+
+	const existingUser = await ctx.drizzleClient.query.usersTable.findFirst({
+		where: (fields, operators) => operators.eq(fields.id, updaterId),
+	});
+
+	// Updater id existing but the associated user not existing is a business logic error and probably means that the corresponding data in the database is in a corrupted state. It must be investigated and fixed as soon as possible to prevent additional data corruption.
+	if (existingUser === undefined) {
+		ctx.log.error(
+			"Postgres select operation returned an empty array for a fund campaign's updater id that isn't null.",
+		);
+
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "unexpected",
+			},
+		});
+	}
+
+	return existingUser;
+};
+
 FundCampaign.implement({
 	fields: (t) => ({
 		updater: t.field({
 			description: "User who last updated the fund campaign.",
 			complexity: envConfig.API_GRAPHQL_OBJECT_FIELD_COST,
-			resolve: async (parent, _args, ctx) => {
-				if (!ctx.currentClient.isAuthenticated) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthenticated",
-						},
-					});
-				}
-
-				const currentUserId = ctx.currentClient.user.id;
-
-				const [currentUser, existingFund] = await Promise.all([
-					ctx.drizzleClient.query.usersTable.findFirst({
-						where: (fields, operators) =>
-							operators.eq(fields.id, currentUserId),
-					}),
-					ctx.drizzleClient.query.fundsTable.findFirst({
-						columns: {
-							isTaxDeductible: true,
-						},
-						with: {
-							organization: {
-								columns: {
-									countryCode: true,
-								},
-								with: {
-									membershipsWhereOrganization: {
-										columns: {
-											role: true,
-										},
-										where: (fields, operators) =>
-											operators.eq(fields.memberId, currentUserId),
-									},
-								},
-							},
-						},
-						where: (fields, operators) =>
-							operators.eq(fields.id, currentUserId),
-					}),
-				]);
-
-				if (currentUser === undefined) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthenticated",
-						},
-					});
-				}
-
-				// Fund id existing but the associated fund not existing is a business logic error and probably means that the corresponding data in the database is in a corrupted state. It must be investigated and fixed as soon as possible to prevent additional data corruption.
-				if (existingFund === undefined) {
-					ctx.log.error(
-						"Postgres select operation returned an empty array for a fund campaign's fund id that isn't null.",
-					);
-
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unexpected",
-						},
-					});
-				}
-
-				const currentUserOrganizationMembership =
-					existingFund.organization.membershipsWhereOrganization[0];
-
-				if (
-					currentUser.role !== "administrator" &&
-					(currentUserOrganizationMembership === undefined ||
-						currentUserOrganizationMembership.role !== "administrator")
-				) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthorized_action",
-						},
-					});
-				}
-
-				if (parent.updaterId === null) {
-					return null;
-				}
-
-				if (parent.updaterId === currentUserId) {
-					return currentUser;
-				}
-
-				const updaterId = parent.updaterId;
-
-				const existingUser = await ctx.drizzleClient.query.usersTable.findFirst(
-					{
-						where: (fields, operators) => operators.eq(fields.id, updaterId),
-					},
-				);
-
-				// Updater id existing but the associated user not existing is a business logic error and probably means that the corresponding data in the database is in a corrupted state. It must be investigated and fixed as soon as possible to prevent additional data corruption.
-				if (existingUser === undefined) {
-					ctx.log.error(
-						"Postgres select operation returned an empty array for a fund campaign's updater id that isn't null.",
-					);
-
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unexpected",
-						},
-					});
-				}
-
-				return existingUser;
-			},
+			resolve: updaterResolver,
 			type: User,
 		}),
 	}),

--- a/test/graphql/types/FundCampaign/updater.test.ts
+++ b/test/graphql/types/FundCampaign/updater.test.ts
@@ -1,0 +1,238 @@
+import { createMockGraphQLContext } from "test/_Mocks_/mockContextCreator/mockContextCreator";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { FundCampaign } from "~/src/graphql/types/FundCampaign/FundCampaign";
+import { updaterResolver } from "~/src/graphql/types/FundCampaign/updater";
+import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
+import type { GraphQLContext } from "../../../../src/graphql/context";
+
+describe("FundCampaign Resolver - Updater Field", () => {
+	let ctx: GraphQLContext;
+	let mockFundCampaign: FundCampaign;
+	let mocks: ReturnType<typeof createMockGraphQLContext>["mocks"];
+
+	beforeEach(() => {
+		const { context, mocks: newMocks } = createMockGraphQLContext(true, "123");
+		ctx = context;
+		mocks = newMocks;
+		mockFundCampaign = {
+			createdAt: new Date(),
+			name: "Annual Fundraiser",
+			id: "campaign-111",
+			fundId: "fund-456",
+			creatorId: "000",
+			updatedAt: new Date(),
+			updaterId: "id-222",
+			currencyCode: "USD",
+			goalAmount: 50000,
+			startAt: new Date("2024-01-01T00:00:00Z"),
+			endAt: new Date("2024-12-31T23:59:59Z"),
+		};
+
+		vi.clearAllMocks();
+	});
+
+	it("should throw unauthenticated error when user is not authenticated", async () => {
+		ctx.currentClient.isAuthenticated = false;
+
+		await expect(
+			updaterResolver(mockFundCampaign, {}, ctx as GraphQLContext),
+		).rejects.toThrow(TalawaGraphQLError);
+	});
+
+	it("should throw unauthenticated error when user is undefined", async () => {
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue(undefined);
+
+		await expect(
+			updaterResolver(mockFundCampaign, {}, ctx as GraphQLContext),
+		).rejects.toThrow(TalawaGraphQLError);
+	});
+
+	it("should throw unauthorized_action when user is not an administrator", async () => {
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+			id: "user123",
+			role: "member",
+		});
+
+		mocks.drizzleClient.query.fundsTable.findFirst.mockResolvedValue({
+			isTaxDeductible: false,
+			organization: {
+				countryCode: "US",
+				membershipsWhereOrganization: [{ role: "member" }],
+			},
+		});
+
+		await expect(
+			updaterResolver(mockFundCampaign, {}, ctx as GraphQLContext),
+		).rejects.toThrow(
+			new TalawaGraphQLError({
+				extensions: {
+					code: "unauthorized_action",
+				},
+			}),
+		);
+	});
+
+	it("should throw unauthorized_action when user has no organization memberships", async () => {
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+			id: "user123",
+			role: "member",
+		});
+
+		mocks.drizzleClient.query.fundsTable.findFirst.mockResolvedValue({
+			isTaxDeductible: false,
+			organization: {
+				countryCode: "US",
+				membershipsWhereOrganization: [],
+			},
+		});
+
+		await expect(
+			updaterResolver(mockFundCampaign, {}, ctx as GraphQLContext),
+		).rejects.toThrow(
+			new TalawaGraphQLError({
+				extensions: {
+					code: "unauthorized_action",
+				},
+			}),
+		);
+	});
+
+	it("should throw unauthorized_action when membershipsWhereOrganization.role is not an administrator", async () => {
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+			id: "user123",
+			role: "member",
+		});
+
+		mocks.drizzleClient.query.fundsTable.findFirst.mockResolvedValue({
+			isTaxDeductible: false,
+			organization: {
+				countryCode: "US",
+				membershipsWhereOrganization: [{ role: "member" }],
+			},
+		});
+
+		await expect(
+			updaterResolver(mockFundCampaign, {}, ctx as GraphQLContext),
+		).rejects.toThrow(
+			new TalawaGraphQLError({
+				extensions: {
+					code: "unauthorized_action",
+				},
+			}),
+		);
+	});
+
+	it("returns null if updaterId is null", async () => {
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+			id: "user123",
+			role: "administrator",
+		});
+		mocks.drizzleClient.query.fundsTable.findFirst.mockResolvedValue({
+			isTaxDeductible: false,
+			organization: {
+				countryCode: "US",
+				membershipsWhereOrganization: [{ role: "administrator" }],
+			},
+		});
+
+		const result = await updaterResolver(
+			{ ...mockFundCampaign, updaterId: null },
+			{},
+			ctx as GraphQLContext,
+		);
+		expect(result).toBeNull();
+	});
+
+	it("returns current user if they are the updater", async () => {
+		Object.assign(ctx.currentClient, {
+			user: { id: "user123" },
+			isAuthenticated: true,
+		});
+
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+			id: "user123",
+			role: "administrator",
+		});
+		mocks.drizzleClient.query.fundsTable.findFirst.mockResolvedValue({
+			isTaxDeductible: false,
+			organization: {
+				countryCode: "US",
+				membershipsWhereOrganization: [{ role: "administrator" }],
+			},
+		});
+
+		await expect(
+			updaterResolver({ ...mockFundCampaign, updaterId: "user123" }, {}, ctx),
+		).resolves.toEqual({ id: "user123", role: "administrator" });
+	});
+
+	it("throws unexpected error if updater user does not exist", async () => {
+		mocks.drizzleClient.query.usersTable.findFirst
+			.mockResolvedValueOnce({ id: "user123", role: "administrator" })
+			.mockResolvedValueOnce(undefined);
+		mocks.drizzleClient.query.fundsTable.findFirst.mockResolvedValue({
+			isTaxDeductible: false,
+			organization: {
+				countryCode: "US",
+				membershipsWhereOrganization: [{ role: "administrator" }],
+			},
+		});
+
+		await expect(
+			updaterResolver(mockFundCampaign, {}, ctx as GraphQLContext),
+		).rejects.toThrow(
+			new TalawaGraphQLError({
+				extensions: {
+					code: "unexpected",
+				},
+			}),
+		);
+		expect(ctx.log.error).toHaveBeenCalledWith(
+			"Postgres select operation returned an empty array for a fund campaign's updater id that isn't null.",
+		);
+	});
+
+	it("returns the existing user if updaterId is set and user exists", async () => {
+		mocks.drizzleClient.query.usersTable.findFirst
+			.mockResolvedValueOnce({ id: "user123", role: "administrator" })
+			.mockResolvedValueOnce({ id: "user456", role: "member" });
+		mocks.drizzleClient.query.fundsTable.findFirst.mockResolvedValue({
+			isTaxDeductible: false,
+			organization: {
+				countryCode: "US",
+				membershipsWhereOrganization: [{ role: "administrator" }],
+			},
+		});
+
+		const result = await updaterResolver(
+			mockFundCampaign,
+			{},
+			ctx as GraphQLContext,
+		);
+		expect(result).toEqual({ id: "user456", role: "member" });
+	});
+
+	it("should throw unexpected error when fund does not exist", async () => {
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+			id: "user123",
+			role: "administrator",
+		});
+
+		// Mock fund as undefined
+		mocks.drizzleClient.query.fundsTable.findFirst.mockResolvedValue(undefined);
+
+		await expect(
+			updaterResolver(mockFundCampaign, {}, ctx as GraphQLContext),
+		).rejects.toThrow(
+			new TalawaGraphQLError({
+				extensions: {
+					code: "unexpected",
+				},
+			}),
+		);
+
+		expect(ctx.log.error).toHaveBeenCalledWith(
+			"Postgres select operation returned an empty array for a fund campaign's fund id that isn't null.",
+		);
+	});
+});


### PR DESCRIPTION
…coverage for FundCampaign

**What kind of change does this PR introduce?** 
Tests

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #3048


**Snapshots/Videos:**
<img width="1192" height="446" alt="image" src="https://github.com/user-attachments/assets/b15def52-a4eb-487b-baeb-07988f86464f" />

**If relevant, did you update the documentation?**

NO 

**Summary**

Added tests for the updater resolver in FundCampaign.

To do this, I had to export the updaterResolver from updater.ts so updater.test.ts could use it in tests.

I created the new updater.test.ts file and added 10 tests to get complete coverage.

The tests cover:

 - Auth: Not authenticated, user undefined, not an admin, no org memberships, non-admin org role.

  -  Data Validation: Fund doesn't exist, updater user doesn't exist (data corruption cases).

  -  Logic: Null updaterId returns null, and the current user optimization check.

  -  Success: The main happy path for retrieving an existing updater.

**Does this PR introduce a breaking change?**
 NO  

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

## Checklist

### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [x] I have implemented or provided justification for each non-critical suggestion
- [x] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes 
