### PR TITLE
Revert "Add back CMD for non-compose deployment support "

### DIFF
--- a/docker/api.Containerfile
+++ b/docker/api.Containerfile
@@ -75,9 +75,7 @@ COPY --chown=talawa:talawa ./pnpm-lock.yaml ./pnpm-lock.yaml
 RUN pnpm fetch --frozen-lockfile
 COPY --chown=talawa:talawa ./ ./
 RUN pnpm install --frozen-lockfile --offline
-# Default command to start development server automatically
-# Compose files can override this if needed
-CMD ["bash", "-l", "-c", "pnpm run start_development_server"]
+# No CMD specified - command is provided via compose file overrides
 
 # This build stage is used to build the codebase used in production environment of talawa api. 
 FROM base AS production_code


### PR DESCRIPTION
Reverts PalisadoesFoundation/talawa-api#4871

@MuhammadUmar7195 This needs to be reverted. The site is broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container configuration to require explicit command specification via external orchestration, removing the automatic default startup behavior for more flexible deployment control.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->