### PR TITLE
test: add avatarURL resolver tests

### DIFF
--- a/test/graphql/types/Chat/avatarURL.test.ts
+++ b/test/graphql/types/Chat/avatarURL.test.ts
@@ -129,7 +129,6 @@ suite("Chat field avatarURL", () => {
 
 		testChatId = await createTestChat(adminAuthToken, organizationId);
 
-		// Build schema once and cache avatarURL field resolver
 		const schema = await schemaManager.buildInitialSchema();
 		const chatType = schema.getType("Chat") as GraphQLObjectType;
 		const avatarURLField = chatType.getFields().avatarURL;
@@ -154,7 +153,6 @@ suite("Chat field avatarURL", () => {
 		} catch (error) {}
 	});
 
-	// Helper function to construct ctx object
 	function createTestContext() {
 		return {
 			currentClient: { isAuthenticated: true, user: { id: adminUserId } },
@@ -244,15 +242,6 @@ suite("Chat field avatarURL", () => {
 	});
 
 	test("URL construction uses correct base URL and path format", async () => {
-		const schema = await schemaManager.buildInitialSchema();
-
-		const chatType = schema.getType("Chat") as GraphQLObjectType;
-		const fields = chatType.getFields();
-		const avatarURLField = fields.avatarURL;
-		assertToBeNonNullish(avatarURLField);
-		const resolver = avatarURLField.resolve;
-		assertToBeNonNullish(resolver);
-
 		const testCases = [
 			"avatar1.jpg",
 			"subfolder/avatar2.png",
@@ -266,16 +255,12 @@ suite("Chat field avatarURL", () => {
 				avatarName,
 			};
 
-			const ctx = {
-				currentClient: { isAuthenticated: true, user: { id: adminUserId } },
-				drizzleClient: server.drizzleClient,
-				log: server.log,
-				envConfig: server.envConfig,
-				jwt: server.jwt,
-				minio: server.minio,
-			};
-
-			const result = await resolver(parent, {}, ctx, {} as never);
+			const result = await avatarURLResolver(
+				parent,
+				{},
+				createTestContext(),
+				{} as never,
+			);
 
 			expect(result).toBe(
 				new URL(


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Test coverage for Chat.avatarURL 

**Issue Number:**

Fixes #3928

**Snapshots/Videos:**

N/A - Test coverage improvement only

**If relevant, did you update the documentation?**

N/A - No documentation updates required

**Summary**

This PR improves code coverage for src/graphql/types/Chat/avatarURL.ts by adding comprehensive test cases to achieve 100% coverage.

**Changes made:**
- Added integration and unit tests for the avatarURL resolver.

- Covered both resolver branches (avatarName: null and non-null).

- Verified URL construction logic, complexity value, and schema behavior.

**Does this PR introduce a breaking change?**

No

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass

**Other information**

This PR is part of the ongoing effort to improve overall code coverage for the talawa-api repository (parent issue https://github.com/PalisadoesFoundation/talawa-api/issues/2920).

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a Vitest suite for the Chat avatarURL GraphQL field: sets up and tears down test resources, checks null vs non‑null avatar behavior, verifies URL construction across varied avatar names/paths uses the API base/object path, confirms resolver returns expected values both via schema and end-to-end server, and validates the GraphQL field complexity cost.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->