### PR TITLE
test: add unit tests for AdvertisementAttachment.url field resolver

### DIFF
--- a/test/graphql/types/AdvertisementAttachment/url.test.ts
+++ b/test/graphql/types/AdvertisementAttachment/url.test.ts
@@ -1,0 +1,202 @@
+import type { GraphQLObjectType } from "graphql";
+import { beforeAll, describe, expect, it } from "vitest";
+import { schemaManager } from "~/src/graphql/schemaManager";
+import type { AdvertisementAttachment } from "~/src/graphql/types/AdvertisementAttachment/AdvertisementAttachment";
+// Import the actual implementation to ensure it's loaded for coverage
+import "~/src/graphql/types/AdvertisementAttachment/url";
+import envConfig from "~/src/utilities/graphqLimits";
+import { assertToBeNonNullish } from "../../../helpers";
+import { server } from "../../../server";
+
+describe("AdvertisementAttachment.url field resolver", () => {
+	let urlResolver!: NonNullable<
+		NonNullable<ReturnType<GraphQLObjectType["getFields"]>["url"]>["resolve"]
+	>;
+
+	beforeAll(async () => {
+		const schema = await schemaManager.buildInitialSchema();
+		const advertisementAttachmentType = schema.getType(
+			"AdvertisementAttachment",
+		) as GraphQLObjectType;
+		assertToBeNonNullish(advertisementAttachmentType);
+
+		const urlField = advertisementAttachmentType.getFields().url;
+		assertToBeNonNullish(urlField);
+		assertToBeNonNullish(urlField.resolve);
+		urlResolver = urlField.resolve;
+	});
+
+	function createTestContext() {
+		return {
+			currentClient: { isAuthenticated: true, user: { id: "test-user-id" } },
+			drizzleClient: server.drizzleClient,
+			log: server.log,
+			envConfig: server.envConfig,
+			jwt: server.jwt,
+			minio: server.minio,
+		};
+	}
+
+	function createMockParent(
+		name: string,
+	): Pick<AdvertisementAttachment, "name" | "mimeType" | "advertisementId"> {
+		return {
+			name,
+			mimeType: "image/png",
+			advertisementId: "test-advertisement-id",
+		};
+	}
+
+	describe("URL construction", () => {
+		it("should construct URL correctly with a simple file name", async () => {
+			const testName = "test-attachment.png";
+			const parent = createMockParent(testName);
+
+			const result = await urlResolver(
+				parent,
+				{},
+				createTestContext(),
+				{} as never,
+			);
+
+			expect(result).toBe(
+				new URL(
+					`/objects/${testName}`,
+					server.envConfig.API_BASE_URL,
+				).toString(),
+			);
+		});
+
+		it("should construct URL correctly with a name containing subdirectory", async () => {
+			const testName = "subdirectory/test-attachment.jpg";
+			const parent = createMockParent(testName);
+
+			const result = await urlResolver(
+				parent,
+				{},
+				createTestContext(),
+				{} as never,
+			);
+
+			expect(result).toBe(
+				new URL(
+					`/objects/${testName}`,
+					server.envConfig.API_BASE_URL,
+				).toString(),
+			);
+		});
+
+		it("should construct URL correctly with a name containing dashes and underscores", async () => {
+			const testName = "test-file_with-mixed_separators.webp";
+			const parent = createMockParent(testName);
+
+			const result = await urlResolver(
+				parent,
+				{},
+				createTestContext(),
+				{} as never,
+			);
+
+			expect(result).toBe(
+				new URL(
+					`/objects/${testName}`,
+					server.envConfig.API_BASE_URL,
+				).toString(),
+			);
+		});
+
+		it("should return a valid URL string", async () => {
+			const testName = "valid-attachment.png";
+			const parent = createMockParent(testName);
+
+			const result = await urlResolver(
+				parent,
+				{},
+				createTestContext(),
+				{} as never,
+			);
+
+			expect(() => new URL(result as string)).not.toThrow();
+			expect(result).toContain(testName);
+		});
+
+		it("should use the API_BASE_URL from context", async () => {
+			const testName = "attachment.png";
+			const parent = createMockParent(testName);
+
+			const result = await urlResolver(
+				parent,
+				{},
+				createTestContext(),
+				{} as never,
+			);
+
+			expect(result).toContain(server.envConfig.API_BASE_URL);
+		});
+
+		it("should include /objects/ path in the URL", async () => {
+			const testName = "test.png";
+			const parent = createMockParent(testName);
+
+			const result = await urlResolver(
+				parent,
+				{},
+				createTestContext(),
+				{} as never,
+			);
+
+			expect(result).toContain("/objects/");
+		});
+	});
+
+	describe("URL construction with various name formats", () => {
+		const testCases = [
+			"simple.png",
+			"with-dashes.jpg",
+			"with_underscores.gif",
+			"nested/path/file.webp",
+			"uuid-style-12345678-1234-1234-1234-123456789012.png",
+		];
+
+		it.each(testCases)(
+			"should construct correct URL for name: %s",
+			async (name) => {
+				const parent = createMockParent(name);
+
+				const result = await urlResolver(
+					parent,
+					{},
+					createTestContext(),
+					{} as never,
+				);
+
+				expect(result).toBe(
+					new URL(
+						`/objects/${name}`,
+						server.envConfig.API_BASE_URL,
+					).toString(),
+				);
+			},
+		);
+	});
+
+	describe("complexity configuration", () => {
+		it("should have correct complexity value", async () => {
+			const schema = await schemaManager.buildInitialSchema();
+
+			const advertisementAttachmentType = schema.getType(
+				"AdvertisementAttachment",
+			) as GraphQLObjectType;
+			const fields = advertisementAttachmentType.getFields();
+			expect(fields.url).toBeDefined();
+
+			const urlField = fields.url;
+			assertToBeNonNullish(urlField);
+
+			expect(urlField.extensions?.complexity).toBe(
+				envConfig.API_GRAPHQL_SCALAR_FIELD_COST,
+			);
+		});
+	});
+});
+


### PR DESCRIPTION
 **What kind of change does this PR introduce?**

Test coverage improvement - Adding unit tests for `src/graphql/types/AdvertisementAttachment/url.ts`

**Issue Number:**
Fixes #3922


**If relevant, did you update the documentation?**
N/A - No documentation changes required for test additions.

**Summary**
This PR adds comprehensive test coverage for the `AdvertisementAttachment.url` field resolver located at `src/graphql/types/AdvertisementAttachment/url.ts`.

The changes include:

1. **Created new test file**: `test/graphql/types/AdvertisementAttachment/url.test.ts`

2. **Implemented comprehensive tests for URL construction**:
   - Tests URL construction with simple file names (e.g., `test-attachment.png`)
   - Tests URL construction with subdirectory paths (e.g., `subdirectory/test-attachment.jpg`)
   - Tests URL construction with mixed separators (dashes and underscores)
   - Validates that the returned URL is a valid URL string
   - Confirms the URL uses `API_BASE_URL` from context
   - Verifies the URL includes the `/objects/` path prefix

3. **Validated correct URL generation with different naming conventions**:
   - Used parameterized tests (`it.each`) to test various name formats:
     - `simple.png`
     - `with-dashes.jpg`
     - `with_underscores.gif`
     - `nested/path/file.webp`
     - `uuid-style-12345678-1234-1234-1234-123456789012.png`

4. **Confirmed complexity configuration**:
   - Tests that the `url` field has the correct complexity value (`API_GRAPHQL_SCALAR_FIELD_COST`)

**Does this PR introduce a breaking change?**
No - This PR only adds tests and does not modify any production code.

## Checklist
### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [x] I have implemented or provided justification for each non-critical suggestion
- [x] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass

**Other information**

The test file follows the existing testing patterns in the repository, specifically modeled after similar URL resolver tests like `test/graphql/types/Chat/avatarURL.test.ts`.

Tests cover:
- URL construction logic using `new URL()` constructor
- Proper concatenation of `/objects/${parent.name}` with `ctx.envConfig.API_BASE_URL`
- Edge cases with various file name formats
- GraphQL field complexity configuration

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for the AdvertisementAttachment URL field resolver, validating URL construction for various file naming formats and GraphQL complexity metadata compliance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->