### PR TITLE
test: add unit tests for Fund.createdAt resolver (Fixes #3090)

### DIFF
--- a/test/graphql/types/Fund/createdAt.test.ts
+++ b/test/graphql/types/Fund/createdAt.test.ts
@@ -1,0 +1,107 @@
+import { createMockGraphQLContext } from "test/_Mocks_/mockContextCreator/mockContextCreator";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Fund } from "~/src/graphql/types/Fund/Fund";
+import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
+import "~/src/graphql/types/Fund/createdAt";
+
+describe("Fund Resolver - createdAt Field", () => {
+  let ctx: any;
+  let mockFund: Fund;
+  let mocks: ReturnType<typeof createMockGraphQLContext>["mocks"];
+
+  beforeEach(() => {
+    const { context, mocks: newMocks } = createMockGraphQLContext(
+      true,
+      "user-1"
+    );
+    ctx = context;
+    mocks = newMocks;
+
+    mockFund = {
+      createdAt: new Date("2025-01-01T00:00:00.000Z"),
+      name: "Healthcare Fund",
+      id: "fund-1",
+      creatorId: "creator-1",
+      updatedAt: new Date(),
+      updaterId: "user-1",
+      organizationId: "org-123",
+      isTaxDeductible: false,
+    };
+
+    mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+      id: "user-1",
+      role: "member",
+      organizationMembershipsWhereMember: [],
+    });
+
+    vi.clearAllMocks();
+  });
+
+  it("throws unauthenticated error when user is not authenticated", async () => {
+    ctx.currentClient.isAuthenticated = false;
+
+    await expect(
+      ctx.schema.Fund.fields.createdAt.resolve(mockFund, {}, ctx)
+    ).rejects.toThrow(
+      new TalawaGraphQLError({ extensions: { code: "unauthenticated" } })
+    );
+  });
+
+  it("throws unauthenticated error when user is not found", async () => {
+    mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue(undefined);
+
+    await expect(
+      ctx.schema.Fund.fields.createdAt.resolve(mockFund, {}, ctx)
+    ).rejects.toThrow(
+      new TalawaGraphQLError({ extensions: { code: "unauthenticated" } })
+    );
+  });
+
+  it("throws unauthorized_action when user has no organization memberships", async () => {
+    mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+      id: "user-1",
+      role: "member",
+      organizationMembershipsWhereMember: [],
+    });
+
+    await expect(
+      ctx.schema.Fund.fields.createdAt.resolve(mockFund, {}, ctx)
+    ).rejects.toThrow(
+      new TalawaGraphQLError({ extensions: { code: "unauthorized_action" } })
+    );
+  });
+
+  it("returns createdAt for admin users", async () => {
+    mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+      id: "user-1",
+      role: "administrator",
+      organizationMembershipsWhereMember: [],
+    });
+
+    const result = await ctx.schema.Fund.fields.createdAt.resolve(
+      mockFund,
+      {},
+      ctx
+    );
+    expect(result).toEqual(mockFund.createdAt);
+  });
+
+  it("returns createdAt for users with organization membership", async () => {
+    mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+      id: "user-1",
+      role: "member",
+      organizationMembershipsWhereMember: [
+        {
+          role: "member",
+        },
+      ],
+    });
+
+    const result = await ctx.schema.Fund.fields.createdAt.resolve(
+      mockFund,
+      {},
+      ctx
+    );
+    expect(result).toEqual(mockFund.createdAt);
+  });
+});


### PR DESCRIPTION
**Type of Change:**
Test coverage improvement – Adds unit tests for the Fund.createdAt GraphQL resolver.

**Issue Number:**
Fixes #3090

**Summary:**
This pull request adds unit tests for the createdAt resolver in src/graphql/types/Fund/createdAt.ts. The tests cover all branches of the resolver logic:

- [x] 1. Throws "unauthenticated" when the user is not authenticated
- [x] 2. Throws "unauthenticated" when the user record does not exist
- [x] 3. Throws "unauthorized_action" when the user has no organization memberships and is not an admin
- [x] 4. Returns the createdAt value for admin users
- [x] 5. Returns the createdAt value for users with valid organization memberships
- [x] 6. The tests follow the existing structure used in other Fund resolver tests, like updater.test.ts.

**Breaking Changes:**
None. This PR only adds tests and does not modify existing implementation.

**Checklist:**
- I added only one new test file: test/graphql/types/Fund/createdAt.test.ts
- I followed the testing pattern used in existing resolvers
- All logical branches in the resolver are covered
- I have read and followed the contributing guidelines

**🔹 Note:** Due to @fastify/redis plugin timeout, pnpm run check_tests fails locally on both develop and this branch. This issue is unrelated to the added test.
 Coverage for this resolver is expected to reach 100%

**Other Information:**
I am a new contributor preparing for Talawa’s internship and GSoC.
This is my first backend test contribution, and I carefully followed existing conventions to ease review.

**Have you read the contributing guide?**
✔ Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for GraphQL field access control, including authentication and authorization scenarios with various user roles and organization membership states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->