### PR TITLE
Revert "Revert "Revert "Fix: Sample post attachments upload to MinIO"""

### DIFF
--- a/scripts/dbManagement/helpers.ts
+++ b/scripts/dbManagement/helpers.ts
@@ -428,7 +428,7 @@ export async function insertCollections(
 								const fileExtension = attachment.mimeType.split("/").pop();
 								const filePath = path.resolve(
 									dirname,
-									`./sample_data/images/${attachment.objectName}.${fileExtension}`,
+									`./sample_data/images/${attachment.name}.${fileExtension}`,
 								);
 								const fileData = await fs.readFile(filePath);
 								await minioClient.putObject(
@@ -442,7 +442,7 @@ export async function insertCollections(
 								);
 							} catch (error) {
 								console.error(
-									`Failed to upload attachment ${attachment.objectName}:`,
+									`Failed to upload attachment ${attachment.name}:`,
 									error,
 								);
 								throw error;


### PR DESCRIPTION
Reverts PalisadoesFoundation/talawa-api#4056

1. This needs to be reverted
1. It's causing failures in the Talawa Admin E2E workflow where the db cannot be loaded
    1. https://github.com/PalisadoesFoundation/talawa-admin/actions/runs/20438348438/job/58731312464?pr=5264

        <img width="1760" height="1002" alt="image" src="https://github.com/user-attachments/assets/38cfb052-bafc-48b8-975c-f60fe460247b" />


All your recent PRs related to image uploads need to be reverted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected attachment name handling in post attachments processing to ensure proper file path resolution and accurate error messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->