### PR TITLE
fix(tests): MutationCreateAgendaItemInput validation bug and 100% coverage

### DIFF
--- a/src/graphql/inputs/MutationCreateAgendaItemInput.ts
+++ b/src/graphql/inputs/MutationCreateAgendaItemInput.ts
@@ -31,7 +31,7 @@ export const mutationCreateAgendaItemInputSchema = agendaItemsTableInsertSchema
 					message: `Cannot be provided for an agenda item of type "${arg.type}".`,
 					path: ["duration"],
 				});
-			} else {
+			} else if (arg.key !== undefined) {
 				ctx.addIssue({
 					code: "custom",
 					message: `Cannot be provided for an agenda item of type "${arg.type}".`,

--- a/test/graphql/inputs/MutationCreateAgendaItemInput.test.ts
+++ b/test/graphql/inputs/MutationCreateAgendaItemInput.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, it } from "vitest";
+import {
+	AGENDA_ITEM_DESCRIPTION_MAX_LENGTH,
+	AGENDA_ITEM_NAME_MAX_LENGTH,
+} from "~/src/drizzle/tables/agendaItems";
+import {
+	MutationCreateAgendaItemInput,
+	mutationCreateAgendaItemInputSchema,
+} from "~/src/graphql/inputs/MutationCreateAgendaItemInput";
+
+/**
+ * Tests for MutationCreateAgendaItemInput schema validation.
+ * Validates the superRefine logic for type-specific field constraints
+ * and base field validations for name and description.
+ */
+describe("MutationCreateAgendaItemInput Schema", () => {
+	const validBaseInput = {
+		folderId: "550e8400-e29b-41d4-a716-446655440000",
+		name: "Test Agenda Item",
+		type: "song" as const,
+	};
+
+	describe("type 'note' validation", () => {
+		it("should reject when both duration and key are provided for type 'note'", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				type: "note",
+				duration: "30 minutes",
+				key: "C Major",
+			});
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				const issues = result.error.issues;
+				const durationIssue = issues.find((i) => i.path.includes("duration"));
+				const keyIssue = issues.find((i) => i.path.includes("key"));
+				expect(durationIssue).toBeDefined();
+				expect(keyIssue).toBeDefined();
+				expect(durationIssue?.message).toContain('type "note"');
+				expect(keyIssue?.message).toContain('type "note"');
+			}
+		});
+
+		it("should reject when only duration is provided for type 'note'", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				type: "note",
+				duration: "30 minutes",
+			});
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				const issues = result.error.issues;
+				const durationIssue = issues.find((i) => i.path.includes("duration"));
+				expect(durationIssue).toBeDefined();
+				expect(durationIssue?.message).toContain('type "note"');
+				// Ensure key issue is NOT present since key was not provided
+				const keyIssue = issues.find((i) => i.path.includes("key"));
+				expect(keyIssue).toBeUndefined();
+			}
+		});
+
+		it("should reject when only key is provided for type 'note'", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				type: "note",
+				key: "C Major",
+			});
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				const issues = result.error.issues;
+				const keyIssue = issues.find((i) => i.path.includes("key"));
+				expect(keyIssue).toBeDefined();
+				expect(keyIssue?.message).toContain('type "note"');
+				// Ensure duration issue is NOT present since duration was not provided
+				const durationIssue = issues.find((i) => i.path.includes("duration"));
+				expect(durationIssue).toBeUndefined();
+			}
+		});
+
+		it("should accept type 'note' without duration and key", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				type: "note",
+			});
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe("type 'general' validation", () => {
+		it("should reject when key is provided for type 'general'", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				type: "general",
+				key: "C Major",
+			});
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				const issues = result.error.issues;
+				const keyIssue = issues.find((i) => i.path.includes("key"));
+				expect(keyIssue).toBeDefined();
+				expect(keyIssue?.message).toContain('type "general"');
+			}
+		});
+
+		it("should accept type 'general' without key", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				type: "general",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should accept type 'general' with duration (duration is allowed)", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				type: "general",
+				duration: "45 minutes",
+			});
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe("type 'scripture' validation", () => {
+		it("should reject when key is provided for type 'scripture'", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				type: "scripture",
+				key: "C Major",
+			});
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				const issues = result.error.issues;
+				const keyIssue = issues.find((i) => i.path.includes("key"));
+				expect(keyIssue).toBeDefined();
+				expect(keyIssue?.message).toContain('type "scripture"');
+			}
+		});
+
+		it("should accept type 'scripture' without key", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				type: "scripture",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should accept type 'scripture' with duration (duration is allowed)", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				type: "scripture",
+				duration: "15 minutes",
+			});
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe("type 'song' validation", () => {
+		it("should accept type 'song' with key and duration", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				type: "song",
+				key: "G Major",
+				duration: "5 minutes",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should accept type 'song' with only key", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				type: "song",
+				key: "A Minor",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should accept type 'song' with only duration", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				type: "song",
+				duration: "3 minutes",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should accept type 'song' without key and duration", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				type: "song",
+			});
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe("name field validation", () => {
+		it("should accept valid name", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				name: "Valid Agenda Item Name",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should reject empty name", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				name: "",
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("should reject name exceeding max length", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				name: "a".repeat(AGENDA_ITEM_NAME_MAX_LENGTH + 1),
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("should accept name at exactly max length", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				name: "a".repeat(AGENDA_ITEM_NAME_MAX_LENGTH),
+			});
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe("description field validation", () => {
+		it("should accept valid description", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				description: "A valid agenda item description",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should accept input without description (optional field)", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should reject empty description", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				description: "",
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("should reject description exceeding max length", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				description: "a".repeat(AGENDA_ITEM_DESCRIPTION_MAX_LENGTH + 1),
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("should accept description at exactly max length", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				description: "a".repeat(AGENDA_ITEM_DESCRIPTION_MAX_LENGTH),
+			});
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe("required fields validation", () => {
+		it("should reject missing folderId", () => {
+			const { folderId, ...inputWithoutFolderId } = validBaseInput;
+			const result =
+				mutationCreateAgendaItemInputSchema.safeParse(inputWithoutFolderId);
+			expect(result.success).toBe(false);
+		});
+
+		it("should reject missing name", () => {
+			const { name, ...inputWithoutName } = validBaseInput;
+			const result =
+				mutationCreateAgendaItemInputSchema.safeParse(inputWithoutName);
+			expect(result.success).toBe(false);
+		});
+
+		it("should reject missing type", () => {
+			const { type, ...inputWithoutType } = validBaseInput;
+			const result =
+				mutationCreateAgendaItemInputSchema.safeParse(inputWithoutType);
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe("folderId field validation", () => {
+		it("should accept valid UUID folderId", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				folderId: "123e4567-e89b-12d3-a456-426614174000",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should reject invalid UUID folderId", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				folderId: "not-a-valid-uuid",
+			});
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe("type field validation", () => {
+		it("should reject invalid type value", () => {
+			const result = mutationCreateAgendaItemInputSchema.safeParse({
+				...validBaseInput,
+				type: "invalid_type",
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("should accept all valid type values", () => {
+			const validTypes = ["general", "note", "scripture", "song"] as const;
+			for (const type of validTypes) {
+				const result = mutationCreateAgendaItemInputSchema.safeParse({
+					...validBaseInput,
+					type,
+				});
+				expect(result.success).toBe(true);
+			}
+		});
+	});
+
+	describe("GraphQL Builder Type", () => {
+		it("should have MutationCreateAgendaItemInput defined in schema", async () => {
+			// Dynamically import the schema to trigger builder execution
+			// This causes the fields function (lines 62-85) to execute
+			const { schema } = await import("~/src/graphql/schema");
+
+			expect(schema).toBeDefined();
+			expect(MutationCreateAgendaItemInput).toBeDefined();
+
+			// Verify the input type exists in the schema
+			const typeMap = schema.getTypeMap();
+			expect(typeMap.MutationCreateAgendaItemInput).toBeDefined();
+		});
+	});
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Test coverage improvement and bug fix

**Issue Number:**

Fixes #4082 #3878

**Snapshots/Videos:**

Coverage before: 0%
Coverage after: 100%

```
 % Coverage report from v8
-|---------|----------|---------|---------|-------------------
 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-|---------|----------|---------|---------|-------------------
 |     100 |      100 |     100 |     100 |                   
  |     100 |      100 |     100 |     100 |                   
-|---------|----------|---------|---------|-------------------
```

**If relevant, did you update the documentation?**

N/A - Test coverage changes only

**Summary**

This PR improves the code coverage for `src/graphql/inputs/MutationCreateAgendaItemInput.ts` to 100%.

### Changes Made:

1. **Fixed a validation logic bug** in `MutationCreateAgendaItemInput.ts`:
   - The `superRefine` validation had an incorrect `else` branch that would add a `key` error even when `key` was undefined
   - Changed `} else {` to `} else if (arg.key !== undefined) {` at line 34
   - This allows "note" type agenda items to be created without providing unnecessary fields

2. **Created comprehensive test file** `test/graphql/inputs/MutationCreateAgendaItemInput.test.ts` with 31 tests covering:
   - Type-specific validation (note, general, scripture, song) - 15 tests
   - Name and description field validation - 9 tests
   - Required fields validation - 3 tests
   - folderId UUID validation - 2 tests
   - Type enum validation - 2 tests
   - GraphQL builder schema execution - 1 test

### All validation branches covered:
- Type "note" with both duration and key (reject)
- Type "note" with only duration (reject)
- Type "note" with only key (reject)
- Type "note" without duration or key (accept)
- Type "general" with key (reject)
- Type "scripture" with key (reject)
- Type "song" with any combination (accept)

**Does this PR introduce a breaking change?**

No. The bug fix corrects incorrect validation behavior that was preventing valid "note" type agenda items from being created.

## Checklist

### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [x] I have implemented or provided justification for each non-critical suggestion
- [x] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95% (100% achieved)
- [x] I have run the test suite locally and all tests pass

**Other information**

Run tests with coverage:
```bash
pnpm vitest run test/graphql/inputs/MutationCreateAgendaItemInput.test.ts --coverage --coverage.include="src/graphql/inputs/MutationCreateAgendaItemInput.ts"
```

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined validation for note-type agenda items so key-related errors are reported only when a key is actually provided; duration/key combinations now produce accurate error outcomes.

* **Tests**
  * Added comprehensive validation tests for agenda item creation covering all item types, required fields, field boundaries, UUID/type validation, and builder/schema presence.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->