### PR TITLE
Revert "Automatically start development server in talawa-api container on launch #4829"

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -19,10 +19,7 @@ services:
       # https://docs.docker.com/reference/compose-file/build/#dockerfile
       dockerfile: ./docker/api.Containerfile
       # https://docs.docker.com/reference/compose-file/build/#target
-      target: non_production
-    # Override the default command to run the development server
-    # Using bash -l to ensure login shell loads environment properly
-    command: bash -l -c "pnpm run start_development_server"
+      target: production
     # https://docs.docker.com/reference/compose-file/services/#depends_on
     depends_on:
       minio:
@@ -91,7 +88,7 @@ services:
 
     # https://docs.docker.com/reference/compose-file/build/#using-build-and-image
     # https://docs.docker.com/reference/compose-file/build/#publishing-built-images
-    # https://docs.docker.com/reference/compose-file/services/#image
+    # https://docs.docker.com/reference/compose-file/services/#image 
     # image: ghcr.io/talawa/api:latest
     # https://docs.docker.com/reference/dockerfile/#healthcheck
     # https://docs.docker.com/reference/compose-file/services/#healthcheck
@@ -209,7 +206,7 @@ services:
     # https://docs.docker.com/compose/environment-variables/
     # https://docs.docker.com/reference/compose-file/services/#environment
     environment:
-      # https://github.com/docker-library/docs/blob/master/postgres/README.md#postgres_db
+        # https://github.com/docker-library/docs/blob/master/postgres/README.md#postgres_db
       - POSTGRES_DB=${POSTGRES_DB:?error}
         # https://github.com/docker-library/docs/blob/master/postgres/README.md#postgres_password
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?error}
@@ -252,7 +249,7 @@ services:
       test: ["CMD", "redis-cli", "ping"]
       timeout: 10s
     networks:
-      - redis # Connect Redis to the Redis network
+      - redis  # Connect Redis to the Redis network
     restart: unless-stopped
     volumes:
       - source: redis_data

--- a/docker/api.Containerfile
+++ b/docker/api.Containerfile
@@ -56,26 +56,21 @@ ARG API_GID
 ARG API_UID
 # For the subsequent shell commands makes the shell exit immediately if any command exits with a non zero exit code, makes the shell consider the exit code of the first command amongst the commands connected using the pipe operator `|` that exits with a non zero exit code for it to exit immediately(by default the shell considers the exit code of the last command amongst the commands connected with a pipe operator `|` for it to determine whether the operation was successful), tells the shell that following strings passed to it are commands to be executed and not paths to script files. 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-# Enable corepack globally before creating user
-RUN corepack enable
 # Deletes the pre-included "node" user along with its home directory.
 RUN userdel -r node \
     # Adds the "talawa" group with id equal to the value of argument "${API_GID}".
     && groupadd -g ${API_GID} talawa \
     # Adds the "talawa" user with id equal to the value of argument "${API_UID}", assigns it to "talawa" group, creates the home directory for "talawa" user, sets bash as the "talawa" user's login shell.
-    && useradd -g talawa -l -m -s "$(which bash)" -u ${API_UID} talawa
+    && useradd -g talawa -l -m -s "$(which bash)" -u ${API_UID} talawa \
+    && corepack enable
 USER talawa
 WORKDIR /home/talawa/api
-
-# Install pnpm for talawa user (corepack already enabled at system level)
-RUN corepack install -g pnpm@10.26.1
 
 FROM base AS non_production
 COPY --chown=talawa:talawa ./pnpm-lock.yaml ./pnpm-lock.yaml
 RUN pnpm fetch --frozen-lockfile
 COPY --chown=talawa:talawa ./ ./
 RUN pnpm install --frozen-lockfile --offline
-# No CMD specified - command is provided via compose file overrides
 
 # This build stage is used to build the codebase used in production environment of talawa api. 
 FROM base AS production_code

--- a/docker/compose.devcontainer.yaml
+++ b/docker/compose.devcontainer.yaml
@@ -11,9 +11,6 @@ services:
         - API_DEBUGGER_PORT=${API_DEBUGGER_PORT:?error}
       # https://docs.docker.com/reference/compose-file/build/#target
       target: devcontainer
-    # Override the default command to run the development server in devcontainer
-    # Using bash -l to ensure login shell loads environment properly
-    command: bash -l -c "pnpm run start_development_server"
     depends_on:
       minio:
         condition: service_healthy
@@ -180,6 +177,7 @@ services:
         name: redis
         published: ${REDIS_MAPPED_PORT:?error}
         target: 6379
+# https://docs.docker.com/reference/compose-file/volumes/
   redis-test:
     ports:
       - host_ip: ${REDIS_MAPPED_HOST_IP:?error}
@@ -190,7 +188,6 @@ services:
       - source: redis_test_data
         target: /data
         type: volume
-# https://docs.docker.com/reference/compose-file/volumes/
 volumes:
   api_bash_history:
   api_node_modules:

--- a/docs/docs/docs/getting-started/operation.md
+++ b/docs/docs/docs/getting-started/operation.md
@@ -138,23 +138,11 @@ All done!
 
 ### Development Server Startup
 
-The development server starts automatically when the `talawa-api` container is launched. You don't need to run any additional commands.
+The Development Server startup methodology depends on your environment.
 
-#### Automatic Startup
+#### From the CLI
 
-When you start the Docker container using:
-
-```bash
-docker compose up
-```
-
-The development server will automatically start and be accessible on port 4000.
-
-#### Manual Server Control (Optional)
-
-If you need to manually start or restart the server for debugging purposes:
-
-##### From the CLI
+After a successful installation of the DevContainer environment, use these commands to start the application's Docker container.
 
 1. To run in attached Mode
 
@@ -168,9 +156,9 @@ If you need to manually start or restart the server for debugging purposes:
    docker exec talawa-api-1 /bin/bash -c 'nohup pnpm run start_development_server > /dev/null 2>&1 &'
    ```
 
-##### Within VScode
+#### Within VScode
 
-You can run the app manually after closing the terminal or restarting vscode using these commands:
+You can run the app after closing the terminal or restating the vscode using these commands:
 
 1. for normal mode
 
@@ -184,7 +172,7 @@ You can run the app manually after closing the terminal or restarting vscode usi
       pnpm run start_development_server_with_debugger
    ```
 
-**Note:** The server automatically starts in development mode when the container launches.
+**Note:** These commands will start the server in development mode.
 
 ### Development Server Shutdown
 


### PR DESCRIPTION
Reverts PalisadoesFoundation/talawa-api#4843

@MuhammadUmar7195 This needs to be reverted. The site is broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated API container build process to use production target instead of development configuration
  * Reorganized container build step sequencing for improved efficiency
  * Adjusted service dependency resolution to allow optional startup sequencing in development environments

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->