### PR TITLE
test: added test for src/graphql/types/TagFolder/parentFolder.ts

### DIFF
--- a/test/graphql/types/TagFolder/parentFolder.test.ts
+++ b/test/graphql/types/TagFolder/parentFolder.test.ts
@@ -1,0 +1,253 @@
+import { createMockGraphQLContext } from "test/_Mocks_/mockContextCreator/mockContextCreator";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GraphQLContext } from "~/src/graphql/context";
+import { schema } from "~/src/graphql/schema";
+import type { TagFolder as TagFolderType } from "~/src/graphql/types/TagFolder/TagFolder";
+
+describe("TagFolder Resolver - ParentFolder Field", () => {
+	let ctx: GraphQLContext;
+	let mockTagFolder: TagFolderType;
+	let mocks: ReturnType<typeof createMockGraphQLContext>["mocks"];
+
+	beforeEach(() => {
+		const { context, mocks: newMocks } = createMockGraphQLContext(
+			true,
+			"user-123",
+		);
+		ctx = context;
+		mocks = newMocks;
+		mockTagFolder = {
+			id: "folder-123",
+			name: "Test Folder",
+			createdAt: new Date(),
+			updatedAt: new Date(),
+			creatorId: "user-123",
+			updaterId: null,
+			organizationId: "org-123",
+			parentFolderId: "parent-folder-456",
+		} as TagFolderType;
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("should return null if parentFolderId is null", async () => {
+		mockTagFolder.parentFolderId = null;
+
+		const tagFolderType = schema.getType("TagFolder");
+
+		if (
+			!tagFolderType ||
+			tagFolderType.constructor.name !== "GraphQLObjectType"
+		) {
+			throw new Error("TagFolder type not found in schema");
+		}
+
+		const fields = (
+			tagFolderType as {
+				getFields: () => Record<
+					string,
+					{
+						resolve?: (
+							parent: TagFolderType,
+							args: Record<string, unknown>,
+							context: GraphQLContext,
+						) => Promise<unknown>;
+					}
+				>;
+			}
+		).getFields();
+		const parentFolderField = fields.parentFolder;
+
+		if (!parentFolderField || !parentFolderField.resolve) {
+			throw new Error("parentFolder field or resolver not found");
+		}
+
+		const result = await parentFolderField.resolve(mockTagFolder, {}, ctx);
+		expect(result).toBeNull();
+		expect(
+			mocks.drizzleClient.query.tagFoldersTable.findFirst,
+		).not.toHaveBeenCalled();
+	});
+
+	it("should fetch and return parent folder if parentFolderId exists", async () => {
+		const parentFolder = {
+			id: "parent-folder-456",
+			name: "Parent Folder",
+			createdAt: new Date(),
+			updatedAt: new Date(),
+			creatorId: "user-123",
+			updaterId: null,
+			organizationId: "org-123",
+			parentFolderId: null,
+		};
+
+		mockTagFolder.parentFolderId = "parent-folder-456";
+		mocks.drizzleClient.query.tagFoldersTable.findFirst.mockResolvedValueOnce(
+			parentFolder,
+		);
+
+		const tagFolderType = schema.getType("TagFolder");
+
+		if (
+			!tagFolderType ||
+			tagFolderType.constructor.name !== "GraphQLObjectType"
+		) {
+			throw new Error("TagFolder type not found in schema");
+		}
+
+		const fields = (
+			tagFolderType as {
+				getFields: () => Record<
+					string,
+					{
+						resolve?: (
+							parent: TagFolderType,
+							args: Record<string, unknown>,
+							context: GraphQLContext,
+						) => Promise<unknown>;
+					}
+				>;
+			}
+		).getFields();
+		const parentFolderField = fields.parentFolder;
+
+		if (!parentFolderField || !parentFolderField.resolve) {
+			throw new Error("parentFolder field or resolver not found");
+		}
+
+		const result = await parentFolderField.resolve(mockTagFolder, {}, ctx);
+		expect(result).toEqual(parentFolder);
+		expect(
+			mocks.drizzleClient.query.tagFoldersTable.findFirst,
+		).toHaveBeenCalledTimes(1);
+	});
+
+	it("should throw unexpected error and log if parent folder does not exist (database corruption)", async () => {
+		mockTagFolder.parentFolderId = "parent-folder-456";
+		mocks.drizzleClient.query.tagFoldersTable.findFirst.mockResolvedValueOnce(
+			undefined,
+		);
+
+		const logErrorSpy = vi.spyOn(ctx.log, "error");
+
+		const tagFolderType = schema.getType("TagFolder");
+
+		if (
+			!tagFolderType ||
+			tagFolderType.constructor.name !== "GraphQLObjectType"
+		) {
+			throw new Error("TagFolder type not found in schema");
+		}
+
+		const fields = (
+			tagFolderType as {
+				getFields: () => Record<
+					string,
+					{
+						resolve?: (
+							parent: TagFolderType,
+							args: Record<string, unknown>,
+							context: GraphQLContext,
+						) => Promise<unknown>;
+					}
+				>;
+			}
+		).getFields();
+		const parentFolderField = fields.parentFolder;
+
+		if (!parentFolderField || !parentFolderField.resolve) {
+			throw new Error("parentFolder field or resolver not found");
+		}
+
+		await expect(
+			parentFolderField.resolve(mockTagFolder, {}, ctx),
+		).rejects.toMatchObject({
+			extensions: { code: "unexpected" },
+		});
+
+		expect(logErrorSpy).toHaveBeenCalledWith(
+			"Postgres select operation returned an empty array for a tag folder's parent folder id that isn't null.",
+		);
+	});
+
+	it("should query tagFoldersTable with correct parentFolderId in where clause", async () => {
+		const parentFolder = {
+			id: "parent-folder-456",
+			name: "Parent Folder",
+			createdAt: new Date(),
+			updatedAt: new Date(),
+			creatorId: "user-123",
+			updaterId: null,
+			organizationId: "org-123",
+			parentFolderId: null,
+		};
+
+		mockTagFolder.parentFolderId = "parent-folder-456";
+		mocks.drizzleClient.query.tagFoldersTable.findFirst.mockResolvedValueOnce(
+			parentFolder,
+		);
+
+		const tagFolderType = schema.getType("TagFolder");
+
+		if (
+			!tagFolderType ||
+			tagFolderType.constructor.name !== "GraphQLObjectType"
+		) {
+			throw new Error("TagFolder type not found in schema");
+		}
+
+		const fields = (
+			tagFolderType as {
+				getFields: () => Record<
+					string,
+					{
+						resolve?: (
+							parent: TagFolderType,
+							args: Record<string, unknown>,
+							context: GraphQLContext,
+						) => Promise<unknown>;
+					}
+				>;
+			}
+		).getFields();
+		const parentFolderField = fields.parentFolder;
+
+		if (!parentFolderField || !parentFolderField.resolve) {
+			throw new Error("parentFolder field or resolver not found");
+		}
+
+		await parentFolderField.resolve(mockTagFolder, {}, ctx);
+
+		expect(
+			mocks.drizzleClient.query.tagFoldersTable.findFirst,
+		).toHaveBeenCalledWith({
+			where: expect.any(Function),
+		});
+
+		// Get the where function that was passed and verify it uses the correct id
+		const findFirstCall = mocks.drizzleClient.query.tagFoldersTable.findFirst
+			.mock.calls[0] as [{ where?: unknown }] | undefined;
+
+		if (!findFirstCall || !findFirstCall[0]) {
+			throw new Error("findFirst was not called with expected arguments");
+		}
+
+		const whereClause = findFirstCall[0].where;
+
+		if (typeof whereClause === "function") {
+			const mockFields = { id: "id-field" };
+			const mockOperators = {
+				eq: vi.fn().mockReturnValue("eq-result"),
+			};
+
+			whereClause(mockFields, mockOperators);
+
+			expect(mockOperators.eq).toHaveBeenCalledWith(
+				"id-field",
+				"parent-folder-456",
+			);
+		}
+	});
+});


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
Fixes #3891

Fixes #<!--Add related issue number here.-->

**Snapshots/Videos:**

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for the TagFolder "parentFolder" field covering null-parent handling, successful parent fetching, simulated error handling with logged error verification, and validation that the data query uses the correct filtering logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->