### PR TITLE
test: add 100% code coverage for Advertisement organization resolver

### DIFF
--- a/src/graphql/types/Advertisement/organization.ts
+++ b/src/graphql/types/Advertisement/organization.ts
@@ -1,34 +1,45 @@
 import { Organization } from "~/src/graphql/types/Organization/Organization";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 import envConfig from "~/src/utilities/graphqLimits";
-import { Advertisement } from "./Advertisement";
+import type { GraphQLContext } from "../../context";
+import {
+	Advertisement,
+	type Advertisement as AdvertisementType,
+} from "./Advertisement";
+
+export const advertisementOrganization = async (
+	parent: AdvertisementType,
+	_args: Record<string, never>,
+	ctx: GraphQLContext,
+) => {
+	const existingOrganization =
+		await ctx.drizzleClient.query.organizationsTable.findFirst({
+			where: (fields, operators) =>
+				operators.eq(fields.id, parent.organizationId),
+		});
+
+	// Organization id existing but the associated organization not existing is a business logic error and probably means that the corresponding data in the database is in a corrupted state. It must be investigated and fixed as soon as possible to prevent additional data corruption.
+	if (existingOrganization === undefined) {
+		ctx.log.error(
+			"Postgres select operation returned an empty array for an advertisement's organization id that isn't null.",
+		);
+
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "unexpected",
+			},
+		});
+	}
+
+	return existingOrganization;
+};
+
 Advertisement.implement({
 	fields: (t) => ({
 		organization: t.field({
 			description: "Organization which the advertisement belongs to.",
 			complexity: envConfig.API_GRAPHQL_OBJECT_FIELD_COST,
-			resolve: async (parent, _args, ctx) => {
-				const existingOrganization =
-					await ctx.drizzleClient.query.organizationsTable.findFirst({
-						where: (fields, operators) =>
-							operators.eq(fields.id, parent.organizationId),
-					});
-
-				// Organziation id existing but the associated organization not existing is a business logic error and probably means that the corresponding data in the database is in a corrupted state. It must be investigated and fixed as soon as possible to prevent additional data corruption.
-				if (existingOrganization === undefined) {
-					ctx.log.error(
-						"Postgres select operation returned an empty array for an advertisement's organization id that isn't null.",
-					);
-
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unexpected",
-						},
-					});
-				}
-
-				return existingOrganization;
-			},
+			resolve: advertisementOrganization,
 			type: Organization,
 		}),
 	}),

--- a/test/graphql/types/Advertisement/organization.test.ts
+++ b/test/graphql/types/Advertisement/organization.test.ts
@@ -1,0 +1,128 @@
+import { createMockGraphQLContext } from "test/_Mocks_/mockContextCreator/mockContextCreator";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GraphQLContext } from "~/src/graphql/context";
+import type { Advertisement as AdvertisementType } from "~/src/graphql/types/Advertisement/Advertisement";
+import { advertisementOrganization } from "~/src/graphql/types/Advertisement/organization";
+import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
+
+type OrganizationType = {
+	id: string;
+	name: string;
+	createdAt?: Date;
+	updatedAt?: Date | null;
+};
+
+describe("Advertisement Resolver - Organization Field", () => {
+	let ctx: GraphQLContext;
+	let mockAdvertisement: AdvertisementType;
+	let mocks: ReturnType<typeof createMockGraphQLContext>["mocks"];
+
+	const mockOrganization: OrganizationType = {
+		id: "org-123",
+		name: "Test Organization",
+		createdAt: new Date(),
+		updatedAt: null,
+	};
+
+	beforeEach(() => {
+		const { context, mocks: newMocks } = createMockGraphQLContext(
+			true,
+			"user-123",
+		);
+		ctx = context;
+		mocks = newMocks;
+
+		mockAdvertisement = {
+			id: "advert-123",
+			name: "Test Advertisement",
+			createdAt: new Date(),
+			updatedAt: null,
+			creatorId: "user-123",
+			updaterId: null,
+			description: "Test description",
+			endAt: new Date(),
+			startAt: new Date(),
+			type: "banner",
+			organizationId: "org-123",
+			attachments: [],
+		};
+	});
+
+	it("should return the organization when it exists", async () => {
+		mocks.drizzleClient.query.organizationsTable.findFirst.mockResolvedValue(
+			mockOrganization,
+		);
+
+		const result = await advertisementOrganization(mockAdvertisement, {}, ctx);
+
+		expect(result).toEqual(mockOrganization);
+		expect(
+			mocks.drizzleClient.query.organizationsTable.findFirst,
+		).toHaveBeenCalledTimes(1);
+	});
+
+	it("should throw unexpected error when organization does not exist", async () => {
+		mocks.drizzleClient.query.organizationsTable.findFirst.mockResolvedValue(
+			undefined,
+		);
+
+		await expect(async () => {
+			await advertisementOrganization(mockAdvertisement, {}, ctx);
+		}).rejects.toThrow(
+			new TalawaGraphQLError({
+				extensions: { code: "unexpected" },
+			}),
+		);
+	});
+
+	it("should log an error when organization does not exist", async () => {
+		mocks.drizzleClient.query.organizationsTable.findFirst.mockResolvedValue(
+			undefined,
+		);
+
+		const logErrorSpy = vi.spyOn(ctx.log, "error");
+
+		await expect(async () => {
+			await advertisementOrganization(mockAdvertisement, {}, ctx);
+		}).rejects.toThrow();
+
+		expect(logErrorSpy).toHaveBeenCalledWith(
+			"Postgres select operation returned an empty array for an advertisement's organization id that isn't null.",
+		);
+	});
+
+	it("should call where function correctly", async () => {
+		const organizationId = "org-123";
+		mocks.drizzleClient.query.organizationsTable.findFirst.mockResolvedValue(
+			mockOrganization,
+		);
+
+		await advertisementOrganization(mockAdvertisement, {}, ctx);
+
+		expect(
+			mocks.drizzleClient.query.organizationsTable.findFirst,
+		).toHaveBeenCalledTimes(1);
+
+		const calls = (
+			mocks.drizzleClient.query.organizationsTable.findFirst as ReturnType<
+				typeof vi.fn
+			>
+		).mock.calls;
+		expect(calls.length).toBe(1);
+
+		// Extract the `where` function
+		const whereFn = calls[0]?.[0]?.where;
+		expect(whereFn).toBeDefined();
+
+		// Mock field conditions
+		const mockFields = { id: organizationId };
+		const mockOperators = { eq: vi.fn((a, b) => ({ field: a, value: b })) };
+
+		// Call the `where` function
+		whereFn(mockFields, mockOperators);
+		expect(mockOperators.eq).toHaveBeenCalledWith(
+			mockFields.id,
+			organizationId,
+		);
+	});
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Test coverage improvement and minor refactoring for testability.

**Issue Number:**

Fixes #3914

**Snapshots/Videos:**

N/A - This is a test coverage improvement, no UI changes.

**If relevant, did you update the documentation?**

N/A - No documentation changes required.

**Summary**

This PR adds 100% code coverage for [src/graphql/types/Advertisement/organization.ts](cci:7://file:///Users/tanishqjain/Desktop/talawa-api/src/graphql/types/Advertisement/organization.ts:0:0-0:0):

1. **Refactored** [organization.ts](src/graphql/types/Advertisement/organization.ts:0:0-0:0) to export the [advertisementOrganization](src/graphql/types/Advertisement/organization.ts:9:0-34:2) resolver function, making it directly testable 
2. **Created** [organization.test.ts](test/graphql/types/Advertisement/organization.test.ts:0:0-0:0) with 4 comprehensive test cases:
   - Returns organization when it exists (success path)
   - Throws `TalawaGraphQLError` with code `unexpected` when organization doesn't exist
   - Logs an error message when organization lookup fails
   - Validates the [where](src/graphql/types/Advertisement/creator.ts:29:4-30:63) function callback is called correctly

**Does this PR introduce a breaking change?**

No.

## Checklist

### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [x] I have implemented or provided justification for each non-critical suggestion
- [x] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass

**Other information**

The resolver function was extracted and exported to allow direct unit testing, following the existing pattern used in [creator.ts](talawa-api/src/graphql/types/Advertisement/creator.ts:0:0-0:0) within the same directory.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization by extracting resolver logic into a dedicated function with enhanced type safety.

* **Tests**
  * Added comprehensive unit tests to validate resolver behavior for organization retrieval, including success and error scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->