### PR TITLE
Test/create tag folder mutation coverage

### DIFF
--- a/test/graphql/types/Mutation/createTagFolder.test.ts
+++ b/test/graphql/types/Mutation/createTagFolder.test.ts
@@ -85,6 +85,12 @@ async function createOrganization(adminAuthToken: string): Promise<string> {
 		},
 	);
 
+	if (createOrgResult.errors) {
+		throw new Error(
+			`Organization creation failed: ${JSON.stringify(createOrgResult.errors)}`,
+		);
+	}
+
 	assertToBeNonNullish(createOrgResult.data?.createOrganization?.id);
 	return createOrgResult.data.createOrganization.id;
 }
@@ -96,16 +102,25 @@ async function addOrganizationMembership(params: {
 	organizationId: string;
 	role: "administrator" | "regular";
 }) {
-	await mercuriusClient.mutate(Mutation_createOrganizationMembership, {
-		headers: { authorization: `bearer ${params.adminAuthToken}` },
-		variables: {
-			input: {
-				memberId: params.memberId,
-				organizationId: params.organizationId,
-				role: params.role,
+	const result = await mercuriusClient.mutate(
+		Mutation_createOrganizationMembership,
+		{
+			headers: { authorization: `bearer ${params.adminAuthToken}` },
+			variables: {
+				input: {
+					memberId: params.memberId,
+					organizationId: params.organizationId,
+					role: params.role,
+				},
 			},
 		},
-	});
+	);
+
+	if (result.errors) {
+		throw new Error(
+			`Organization membership creation failed: ${JSON.stringify(result.errors)}`,
+		);
+	}
 }
 
 suite("Mutation field createTagFolder", () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Test coverage improvement

**Issue Number:** #3858 
Fixes: #3858


**Snapshots/Videos:**

N/A - Test file only

**If relevant, did you update the documentation?**

N/A - No documentation changes required

**Summary**

This PR adds comprehensive test coverage for `src/graphql/types/Mutation/createTagFolder.ts` to achieve **100% code coverage**.

**Changes made:**
- Created new test file: `test/graphql/types/Mutation/createTagFolder.test.ts`
- Added 15 test cases covering all code paths

**Test cases implemented:**

| Suite | Test Case |
|-------|-----------|
| Authentication | Returns error when client is not authenticated |
| Authentication | Returns error when user in token is not in database |
| Authentication | Returns error when non-member user tries to create |
| Authentication | Returns error when regular member (non-admin) tries to create |
| Authorization | Allows system administrator to create tag folder |
| Authorization | Allows organization administrator to create tag folder |
| Input Validation | Returns error for invalid argument types |
| Input Validation | Returns `invalid_arguments` error for empty name (zod schema) |
| Input Validation | Returns `invalid_arguments` error for name exceeding 256 characters |
| Resource Existence | Returns error when organization does not exist |
| Resource Existence | Returns error when parent folder does not exist |
| Resource Existence | Returns error when parent folder belongs to different organization |
| Successful Creation | Creates tag folder successfully without parent folder |
| Successful Creation | Creates tag folder successfully with parent folder |
| Edge Cases | Returns `unexpected` error when insert returns empty array |

**Coverage achieved:**
- Statements: 100%
- Branches: 100%
- Functions: 100%

**Does this PR introduce a breaking change?**

No

## Checklist

### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [x] I have implemented or provided justification for each non-critical suggestion
- [x] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass

**Other information**

The test file follows the existing patterns in the repository, using:
- `mercuriusClient` for GraphQL mutations
- `createRegularUserUsingAdmin()` helper for creating test users
- Proper cleanup functions with `afterEach`
- Mocking for edge case testing (drizzle client insert)

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes

