### PR TITLE
Fix: Made post's attachments optional

### DIFF
--- a/src/graphql/inputs/MutationCreatePostInput.ts
+++ b/src/graphql/inputs/MutationCreatePostInput.ts
@@ -52,7 +52,7 @@ export const mutationCreatePostInputSchema = postsTableInsertSchema
 		organizationId: true,
 	})
 	.extend({
-		attachments: z.array(fileMetadataSchema).max(20).nullish(),
+		attachments: z.array(fileMetadataSchema).max(20).optional(),
 		isPinned: z.boolean().optional(),
 	});
 

--- a/src/graphql/types/Mutation/createPost.ts
+++ b/src/graphql/types/Mutation/createPost.ts
@@ -170,10 +170,7 @@ builder.mutationField("createPost", (t) =>
 					attachments: (typeof postAttachmentsTable.$inferSelect)[];
 				};
 
-				if (
-					parsedArgs.input.attachments != null &&
-					parsedArgs.input.attachments.length > 0
-				) {
+				if (parsedArgs.input.attachments !== undefined) {
 					const attachments = parsedArgs.input.attachments;
 
 					const createdPostAttachments = await tx


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Made attachments optional so user can post without any attachments.

**Issue Number:** #3709

Fixes #3709

**Summary**
previously attachments were required to make a post, but this not how it is suuposed to be in ```Talawa-admin``` so in this PR i've made them optional so user can post without attachments too

**Does this PR introduce a breaking change?**
No

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attachments are now optional when creating posts, allowing you to publish content without files.

* **Bug Fixes**
  * Prevents errors when an empty or null attachments value is provided, treating missing attachments as an empty list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->