### PR TITLE
Test/update fund campaign rebased

### DIFF
--- a/src/graphql/types/Mutation/updateFundCampaign.ts
+++ b/src/graphql/types/Mutation/updateFundCampaign.ts
@@ -165,7 +165,7 @@ builder.mutationField("updateFundCampaign", (t) =>
 							operators.and(
 								operators.eq(fields.fundId, existingFundCampaign.fundId),
 								operators.eq(fields.name, name),
-								operators.ne(fields.id, parsedArgs.input.id)
+								operators.ne(fields.id, parsedArgs.input.id),
 							),
 					});
 

--- a/test/graphql/types/Mutation/updateFundCampaign.test.ts
+++ b/test/graphql/types/Mutation/updateFundCampaign.test.ts
@@ -218,20 +218,19 @@ suite("Mutation updateFundCampaign", () => {
 	});
 
 	test("self-name update succeeds", async () => {
-  const res = await mercuriusClient.mutate(UpdateFundCampaignMutation, {
-    headers: { authorization: `bearer ${adminToken}` },
-    variables: {
-      input: {
-        id: campaignId,
-        name: campaignName,
-      },
-    },
-  });
+		const res = await mercuriusClient.mutate(UpdateFundCampaignMutation, {
+			headers: { authorization: `bearer ${adminToken}` },
+			variables: {
+				input: {
+					id: campaignId,
+					name: campaignName,
+				},
+			},
+		});
 
-  expect(res.errors).toBeUndefined();
-  expect(res.data?.updateFundCampaign?.name).toBe(campaignName);
-});
-
+		expect(res.errors).toBeUndefined();
+		expect(res.data?.updateFundCampaign?.name).toBe(campaignName);
+	});
 
 	test("successful update of startAt and endAt", async () => {
 		const newStartAt = new Date(


### PR DESCRIPTION
What kind of change does this PR introduce?
Test coverage improvement

Issue Number
Fixes #3841 

Snapshots/Videos
Not applicable

If relevant, did you update the documentation?
Not required for this change

Summary
This PR adds comprehensive test coverage for the updateFundCampaign GraphQL mutation to ensure all executable branches are fully covered and reported correctly by Codecov.

The tests validate existing behavior only and do not introduce or modify any business logic.

Test Coverage Details
The following scenarios are now fully covered:

Unauthenticated access to the mutation

Invalid arguments handled at the resolver level

Fund campaign not found

Duplicate campaign name within the same fund

Authorization failures

Database update failure (unexpected error path)

Successful campaign update

All conditional branches, error paths, and success paths in the resolver are exercised, resulting in 100% coverage for the file.

Does this PR introduce a breaking change?
No.
This PR only adds and refines test cases and removes an unused test file. Runtime behavior remains unchanged.

Checklist
CodeRabbit AI Review
 I have reviewed and addressed all critical issues flagged by CodeRabbit AI

 I have implemented or provided justification for each non-critical suggestion

 I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

Test Coverage
 I have written tests for all relevant code paths

 I have verified that test coverage meets or exceeds 95%

 I have run the test suite locally and all tests pass

Other information
While improving test coverage, I noticed that goalAmount currently allows negative values without validation. This PR intentionally does not change behavior and remains focused on test coverage only. This can be addressed separately if stricter validation is desired.

Have you read the contributing guide?
Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fix**
  * Prevented false "name already in use" conflicts when updating a fund campaign, allowing the same name to be retained on save.

* **Tests**
  * Added end-to-end tests for fund-campaign updates covering unauthenticated/unauthorized access, not-found/invalid IDs, date validation (start/end), forbidden self-name updates, successful start/end updates, simulated database-failure and current-user-not-found scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->