### PR TITLE
Add tests for TagFolder childFolders resolver with pagination 

### DIFF
--- a/test/graphql/types/TagFolder/childFolders.test.ts
+++ b/test/graphql/types/TagFolder/childFolders.test.ts
@@ -15,6 +15,28 @@ const createCursor = (data: Record<string, unknown>): string => {
 	return Buffer.from(JSON.stringify(data)).toString("base64url");
 };
 
+const makeResolveInfo = (
+	overrides: Partial<GraphQLResolveInfo> = {},
+): GraphQLResolveInfo => {
+	return {
+		fieldName: "childFolders",
+		fieldNodes: [],
+		returnType: schema.getType("TagFolder") as GraphQLObjectType,
+		parentType: schema.getType("TagFolder") as GraphQLObjectType,
+		path: { key: "childFolders", prev: undefined },
+		schema: schema,
+		fragments: {},
+		rootValue: {},
+		operation: {
+			kind: "OperationDefinition",
+			operation: "query",
+			selectionSet: { kind: "SelectionSet", selections: [] },
+		},
+		variableValues: {},
+		...overrides,
+	} as GraphQLResolveInfo;
+};
+
 interface Connection {
 	edges: Array<{ node: Record<string, unknown> }>;
 	pageInfo: {
@@ -62,7 +84,7 @@ describe("TagFolder childFolders Resolver", () => {
 	];
 
 	// The resolver does not use the info argument, so we can cast an empty object.
-	const mockResolveInfo: GraphQLResolveInfo = {} as GraphQLResolveInfo;
+	const mockResolveInfo = makeResolveInfo();
 
 	beforeAll(() => {
 		const tagFolderType = schema.getType("TagFolder") as GraphQLObjectType;


### PR DESCRIPTION


**What kind of change does this PR introduce?**
Test

**Issue Number:**

Fixes #3022 


**If relevant, did you update the documentation?**

 NO , 

**Summary**

added test for src/graphql/types/TagFolder/childFolders.ts

**Does this PR introduce a breaking change?**

NO 

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [X] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass



**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive test suite for the TagFolder child-folders resolver: validates invalid cursor arguments and conflicting pagination params; exercises forward/backward cursor pagination, sentinel boundary cases, empty-result handling, and proper start/end cursor values; verifies hasNext/hasPrevious flags and connection shape (edges/pageInfo); includes complexity evaluation and mocked data/context paths to ensure robust, predictable folder-listing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->