### PR TITLE
InstallFix (MacOS): Add Robust Error Handling with set -euo pipefail

### DIFF
--- a/scripts/install/macos/install-macos.sh
+++ b/scripts/install/macos/install-macos.sh
@@ -169,10 +169,10 @@ NODE_VERSION=$(jq -r '.engines.node // "lts"' package.json)
 # Clean version string (handle >=, ^, etc.)
 if [[ "$NODE_VERSION" =~ ^(\^|>=|~) ]]; then
     # Extract version number after prefix (fnm handles both full semver and major-only)
-    CLEAN_NODE_VERSION=$(echo "$NODE_VERSION" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+    CLEAN_NODE_VERSION=$(echo "$NODE_VERSION" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
     # Fallback to major version only if full semver not found
     if [ -z "$CLEAN_NODE_VERSION" ]; then
-        CLEAN_NODE_VERSION=$(echo "$NODE_VERSION" | grep -oE '[0-9]+' | head -1)
+        CLEAN_NODE_VERSION=$(echo "$NODE_VERSION" | grep -oE '[0-9]+' | head -1 || true)
     fi
 else
     CLEAN_NODE_VERSION="$NODE_VERSION"


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Replaced ```set -e``` with ```set -euo pipefail```

**Issue Number:** #4255

Fixes #4255

**Snapshots/Videos:**
<img width="1241" height="762" alt="image" src="https://github.com/user-attachments/assets/458dea98-2929-40e0-ad7f-b1d1a53b1e92" />

**If relevant, did you update the documentation?**
N/A since no functionality changed

**Summary**
Replaced ```set -e``` with ```set -euo pipefail``` to enable:
-e: Exit on error (existing behavior)
-u: Exit on unset variable usage
-o pipefail: Catch errors in pipeline commands


**Does this PR introduce a breaking change?**
NO

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved macOS installer robustness and error handling: installer now uses stricter safety checks and tolerates missing or unparsable Node.js version information without aborting, reducing false failures and improving reliability during installation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->