### PR TITLE
Added PR merging criteria to auto assignment

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -71,6 +71,35 @@ jobs:
               return;
             }
 
+            /**
+            * Check if a user has any merged PRs in the repository
+            * @param {object} github - GitHub API client
+            * @param {string} owner - Repository owner
+            * @param {string} repo - Repository name
+            * @param {string} username - GitHub username to check
+            * @returns {Promise<boolean>} - True if user has merged PRs, false otherwise
+            */
+            async function hasMergedPRs(github, owner, repo, username) {
+              try {
+                // Use GitHub Search API to find merged PRs authored by the user
+                const query = `repo:${owner}/${repo} type:pr is:merged author:${username}`;
+                
+                const result = await github.rest.search.issuesAndPullRequests({
+                  q: query,
+                  per_page: 1, // We only need to know if at least one exists
+                });
+                
+                const count = result.data.total_count;
+                console.log(`User ${username} has ${count} merged PR(s) in ${owner}/${repo}`);
+                
+                return count > 0;
+              } catch (error) {
+                console.error(`Error checking merged PRs for ${username}:`, error);
+                // On error, return false to be safe (deny access)
+                return false;
+              }
+            }  
+
             const isAssign = body.startsWith("/assign");
             const isUnassign = body.startsWith("/unassign");
 
@@ -101,10 +130,10 @@ jobs:
             * CONTRIBUTOR
             * Author has previously committed to the repository.
             * 
-            * FIRST_TIMER
+            * FIRST_TIMER (Seems to be only applicable to PR commenters)
             * Author has not previously committed to GitHub.
             * 
-            * FIRST_TIME_CONTRIBUTOR
+            * FIRST_TIME_CONTRIBUTOR (Seems to be only applicable to PR commenters)
             * Author has not previously committed to the repository.
             * 
             * MANNEQUIN
@@ -113,7 +142,7 @@ jobs:
             * MEMBER
             * Author is a member of the organization that owns the repository.
             * 
-            * NONE
+            * NONE (Default for non-PR commenters who don't match any of the other associations)
             * Author has no association with the repository.
             * 
             * OWNER
@@ -126,17 +155,35 @@ jobs:
             // New contributors cannot auto assign themselves, but they can unassign themselves
             if (isAssign) {
               if (association === 'FIRST_TIME_CONTRIBUTOR' || association === 'FIRST_TIMER' || association === 'NONE') {
-                await github.rest.issues.createComment({
-                  owner,
-                  repo,
-                  issue_number: issueNumber,
-                  body: `❌ @${user} First time contributors cannot use auto assignment. Please ask to be assigned instead.`,
-                });
-                return;
+
+                // Verify whether the commenter has merged PRs
+                const hasContributed = await hasMergedPRs(github, owner, repo, user);
+
+                if (!hasContributed) {
+                  await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    body: `❌ @${user} First time contributors cannot use auto assignment. You have not successfully merged code into this repository. Please ask to be assigned instead.`,
+                  });
+                  return;
+                }
               }    
             }
 
             if (isUnassign) {
+
+              if (body.trim() !== "/unassign") {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  body: `❌ @${user} This workflow only supports \`/unassign\` without additional text.`,
+                });
+                console.log("Invalid /unassign command (must be exact)");
+                return;
+              }
+
               const currentAssignees = issue.assignees.map(a => a.login);
               if (!currentAssignees.includes(user)) {
                 console.log(`${user} is not assigned, skipping unassign`);


### PR DESCRIPTION
Added PR merging criteria to auto assignment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Auto-assignment workflow enhanced with validation to confirm first-time contributors have prior merged pull requests before being assigned to repository issues.
  * `/unassign` command now includes stricter validation logic with explicit error feedback when commands are formatted incorrectly or lack proper parameters.
  * Contributor documentation updated to clarify eligibility and behavior descriptions for various contributor association types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->