### PR TITLE
fix: reorder setup prompts to prioritize API

### DIFF
--- a/scripts/setup/setup.ts
+++ b/scripts/setup/setup.ts
@@ -950,6 +950,14 @@ export async function setup(): Promise<SetupAnswers> {
 	}
 	answers = await setCI(answers);
 	await initializeEnvFile(answers);
+	const useDefaultApi = await promptConfirm(
+		"useDefaultApi",
+		"Use recommended default API settings?",
+		true,
+	);
+	if (!useDefaultApi) {
+		answers = await apiSetup(answers);
+	}
 	const useDefaultMinio = await promptConfirm(
 		"useDefaultMinio",
 		"Use recommended default Minio settings?",
@@ -983,14 +991,6 @@ export async function setup(): Promise<SetupAnswers> {
 	);
 	if (!useDefaultCaddy) {
 		answers = await caddySetup(answers);
-	}
-	const useDefaultApi = await promptConfirm(
-		"useDefaultApi",
-		"Use recommended default API settings?",
-		true,
-	);
-	if (!useDefaultApi) {
-		answers = await apiSetup(answers);
 	}
 	answers = await administratorEmail(answers);
 	const setupReCaptcha = await promptConfirm(


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Reorders setup prompts so API settings are configured first.
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #4369 <!--Add related issue number here.-->

**Snapshots/Videos:**

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**
The setup script previously prompted for 3rd party app settings (Minio, CloudBeaver, etc.) before API settings. Since API variables are updated most frequently, they should come first. This PR moves the useDefaultApi prompt to immediately after 
initializeEnvFile, before Minio/CloudBeaver/Postgres/Caddy prompts.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->
Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Setup now asks API configuration earlier and no longer repeats the same API prompt, streamlining initial onboarding.

* **Tests**
  * Test suite updated to match the new setup flow: prompts now use boolean-style responses, external setup steps are mocked, file-system checks adapted, and related expectations adjusted to reflect the revised flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->