### PR TITLE
Add test coverage for src/graphql/types/Organization/avatarURL.ts (Fix #3915)

### DIFF
--- a/test/graphql/types/Organization/avatarURL.test.ts
+++ b/test/graphql/types/Organization/avatarURL.test.ts
@@ -204,22 +204,23 @@ describe("Organization.avatarURL field resolver - Unit tests", () => {
 	});
 
 	describe("Different avatar file types", () => {
-        it.each([
+		it.each([
 			["PNG", "avatar.png", "image/png"],
 			["JPG", "avatar.jpg", "image/jpeg"],
 			["WEBP", "avatar.webp", "image/webp"],
 			["AVIF", "avatar.avif", "image/avif"],
 			["no extension", "avatar-no-extension", "image/png"],
-		] as const)(
-			"should handle %s avatars",
-			async (_fileType: string, avatarName: string, mimeType: "image/png" | "image/jpeg" | "image/webp" | "image/avif") => {
-				mockOrganization.avatarName = avatarName;
-				mockOrganization.avatarMimeType = mimeType;
+		] as const)("should handle %s avatars", async (_fileType: string, avatarName: string, mimeType:
+			| "image/png"
+			| "image/jpeg"
+			| "image/webp"
+			| "image/avif") => {
+			mockOrganization.avatarName = avatarName;
+			mockOrganization.avatarMimeType = mimeType;
 
-				const result = await avatarURLResolver(mockOrganization, {}, ctx);
+			const result = await avatarURLResolver(mockOrganization, {}, ctx);
 
-				expect(result).toBe(`http://localhost:4000/objects/${avatarName}`);
-			},
-		);
+			expect(result).toBe(`http://localhost:4000/objects/${avatarName}`);
+		});
 	});
 });


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Test improvement / Code coverage enhancement

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #3915

**Snapshots/Videos:**

NA

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

N/A - This is a testing improvement that doesn't require documentation updates.

<!--Add link to Talawa-Docs.-->

**Summary**

Adds comprehensive unit tests for the Organization.avatarURL field resolver (src/graphql/types/Organization/avatarURL.ts) to satisfy issue #3915 and bring the file to 100% test coverage.

What the tests do:

- Load the resolver via schema import to ensure the implementation is executed for coverage.
- Use a mock GraphQL context (createMockGraphQLContext) and a mock Organization parent to exercise the resolver.
- Verify correct handling of null and empty avatarName values (returns null or expected URL).
- Validate URL construction across different API_BASE_URL configurations (http/https, ports, trailing slashes, base paths) and assert URL constructor behavior.
- Test filename edge cases: special characters, spaces (percent-encoding), path separators, UUID-formatted names, and names without extensions.
- Confirm behavior is independent of authentication state (authenticated vs unauthenticated contexts).
- Check multiple mime types (png, jpg, webp, avif) only to ensure consistent URL output and overall string/URL validity (constructing a URL object to assert correctness).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for the Organization avatar URL resolver, covering null and empty avatar names, various name formats (special characters, UUIDs, subfolders, spaces, with/without extensions), multiple MIME types, different base URL configurations (schemes, ports, paths, trailing slashes), and behavior in authenticated vs unauthenticated contexts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->