### PR TITLE
test: update organizationsWhereMember tests

### DIFF
--- a/test/graphql/types/User/organizationsWhereMember.test.ts
+++ b/test/graphql/types/User/organizationsWhereMember.test.ts
@@ -100,7 +100,10 @@ describe("resolveOrganizationsWhereMember", () => {
 		await expect(
 			resolveOrganizationsWhereMember(
 				mockUserParent,
-				{ filter: 123 as unknown as string }, // Invalid filter type to trigger Zod validation failure
+				{
+					...globalArgs,
+					filter: 123 as unknown as string, // Invalid filter type to trigger Zod validation failure
+				},
 				baseMockCtx,
 			),
 		).rejects.toThrow(TalawaGraphQLError);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Test Addition – This PR adds a complete unit test suite for the `organizationsWhereMember` resolver.

## Issue Number:

Fixes #2925 

## Snapshots/Videos:

Not applicable (tests only)

## If relevant, did you update the documentation?

Not required for resolver tests.

## Summary

This PR adds a comprehensive test suite for the `resolveOrganizationsWhereMember` GraphQL resolver.  
The tests cover:

- Authentication check (unauthenticated user → error)
- Authorization check (non-admin querying other user → error)
- Zod validation (invalid args → error)
- Successful fetch of organizations where the user is a member
- Filtering logic
- Behavior when no filter is provided
- Cursor-based pagination behavior

These tests ensure the resolver behaves correctly under all expected scenarios and improve reliability of membership-related queries.

## Does this PR introduce a breaking change?

No, this PR only adds tests.

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented reasoning in comments where suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass

## Other information

None.

## Have you read the contributing guide?

Yes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for organization access: added input-validation tests for malformed requests, introduced a separate test confirming unauthorized access is blocked for non-admins, and cleaned up test comments for readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->