### PR TITLE
test(api):  improve code coverage for joinPublicOrganization.ts to 100%

### DIFF
--- a/test/graphql/types/Mutation/joinPublicOrganization.test.ts
+++ b/test/graphql/types/Mutation/joinPublicOrganization.test.ts
@@ -599,7 +599,7 @@ suite("Mutation joinPublicOrganization", () => {
 				expect.arrayContaining<TalawaGraphQLFormattedError>([
 					expect.objectContaining<TalawaGraphQLFormattedError>({
 						extensions: expect.objectContaining({
-							code: "unexpected", // Changed to single quotes
+							code: "unexpected",
 						}),
 						message: expect.any(String),
 					}),


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Test Coverage Improvement - This PR adds comprehensive test case to achieve 100% code coverage for the src/graphql/types/Mutation/joinPublicOrganization.ts

**Issue Number:**

Fixes #3378 

**If relevant, did you update the documentation?**

No

**Summary**

This PR achieves 100% test coverage for the joinPublicOrganization mutation.
It adds a new test to cover the if `(newMemberships.length === 0)` "unexpected" error path. This is achieved by:
- Spying on `server.drizzleClient.transaction` with `vi.spyOn`.
- Forcing the transaction to return an empty array using `.mockResolvedValue([])`.

**Does this PR introduce a breaking change?**

No, this PR only adds test cases and does not modify any existing functionality.

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test to verify an "unexpected" error is returned when a backend insert yields no data during organization joining.
  * Improved test teardown by restoring mocks after each test to avoid cross-test interference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->