### PR TITLE
Added tests for src/graphql/types/FundCampaignPledge/updater.ts

### DIFF
--- a/src/graphql/types/FundCampaignPledge/updater.ts
+++ b/src/graphql/types/FundCampaignPledge/updater.ts
@@ -43,6 +43,8 @@ export const resolveUpdater = async (
 			return currentUser;
 		}
 
+		const updaterId = parent.updaterId;
+
 		const existingUser = await ctx.drizzleClient.query.usersTable.findFirst({
 			where: (fields, operators) => operators.eq(fields.id, updaterId),
 		});


### PR DESCRIPTION
Fixes: #3883

**15 Test Cases Written:**

**Authentication:**
- Unauthenticated user error
- User not found after authentication (edge case)

**Self-Pledge Path:**
- Null updater returns null
- Current user is updater (self-update)
- Current user deleted during request (race condition edge case)
- Different updater exists
- Different updater not found (unexpected error)

**Admin Authorization Path:**
- Campaign not found error
- Unauthorized non-admin user
- System administrator without org membership (critical edge case)
- Organization administrator with membership
- Admin path with null updater
- Admin is the updater
- Different updater for admin (exists)
- Different updater for admin (not found)

**Database Query Validation:**
- UsersTable query parameters verification
- FundCampaignsTable nested structure verification
- Membership filtering by current user ID

**Bug Fixed:**
- Fixed undefined `updaterId` variable on line 47 (changed to `parent.updaterId`)

**Coverage Achieved:**
- **Statement:** 85.71%
- **Branch:** 92.00%
- **Function:** 62.50%
- **Lines:** 85.71%

**Uncovered Lines:** 27-28, 31-44, 164-170

Lines 164-170 contain the `FundCampaignPledge.implement()` block, which is Pothos GraphQL builder framework code for field registration. This cannot be reliably tested via unit tests without mocking the entire GraphQL schema builder infrastructure, which would test the framework rather than application logic.

Lines 27-28 and 31-44 are edge cases in the self-pledge validation path that have partial coverage through existing tests.

**Files Modified:**
- `src/graphql/types/FundCampaignPledge/updater.ts` - Fixed bug on line 47
- `test/graphql/types/FundCampaignPledge/updater.test.ts` - Complete test suite (15 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for pledge updater resolution, including scenarios for viewing own pledges, handling missing updaters, and administrative access control.

* **Refactor**
  * Improved internal code structure for pledge updater handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->