### PR TITLE
Add back CMD for non-compose deployment support 

### DIFF
--- a/docker/api.Containerfile
+++ b/docker/api.Containerfile
@@ -75,7 +75,9 @@ COPY --chown=talawa:talawa ./pnpm-lock.yaml ./pnpm-lock.yaml
 RUN pnpm fetch --frozen-lockfile
 COPY --chown=talawa:talawa ./ ./
 RUN pnpm install --frozen-lockfile --offline
-# No CMD specified - command is provided via compose file overrides
+# Default command to start development server automatically
+# Compose files can override this if needed
+CMD ["bash", "-l", "-c", "pnpm run start_development_server"]
 
 # This build stage is used to build the codebase used in production environment of talawa api. 
 FROM base AS production_code


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

**Issue Number:**
Fixes #4829

**Snapshots/Videos:**
N/A - Configuration fix

**If relevant, did you update the documentation?**
No documentation update needed - restoring previous behavior

**Summary**
This PR restores the CMD directive in the `non_production` target of the Dockerfile that was previously removed based on CodeRabbit AI's suggestion to avoid duplication with compose file overrides.

**Does this PR introduce a breaking change?**

No. This restores the previous working behavior and fixes the regression introduced by removing the CMD.

## Checklist

### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [x] I have implemented or provided justification for each non-critical suggestion
- [x] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass


**Other information**
This fixes the regression where removing the CMD directive broke deployments running containers without compose files. The CMD provides a fallback default while maintaining compatibility with compose overrides.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container configuration to automatically start the development server on launch. Manual startup commands are no longer required when running the container; Compose overrides remain available for custom configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->