### PR TITLE
Revert "Fix Flaky Performance Tracker Test"

### DIFF
--- a/test/utilities/metrics/performanceTracker.test.ts
+++ b/test/utilities/metrics/performanceTracker.test.ts
@@ -89,8 +89,8 @@ describe("Performance Tracker", () => {
 		const testOp = snapshot.ops["test-op"];
 		expect(testOp).toBeDefined();
 		expect(testOp?.count).toBe(1);
-		expect(testOp?.ms).toBeGreaterThanOrEqual(9);
-		expect(testOp?.max).toBeGreaterThanOrEqual(9);
+		expect(testOp?.ms).toBeGreaterThanOrEqual(10);
+		expect(testOp?.max).toBeGreaterThanOrEqual(10);
 	});
 
 	it("should handle async operation errors and still track time", async () => {
@@ -147,7 +147,7 @@ describe("Performance Tracker", () => {
 		const manualOp = snapshot.ops["manual-op"];
 		expect(manualOp).toBeDefined();
 		expect(manualOp?.count).toBe(1);
-		expect(manualOp?.ms).toBeGreaterThanOrEqual(9);
+		expect(manualOp?.ms).toBeGreaterThanOrEqual(10);
 	});
 
 	it("should track max duration for operations", async () => {


### PR DESCRIPTION
Reverts PalisadoesFoundation/talawa-api#4183

@iamnikhilranjan

1. Reverting.
2. The test should round to 10 for at least 2 decimal points
3. The spirit of the test has been violated. It is too crude
4. Please resubmit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated performance timing test thresholds for more accurate measurement validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->