### PR TITLE
fix(devcontainer): make setup non-interactive and validate lifecycle in CI

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -77,5 +77,6 @@
 	"remoteUser": "talawa",
 	"service": "api",
 	"shutdownAction": "stopCompose",
-	"workspaceFolder": "/home/talawa/api"
+	"workspaceFolder": "/home/talawa/api",
+	"runServices": ["api"]
 }

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,35 +1,63 @@
 #!/bin/sh
 set -eu
 
-# Preflight checks
-for cmd in fnm corepack pnpm; do
+echo "[devcontainer] Starting post-create setup..."
+
+# --------------------------------------------------------------------
+# Preflight: required base tools
+# --------------------------------------------------------------------
+for cmd in fnm corepack; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
-    echo "Error: Required command '$cmd' is not installed." >&2
+    echo "[ERROR] Required command '$cmd' is not installed." >&2
     exit 1
   fi
 done
 
-# Create directories if they don't exist
+# --------------------------------------------------------------------
+# Node.js setup via fnm (non-interactive)
+# --------------------------------------------------------------------
+fnm install
+fnm use
+
+# --------------------------------------------------------------------
+# Corepack + pnpm (NON-INTERACTIVE, PINNED)
+# Repo pins pnpm to 10.26.1 via packageManager
+# --------------------------------------------------------------------
+echo "[devcontainer] Enabling corepack..."
+corepack enable
+
+echo "[devcontainer] Activating pinned pnpm version (10.26.1)..."
+corepack prepare pnpm@10.26.1 --activate
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "[ERROR] pnpm is not available after corepack setup." >&2
+  exit 1
+fi
+
+pnpm --version
+
+# --------------------------------------------------------------------
+# Workspace directories
+# --------------------------------------------------------------------
 mkdir -p .pnpm-store node_modules
 
-# Fix permissions
-# We check writability first to avoid unnecessary sudo usage.
-# If chown fails on a non-writable directory, we fail fast to prevent hidden issues.
+# --------------------------------------------------------------------
+# Permissions (fail fast if broken)
+# --------------------------------------------------------------------
 if [ ! -w ".pnpm-store" ] || [ ! -w "node_modules" ]; then
-  # Use current user's UID:GID for ownership to ensure portability
   if ! sudo -n chown -R "$(id -u):$(id -g)" .pnpm-store node_modules; then
     echo "
-[ERROR] 'chown' failed for .pnpm-store or node_modules.
-Directories are not writable and sudo failed to change ownership to $(id -u):$(id -g).
-Please fix ownership permissions via Docker Compose volumes options or ensure
-the container user has write access.
+[ERROR] Failed to fix permissions for pnpm directories.
+Please ensure Docker volumes are writable by the container user.
 " >&2
     exit 1
   fi
 fi
 
-# Install dependencies and tools
-fnm install
-fnm use
-corepack enable
-pnpm install
+# --------------------------------------------------------------------
+# Install dependencies
+# --------------------------------------------------------------------
+echo "[devcontainer] Installing dependencies..."
+pnpm install --frozen-lockfile
+
+echo "[devcontainer] Post-create setup complete."

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -53,6 +53,16 @@ jobs:
           echo "Error: Source and Target Branches are the same. Please ensure they are different."
           echo "Error: Close this PR and try again."
           exit 1
+      - name: Lint shell scripts (shellcheck)
+        shell: bash
+        run: |
+          shopt -s globstar nullglob
+          files=(scripts/**/*.sh)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No shell scripts found to lint."
+          else
+            shellcheck -x --severity=error "${files[@]}"
+          fi
 
   Python-Compliance:
     name: Check Python Code Style
@@ -275,6 +285,7 @@ jobs:
             'Caddyfile$'
             'codegen.ts$'
             '^Dockerfile.*'
+            '^docker/.*'
             '^docker-compose.*'
             '^drizzle_migrations/.*'
             '^scripts/.*'
@@ -297,6 +308,8 @@ jobs:
             'LICENSE$'
             'tsconfig.json$'
             'vitest.config.ts$'
+            'vitest.*.config.ts$'
+            'codecov.yml$'
             'pnpm-lock.yaml$'
             'package.json$'
             'package-lock.json$'
@@ -418,6 +431,7 @@ jobs:
     needs:
       [
         Code-Quality-Checks,
+        Devcontainer-Validation,
         python_checks,
         check_type_errors,
         check_mock_isolation,
@@ -893,3 +907,25 @@ jobs:
       - name: Cleanup - Free ports by stopping containers
         if: always()
         run: docker compose down
+
+  Devcontainer-Validation:
+    name: Validate devcontainer lifecycle (non-interactive, pnpm available)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Devcontainer CLI
+        run: npm install -g @devcontainers/cli
+
+      - name: Start devcontainer (must not prompt)
+        env:
+          COMPOSE_PROJECT_NAME: talawa-api-ci
+        run: |
+          devcontainer up --workspace-folder .
+
+      - name: Verify pnpm is available inside devcontainer
+        env:
+          COMPOSE_PROJECT_NAME: talawa-api-ci
+        run: |
+          devcontainer exec --workspace-folder . pnpm --version


### PR DESCRIPTION
**What kind of change does this PR introduce?**

 Bugfix / CI reliability improvement

---

**Issue Number:**

Fixes #4890

---

**Snapshots/Videos:**
<img width="1908" height="992" alt="Screenshot from 2026-01-25 16-50-33" src="https://github.com/user-attachments/assets/b08a802f-2efa-4fdf-a0b0-ba47f216a282" />

<img width="1908" height="992" alt="Screenshot from 2026-01-25 16-50-43" src="https://github.com/user-attachments/assets/92aa4e80-bed8-40a6-ba97-48cb292fa1d7" />

---

**If relevant, did you update the documentation?**

No documentation updates were required. This PR focuses on fixing devcontainer automation and CI validation.

---

## Summary

This PR fixes a devcontainer setup issue where developers were prompted to manually install **corepack / pnpm**, which breaks non-interactive workflows and caused **false-negative CI results**.

### Key improvements:

- Makes devcontainer setup **fully non-interactive**
- Automatically enables **corepack** and activates **pnpm**
- Fails fast if `pnpm` is not available after setup
- Adds a **CI validation job** to ensure devcontainer builds succeed and `pnpm` is available
- Prevents future CI/CD false negatives related to devcontainer setup failures

This ensures local development, CI, and automated workflows behave consistently.

---

**Does this PR introduce a breaking change?**

No.  
The change only affects devcontainer initialization and CI validation logic. Existing workflows continue to work, but now fail correctly if the devcontainer setup is broken.

---

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have verified the devcontainer setup locally
- [x] I have confirmed `pnpm` is available non-interactively inside the devcontainer
- [x] I have validated that CI fails if devcontainer setup is broken

---

**Other information**

- Tested locally using VS Code Dev Containers
- Verified `pnpm --version` runs successfully inside the container
- CI now explicitly validates devcontainer build and tool availability

---

**Have you read the contributing guide?**

Yes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved development environment configuration for consistent setup across all developers.
  * Enhanced build system initialization with better error handling and progress visibility.
  * Added automated validation checks to the continuous integration pipeline to ensure development environment integrity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->