### PR TITLE
Revert "Fix: Sample post attachments upload to MinIO"

### DIFF
--- a/scripts/dbManagement/helpers.ts
+++ b/scripts/dbManagement/helpers.ts
@@ -428,7 +428,7 @@ export async function insertCollections(
 								const fileExtension = attachment.mimeType.split("/").pop();
 								const filePath = path.resolve(
 									dirname,
-									`./sample_data/images/${attachment.objectName}.${fileExtension}`,
+									`./sample_data/images/${attachment.name}.${fileExtension}`,
 								);
 								const fileData = await fs.readFile(filePath);
 								await minioClient.putObject(
@@ -442,7 +442,7 @@ export async function insertCollections(
 								);
 							} catch (error) {
 								console.error(
-									`Failed to upload attachment ${attachment.objectName}:`,
+									`Failed to upload attachment ${attachment.name}:`,
 									error,
 								);
 								throw error;


### PR DESCRIPTION
Reverts PalisadoesFoundation/talawa-api#4047

This needs to be reverted it's causing E2E tests to fail in Talawa Admin

- https://github.com/PalisadoesFoundation/talawa-admin/actions/runs/20436900677/job/58725108602?pr=5406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected attachment reference handling to ensure proper file processing and error reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->