### PR TITLE
test: add comprehensive tests for MutationUnassignUserTagInput schema

### DIFF
--- a/test/graphql/inputs/MutationUnassignUserTagInput.test.ts
+++ b/test/graphql/inputs/MutationUnassignUserTagInput.test.ts
@@ -142,16 +142,15 @@ describe("MutationUnassignUserTagInput Schema", () => {
 			});
 			expect(result.success).toBe(false);
 			if (!result.success) {
-				// Error could be from base schema validation (Required) or refine validation
-				const hasValidationIssue = result.error.issues.some(
+				// Should have an error about tagId being required or undefined
+				expect(result.error.issues.length).toBeGreaterThan(0);
+				const hasTagIdIssue = result.error.issues.some(
 					(issue) =>
-						issue.message.includes("assigneeId") ||
+						issue.path.includes("tagId") ||
 						issue.message.includes("tagId") ||
-						issue.message.includes("Both") ||
-						issue.message.includes("Required") ||
-						issue.code === "invalid_type",
+						issue.message.includes("Both"),
 				);
-				expect(hasValidationIssue).toBe(true);
+				expect(hasTagIdIssue).toBe(true);
 			}
 		});
 	});


### PR DESCRIPTION
## What kind of change does this PR introduce?
Test coverage improvement

## Issue Number:
Fixes #3881

## Summary
This PR adds comprehensive unit tests for [src/graphql/inputs/MutationUnassignUserTagInput.ts](cci:7://file:///c:/Users/ADITYA%20SINGH/Desktop/talawa-api/src/graphql/inputs/MutationUnassignUserTagInput.ts:0:0-0:0) to achieve complete code coverage for the Zod schema validation.

## Changes Made
- Created [test/graphql/inputs/MutationUnassignUserTagInput.test.ts](cci:7://file:///c:/Users/ADITYA%20SINGH/Desktop/talawa-api/test/graphql/inputs/MutationUnassignUserTagInput.test.ts:0:0-0:0) with 12 test cases covering:
  - **Valid input tests** (2 tests): Validates both assigneeId and tagId are accepted when provided correctly
  - **assigneeId field validation** (3 tests): Tests for missing, undefined, and null values
  - **tagId field validation** (3 tests): Tests for missing, undefined, and null values
  - **Refine validation** (4 tests): Tests empty input, both fields undefined/null, and error message verification

## Does this PR introduce a breaking change?
No

## Checklist
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation (N/A - test file only)
- [x] I have updated the documentation accordingly (N/A)
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Vitest test coverage for "unassign user tag" input validation, covering valid input scenarios, per-field presence checks, combined-field refinement rules, and verification of clear validation error messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->