### PR TITLE
fix event creator and attendees authorization

### DIFF
--- a/src/graphql/types/Event/attendees.ts
+++ b/src/graphql/types/Event/attendees.ts
@@ -28,12 +28,20 @@ export const eventAttendeesResolver = async (
 					// For standalone events
 					and(
 						eq(eventAttendeesTable.eventId, parent.id),
-						eq(eventAttendeesTable.isCheckedIn, true),
+						or(
+							eq(eventAttendeesTable.isCheckedIn, true),
+							eq(eventAttendeesTable.isRegistered, true),
+							eq(eventAttendeesTable.isInvited, true),
+						),
 					),
 					// For recurring event instances
 					and(
 						eq(eventAttendeesTable.recurringEventInstanceId, parent.id),
-						eq(eventAttendeesTable.isCheckedIn, true),
+						or(
+							eq(eventAttendeesTable.isCheckedIn, true),
+							eq(eventAttendeesTable.isRegistered, true),
+							eq(eventAttendeesTable.isInvited, true),
+						),
 					),
 				),
 				with: {

--- a/src/graphql/types/Event/creator.ts
+++ b/src/graphql/types/Event/creator.ts
@@ -41,20 +41,8 @@ export const eventCreatorResolver = async (
 			});
 		}
 
-		const currentUserOrganizationMembership =
-			currentUser.organizationMembershipsWhereMember[0];
-
-		if (
-			currentUser.role !== "administrator" &&
-			(currentUserOrganizationMembership === undefined ||
-				currentUserOrganizationMembership.role !== "administrator")
-		) {
-			throw new TalawaGraphQLError({
-				extensions: {
-					code: "unauthorized_action",
-				},
-			});
-		}
+		// Creator information is visible to all authenticated users who can see the event.
+		// No additional authorization check is needed here.
 
 		if (parent.creatorId === null) {
 			return null;

--- a/test/graphql/types/Event/creator.test.ts
+++ b/test/graphql/types/Event/creator.test.ts
@@ -59,21 +59,7 @@ describe("Event Creator Resolver -Test ", () => {
 				new TalawaGraphQLError({ extensions: { code: "unauthenticated" } }),
 			);
 		});
-		it("should throw unauthorized_action for non admin and no organizationMemberShip", async () => {
-			const mockUserData: MockUser = {
-				id: "user-123",
-				role: "member",
-				organizationMembershipsWhereMember: [],
-			};
-
-			mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue(
-				mockUserData,
-			);
-			await expect(eventCreatorResolver(mockEvent, {}, ctx)).rejects.toThrow(
-				new TalawaGraphQLError({ extensions: { code: "unauthorized_action" } }),
-			);
-		});
-		it("should throw unauthorized_action for non admin user", async () => {
+		it("should return creator for non admin user", async () => {
 			const mockUserData: MockUser = {
 				id: "user-123",
 				role: "member",
@@ -82,12 +68,21 @@ describe("Event Creator Resolver -Test ", () => {
 				],
 			};
 
-			mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue(
-				mockUserData,
-			);
+			const mockCreator: MockUser = {
+				id: "creator-456",
+				role: "member",
+				organizationMembershipsWhereMember: [],
+			};
 
-			await expect(eventCreatorResolver(mockEvent, {}, ctx)).rejects.toThrow(
-				new TalawaGraphQLError({ extensions: { code: "unauthorized_action" } }),
+			mocks.drizzleClient.query.usersTable.findFirst
+				.mockResolvedValueOnce(mockUserData)
+				.mockResolvedValueOnce(mockCreator);
+
+			const result = await eventCreatorResolver(mockEvent, {}, ctx);
+			expect(result).toEqual(
+				expect.objectContaining({
+					id: "creator-456",
+				}),
 			);
 		});
 	});
@@ -328,19 +323,28 @@ describe("Event Creator Resolver -Test ", () => {
 			expect(ctx.log.error).not.toHaveBeenCalled();
 		});
 
-		it("should handle missing organization membership gracefully", async () => {
+		it("should return creator even with missing organization membership", async () => {
 			const mockUserData: MockUser = {
 				id: "user-123",
 				role: "member",
 				organizationMembershipsWhereMember: [],
 			};
 
-			mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValueOnce(
-				mockUserData,
-			);
+			const mockCreator: MockUser = {
+				id: "creator-456",
+				role: "member",
+				organizationMembershipsWhereMember: [],
+			};
 
-			await expect(eventCreatorResolver(mockEvent, {}, ctx)).rejects.toThrow(
-				new TalawaGraphQLError({ extensions: { code: "unauthorized_action" } }),
+			mocks.drizzleClient.query.usersTable.findFirst
+				.mockResolvedValueOnce(mockUserData)
+				.mockResolvedValueOnce(mockCreator);
+
+			const result = await eventCreatorResolver(mockEvent, {}, ctx);
+			expect(result).toEqual(
+				expect.objectContaining({
+					id: "creator-456",
+				}),
 			);
 		});
 	});


### PR DESCRIPTION

<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Bugfix
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #4721

**Snapshots/Videos:**
 N/A
<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
 N/A
<!--Add link to Talawa-Docs.-->

**Summary**
This PR fixes authorization for event `creator` and `attendees` fields, which currently return `null` or `unauthorized` for regular users. This blocks frontend visibility logic for Organization Members and Invite Only events.

**Changes:**
- Allow regular users to query `creator` field (public information)
- Allow regular users to query `attendees` field when they are the creator, an org member, or in the attendees list
- Enables proper event visibility in User Portal (frontend PR: https://github.com/PalisadoesFoundation/talawa-admin/pull/6387

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No. This change relaxes authorization restrictions, making previously inaccessible data available to legitimate users.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass


**Other information**
- This fix is essential for proper event visibility in the User Portal
- Without this fix, regular users cannot see their own "Organization Members" or "Invite Only" events
- The frontend has implemented workarounds where possible, but full functionality requires this backend change

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->
Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event attendee list now includes attendees who are checked-in, registered, or invited, improving visibility across standalone and recurring instances.
  * Event creator details are now visible to all authenticated users who can view the event.

* **Tests**
  * Updated authorization tests to expect creator visibility for non-admin users and adjusted mocks to reflect the revised lookup flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->