### PR TITLE
fix(test): make performanceTracker tests deterministic with fake timers

### DIFF
--- a/test/utilities/metrics/performanceTracker.test.ts
+++ b/test/utilities/metrics/performanceTracker.test.ts
@@ -1,10 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	createPerformanceTracker,
 	isPerformanceTracker,
 } from "~/src/utilities/metrics/performanceTracker";
 
 describe("Performance Tracker", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	it("should create a performance tracker with initial empty snapshot", () => {
 		const tracker = createPerformanceTracker();
 		const snapshot = tracker.snapshot();
@@ -85,7 +93,7 @@ describe("Performance Tracker", () => {
 
 		const asyncFn = vi.fn(async () => {
 			// Simulate async work with a delay
-			await new Promise((resolve) => setTimeout(resolve, 10));
+			await vi.advanceTimersByTimeAsync(10);
 			return "result";
 		});
 
@@ -108,7 +116,7 @@ describe("Performance Tracker", () => {
 		const tracker = createPerformanceTracker();
 
 		const asyncFn = vi.fn(async () => {
-			await new Promise((resolve) => setTimeout(resolve, 5));
+			await vi.advanceTimersByTimeAsync(5);
 			throw new Error("Test error");
 		});
 
@@ -121,18 +129,18 @@ describe("Performance Tracker", () => {
 		const errorOp = snapshot.ops["error-op"];
 		expect(errorOp).toBeDefined();
 		expect(errorOp?.count).toBe(1);
-		expect(errorOp?.ms).toBeGreaterThanOrEqual(4);
+		expect(errorOp?.ms).toBeGreaterThanOrEqual(5);
 	});
 
 	it("should track multiple async operations with same name", async () => {
 		const tracker = createPerformanceTracker();
 
 		await tracker.time("query", async () => {
-			await new Promise((resolve) => setTimeout(resolve, 10));
+			await vi.advanceTimersByTimeAsync(10);
 		});
 
 		await tracker.time("query", async () => {
-			await new Promise((resolve) => setTimeout(resolve, 5));
+			await vi.advanceTimersByTimeAsync(5);
 		});
 
 		const snapshot = tracker.snapshot();
@@ -150,7 +158,7 @@ describe("Performance Tracker", () => {
 		const end = tracker.start("manual-op");
 
 		// Simulate some work
-		await new Promise((resolve) => setTimeout(resolve, 10));
+		await vi.advanceTimersByTimeAsync(10);
 
 		end();
 
@@ -167,15 +175,15 @@ describe("Performance Tracker", () => {
 		const tracker = createPerformanceTracker();
 
 		await tracker.time("op", async () => {
-			await new Promise((resolve) => setTimeout(resolve, 5));
+			await vi.advanceTimersByTimeAsync(5);
 		});
 
 		await tracker.time("op", async () => {
-			await new Promise((resolve) => setTimeout(resolve, 20));
+			await vi.advanceTimersByTimeAsync(20);
 		});
 
 		await tracker.time("op", async () => {
-			await new Promise((resolve) => setTimeout(resolve, 10));
+			await vi.advanceTimersByTimeAsync(10);
 		});
 
 		const snapshot = tracker.snapshot();
@@ -194,7 +202,7 @@ describe("Performance Tracker", () => {
 
 		tracker.trackDb(100);
 		await tracker.time("query", async () => {
-			await new Promise((resolve) => setTimeout(resolve, 10));
+			await vi.advanceTimersByTimeAsync(10);
 		});
 
 		const snapshot = tracker.snapshot();
@@ -211,11 +219,11 @@ describe("Performance Tracker", () => {
 		tracker.trackCacheMiss();
 
 		await tracker.time("query", async () => {
-			await new Promise((resolve) => setTimeout(resolve, 10));
+			await vi.advanceTimersByTimeAsync(10);
 		});
 
 		await tracker.time("render", async () => {
-			await new Promise((resolve) => setTimeout(resolve, 5));
+			await vi.advanceTimersByTimeAsync(5);
 		});
 
 		const snapshot = tracker.snapshot();
@@ -313,11 +321,11 @@ describe("Performance Tracker", () => {
 		const tracker = createPerformanceTracker({ slowMs: 10 });
 
 		await tracker.time("fast-op", async () => {
-			await new Promise((resolve) => setTimeout(resolve, 5));
+			await vi.advanceTimersByTimeAsync(5);
 		});
 
 		await tracker.time("slow-op", async () => {
-			await new Promise((resolve) => setTimeout(resolve, 20));
+			await vi.advanceTimersByTimeAsync(20);
 		});
 
 		const snapshot = tracker.snapshot();
@@ -351,10 +359,10 @@ describe("Performance Tracker", () => {
 
 		tracker.trackDb(10);
 		await tracker.time("op1", async () => {
-			await new Promise((resolve) => setTimeout(resolve, 5));
+			await vi.advanceTimersByTimeAsync(5);
 		});
 		await tracker.time("op2", async () => {
-			await new Promise((resolve) => setTimeout(resolve, 5));
+			await vi.advanceTimersByTimeAsync(5);
 		});
 
 		const snapshot = tracker.snapshot();
@@ -368,7 +376,7 @@ describe("Performance Tracker", () => {
 		// Create 60 slow operations
 		for (let i = 0; i < 60; i++) {
 			await tracker.time(`slow-${i}`, async () => {
-				await new Promise((resolve) => setTimeout(resolve, 10));
+				await vi.advanceTimersByTimeAsync(10);
 			});
 		}
 
@@ -381,11 +389,11 @@ describe("Performance Tracker", () => {
 		const tracker = createPerformanceTracker({ slowMs: 50 });
 
 		await tracker.time("op1", async () => {
-			await new Promise((resolve) => setTimeout(resolve, 30));
+			await vi.advanceTimersByTimeAsync(30);
 		});
 
 		await tracker.time("op2", async () => {
-			await new Promise((resolve) => setTimeout(resolve, 60));
+			await vi.advanceTimersByTimeAsync(60);
 		});
 
 		const snapshot = tracker.snapshot();
@@ -396,10 +404,9 @@ describe("Performance Tracker", () => {
 
 	it("records op timings and cache stats", async () => {
 		const perf = createPerformanceTracker({ slowMs: 1 });
-		await perf.time(
-			"db:users.byId",
-			async () => new Promise((r) => setTimeout(r, 2)),
-		);
+		await perf.time("db:users.byId", async () => {
+			await vi.advanceTimersByTimeAsync(2);
+		});
 		perf.trackCacheHit();
 		perf.trackCacheMiss();
 		perf.trackCacheMiss();
@@ -458,7 +465,7 @@ describe("Performance Tracker", () => {
 		for (let i = 0; i < 50; i++) {
 			await tracker.time(`slow-${i}`, async () => {
 				// Use increasing delays: 10ms, 11ms, 12ms, ... 59ms
-				await new Promise((resolve) => setTimeout(resolve, 10 + i));
+				await vi.advanceTimersByTimeAsync(10 + i);
 			});
 		}
 
@@ -468,7 +475,7 @@ describe("Performance Tracker", () => {
 
 		// Add one more that's slower than the minimum (50ms >> 10ms minimum)
 		await tracker.time("very-slow-replacement", async () => {
-			await new Promise((resolve) => setTimeout(resolve, 50));
+			await vi.advanceTimersByTimeAsync(50);
 		});
 
 		const snapshotAfter = tracker.snapshot();
@@ -492,7 +499,7 @@ describe("Performance Tracker", () => {
 			await tracker.time(`slow-${i}`, async () => {
 				// Use increasing delays: 20ms, 21ms, 22ms, ... 69ms
 				// This ensures minMs will be at least 20ms
-				await new Promise((resolve) => setTimeout(resolve, 20 + i));
+				await vi.advanceTimersByTimeAsync(20 + i);
 			});
 		}
 
@@ -511,7 +518,7 @@ describe("Performance Tracker", () => {
 		// This tests the case where roundedMs <= minMs (line 174 condition is false)
 		await tracker.time("not-slower-than-min", async () => {
 			// Use a small delay that's guaranteed to be less than minMs
-			await new Promise((resolve) => setTimeout(resolve, 10));
+			await vi.advanceTimersByTimeAsync(10);
 		});
 
 		const snapshotAfter = tracker.snapshot();
@@ -600,7 +607,7 @@ describe("Performance Tracker", () => {
 		// and hit the if (!cur) { continue; } branch when it encounters slow[0] (undefined)
 		// The loop will skip the undefined entry and continue processing other valid entries
 		await tracker.time("very-slow", async () => {
-			await new Promise((resolve) => setTimeout(resolve, 50));
+			await vi.advanceTimersByTimeAsync(50);
 		});
 
 		// Verify the tracker still works correctly after encountering undefined entries
@@ -638,7 +645,7 @@ describe("Performance Tracker", () => {
 		// because all entries are invalid (ms = null), so the loop skips them all,
 		// leaving minIdx = -1 and minMs = Infinity, which triggers the return on line 180
 		await tracker.time("very-slow", async () => {
-			await new Promise((resolve) => setTimeout(resolve, 50));
+			await vi.advanceTimersByTimeAsync(50);
 		});
 
 		// The defensive check should have been triggered (minIdx === -1 || minMs === Infinity)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #4740 - Flaky test in Shard 4/12 ([test/utilities/metrics/performanceTracker.test.ts](cci:7://file:///Users/h30s/Projects/talawa-api/test/utilities/metrics/performanceTracker.test.ts:0:0-0:0))

## Did you add tests for your changes?

No new tests - this PR fixes existing flaky tests.

## Snapshots/Videos (if applicable)

N/A

## Summary

### Root Cause
Tests used real `setTimeout` with hardcoded delays (5ms, 10ms, 20ms) that were unreliable in CI environments under load due to:
- CPU contention from parallel test shards
- Container resource limits
- GC pauses

### Solution
- Added `vi.useFakeTimers()` in `beforeEach`/`afterEach` hooks
- Replaced all `setTimeout` delays with `vi.advanceTimersByTimeAsync()`
- Makes all 16 timing-based tests **deterministic and reliable**

### Pattern Validation
This fix uses the **established pattern** already proven in 20+ tests across the codebase:
- [test/services/caching/cacheService.test.ts](cci:7://file:///Users/h30s/Projects/talawa-api/test/services/caching/cacheService.test.ts:0:0-0:0)
- [test/utilities/pluginDependencyInstaller.test.ts](cci:7://file:///Users/h30s/Projects/talawa-api/test/utilities/pluginDependencyInstaller.test.ts:0:0-0:0) (15 uses)
- [test/services/email/EmailQueueProcessor.test.ts](cci:7://file:///Users/h30s/Projects/talawa-api/test/services/email/EmailQueueProcessor.test.ts:0:0-0:0)

## Does this PR introduce a breaking change?

No

## Have you read the contributing guide?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for performance tracking with improved timer control mechanisms to ensure more reliable and accurate timing measurements in test environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->