### PR TITLE
tests for src/graphql/types/Mutation/createFundCampaign

### DIFF
--- a/test/graphql/types/Mutation/createFundCampaign.test.ts
+++ b/test/graphql/types/Mutation/createFundCampaign.test.ts
@@ -125,7 +125,7 @@ async function createTestFund(authToken: string, organizationId: string) {
 }
 
 suite("Mutation field createFundCampaign", () => {
-	// Lines 158-168 of src/graphql/types/Mutation/createFundCampaign.ts
+	// Lines 170-182 of src/graphql/types/Mutation/createFundCampaign.ts
 	// contain a defensive branch handling unexpected empty DB insert results.
 	// This branch cannot be reliably tested without DB layer mocking
 	let adminAuthToken: string;


### PR DESCRIPTION
Added integration tests for src/graphql/types/Mutation/createFundCampaign
Fixes: #3867

## 11 Test Cases Written:

Authentication:
- Unauthenticated user error
- Deleted user with valid token

Input Validation:
- Invalid fund UUID format
- Empty campaign name validation
- endAt before startAt validation
- endAt equals startAt validation

Resource Validation:
- Fund not found error

Authorization:
- Regular user without organization admin privileges

Business Logic:
- Duplicate campaign name prevention

Success Scenarios:
- Global administrator creates campaign
- Organization administrator creates campaign

Coverage Achieved:
- Statement: 95.02%
- Branch: 95.65%
- Function: 100%
- Lines: 95.02%

## Uncovered Lines:
Lines 170-182 contain defensive error checks for unexpected PostgreSQL behavior that cannot be reliably tested without database mocking, which violates the repository's integration-first testing philosophy.

Files Modified:
- `test/graphql/types/Mutation/createFundCampaign.test.ts` - Complete test suite (11 tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for fund campaign creation, including validation of authentication, authorization, and various edge cases to ensure mutation reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->