### PR TITLE
docs: add Docusaurus installation step for developers

### DIFF
--- a/docs/docs/docs/getting-started/installation.md
+++ b/docs/docs/docs/getting-started/installation.md
@@ -145,6 +145,24 @@ pnpm install
 
 The prerequisites are now installed. The next step will be to get the app up and running.
 
+### Install Docusaurus (Development only)
+
+> **Note:** This step is required **only for developers** working on documentation.  
+> End users running Talawa-API in production can skip this section.
+
+
+[Docusaurus](https://docusaurus.io/) is a modern static website generator that we use to build our documentation website. You will need to install it **only if you plan to work on or build the documentation locally**.
+
+
+1. Navigate to the `docs` directory:
+   ```bash
+   cd docs
+   ```
+2. Install the dependencies:
+   ```bash
+   pnpm install
+   ```
+
 ### Install Docker
 
 Follow these steps to install Docker on your system:


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Documentation update

**Issue Number:**

Fixes #4031

**Snapshots/Videos:**

Not applicable (documentation-only change)

**If relevant, did you update the documentation?**

Yes – updated the installation guide to include a developer-only Docusaurus setup step.

**Summary**

New contributors encountered pre-commit and documentation build failures due to Docusaurus not being installed.  
This PR updates the installation documentation to clearly include a **developer-only** Docusaurus installation step immediately after installing pnpm dependencies, preventing setup confusion.

**Does this PR introduce a breaking change?**

No

## Checklist

### CodeRabbit AI Review
- [x] Not applicable (documentation-only change)

### Test Coverage
- [x] Not applicable (documentation-only change)

**Other information**

This change is scoped only to documentation and does not affect application logic or runtime behavior.

**Have you read the contributing guide?**

Yes
