### PR TITLE
Revert "fix(devcontainer): ensure setup is non-interactive"

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -73,10 +73,9 @@
 	"initializeCommand": "/bin/sh -c '[ ! -f .env ] && cp ./envFiles/.env.devcontainer ./.env || true'",
 	"name": "talawa_api",
 	"overrideCommand": true,
-	"postCreateCommand": "bash ./.devcontainer/post-create.sh",
+	"postCreateCommand": "./.devcontainer/post-create.sh",
 	"remoteUser": "talawa",
 	"service": "api",
 	"shutdownAction": "stopCompose",
-	"workspaceFolder": "/home/talawa/api",
-	"runServices": ["api", "minio", "postgres", "redis"]
+	"workspaceFolder": "/home/talawa/api"
 }

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,83 +1,35 @@
-#!/usr/bin/env bash
-set -eu -o pipefail
+#!/bin/sh
+set -eu
 
-echo "[devcontainer] Starting post-create setup..."
-
-# --------------------------------------------------------------------
-# Preflight: required base tools
-# --------------------------------------------------------------------
-for cmd in fnm corepack node; do
+# Preflight checks
+for cmd in fnm corepack pnpm; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
-    echo "[ERROR] Required command '$cmd' is not installed." >&2
+    echo "Error: Required command '$cmd' is not installed." >&2
     exit 1
   fi
 done
 
-# --------------------------------------------------------------------
-# Node.js setup via fnm (non-interactive)
-# --------------------------------------------------------------------
-# fnm env outputs shell code; eval is required
-eval "$(fnm env --shell bash)"
-# Extract exact node version from package.json
-NODE_VERSION=$(node -p "require('./package.json').engines.node" 2>/dev/null || echo "lts/*")
-echo "[devcontainer] Installing Node version: $NODE_VERSION"
-fnm install "$NODE_VERSION"
-fnm use "$NODE_VERSION"
-
-# --------------------------------------------------------------------
-# Corepack + pnpm (STRICTLY NON-INTERACTIVE)
-# --------------------------------------------------------------------
-# These MUST be set BEFORE any corepack invocation
-export CI=true
-export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
-
-echo "[devcontainer] Enabling corepack..."
-corepack enable
-
-# --------------------------------------------------------------------
-# Validate and extract pnpm version from package.json
-# --------------------------------------------------------------------
-PNPM_VERSION="$(node -e '
-  const pkg = require("./package.json");
-  const pm = pkg.packageManager;
-  if (!pm || !pm.startsWith("pnpm@")) {
-    console.error("[ERROR] package.json packageManager must be pnpm@<version>.");
-    process.exit(1);
-  }
-  console.log(pm.split("@")[1]);
-')"
-
-echo "[devcontainer] Activating pnpm@${PNPM_VERSION}..."
-corepack prepare "pnpm@${PNPM_VERSION}" --activate
-
-# --------------------------------------------------------------------
-# Verify pnpm is usable WITHOUT triggering a prompt
-# --------------------------------------------------------------------
-PNPM_ACTUAL_VERSION="$(pnpm --version)"
-echo "[devcontainer] pnpm is ready (v${PNPM_ACTUAL_VERSION})"
-
-# --------------------------------------------------------------------
-# Workspace directories
-# --------------------------------------------------------------------
+# Create directories if they don't exist
 mkdir -p .pnpm-store node_modules
 
-# --------------------------------------------------------------------
-# Permissions (fail fast, non-interactive sudo)
-# --------------------------------------------------------------------
 # Fix permissions
 # We check writability first to avoid unnecessary sudo usage.
+# If chown fails on a non-writable directory, we fail fast to prevent hidden issues.
 if [ ! -w ".pnpm-store" ] || [ ! -w "node_modules" ]; then
+  # Use current user's UID:GID for ownership to ensure portability
   if ! sudo -n chown -R "$(id -u):$(id -g)" .pnpm-store node_modules; then
-    echo "[ERROR] Failed to fix pnpm directory permissions." >&2
-    echo "Directories are not writable and sudo failed to change ownership to $(id -u):$(id -g)." >&2
+    echo "
+[ERROR] 'chown' failed for .pnpm-store or node_modules.
+Directories are not writable and sudo failed to change ownership to $(id -u):$(id -g).
+Please fix ownership permissions via Docker Compose volumes options or ensure
+the container user has write access.
+" >&2
     exit 1
   fi
 fi
 
-# --------------------------------------------------------------------
-# Install dependencies
-# --------------------------------------------------------------------
-echo "[devcontainer] Installing dependencies..."
-pnpm install --frozen-lockfile
-
-echo "[devcontainer] Post-create setup complete."
+# Install dependencies and tools
+fnm install
+fnm use
+corepack enable
+pnpm install


### PR DESCRIPTION
Reverts PalisadoesFoundation/talawa-api#4928

CODEAbhinav-art 

This PR needed to be reverted.
- https://github.com/PalisadoesFoundation/talawa-api/pull/4928

The following error is seen when deploying on Linux. There is an incompatibility that needs to be resolved.


```
==> Downloading pnpm binaries 10.28.2
 WARN  using --force I sure hope you know what you are doing
Copying pnpm CLI from /tmp/tmp.fId41KWmDF/pnpm to /home/talawa-api/.local/share/pnpm/.tools/pnpm-exe/10.28.2/pnpm
No changes to the environment were made. Everything is already up to date.
 WARN  Unsupported engine: wanted: {"node":"24.12.0"} (current: {"node":"v22.22.0","pnpm":"10.26.1"})
Lockfile is up to date, resolution step is skipped
Packages: +823
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

   ╭──────────────────────────────────────────╮
   │                                          │
   │   Update available! 10.26.1 → 10.28.2.   │
   │   Changelog: https://pnpm.io/v/10.28.2   │
   │     To update, run: pnpm self-update     │
   │                                          │
   ╰──────────────────────────────────────────╯

Progress: resolved 823, reused 823, downloaded 0, added 823, done

dependencies:
+ @aws-sdk/client-ses 3.962.0
+ @fastify/cookie 11.0.2
+ @fastify/cors 11.2.0
+ @fastify/helmet 13.0.2
+ @fastify/jwt 10.0.0
+ @fastify/otel 0.16.0
+ @fastify/redis 7.1.0
+ @fastify/type-provider-typebox 6.1.0
+ @node-rs/argon2 2.0.2
+ @opentelemetry/api 1.9.0
+ @opentelemetry/core 2.2.0
+ @opentelemetry/exporter-trace-otlp-http 0.208.0
+ @opentelemetry/instrumentation-http 0.208.0
+ @opentelemetry/resources 2.2.0
+ @opentelemetry/sdk-node 0.208.0
+ @opentelemetry/sdk-trace-base 2.2.0
+ @pothos/core 4.12.0
+ @pothos/plugin-complexity 4.1.2
+ @pothos/plugin-relay 4.6.2
+ ajv-formats 3.0.1
+ axios 1.13.2
+ close-with-grace 2.4.0
+ dataloader 2.2.3
+ dotenv 17.2.3
+ drizzle-orm 0.44.7
+ drizzle-zod 0.8.3
+ env-schema 7.0.0
+ fastify 5.6.2
+ fastify-plugin 5.1.0
+ graphql 16.12.0
+ graphql-scalars 1.25.0
+ graphql-tag 2.12.6
+ graphql-upload-minimal 1.6.4
+ inquirer 12.11.1
+ mercurius 16.6.0
+ mercurius-upload 8.0.0
+ minio 8.0.6
+ node-cron 3.0.3
+ nodemailer 6.10.1
+ pino 9.14.0
+ postgres 3.4.7
+ typebox 1.0.71
+ ulidx 2.4.1
+ uuidv7 1.1.0
+ yauzl 3.2.0
+ zod 4.3.4

devDependencies:
+ @biomejs/biome 2.3.11
+ @faker-js/faker 10.1.0
+ @microsoft/tsdoc 0.16.0
+ @swc/cli 0.7.9
+ @swc/core 1.15.8
+ @types/node 22.19.3
+ @types/node-cron 3.0.11
+ @types/nodemailer 6.4.21
+ @types/yauzl 2.10.3
+ @vitest/coverage-v8 3.2.4
+ drizzle-kit 0.31.8
+ drizzle-seed 0.3.1
+ glob 13.0.0
+ gql.tada 1.9.0
+ knip 5.79.0
+ lefthook 2.0.13
+ mercurius-integration-testing 9.0.1
+ nyc 17.1.0
+ pino-pretty 13.1.3
+ tsx 4.21.0
+ typedoc 0.28.15
+ typedoc-plugin-markdown 4.9.0
+ typescript 5.9.3
+ vite-tsconfig-paths 5.1.4
+ vitest 3.2.4

╭ Warning ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                   │
│   Ignored build scripts: @swc/core@1.15.8, esbuild@0.18.20, esbuild@0.25.12, esbuild@0.27.2, lefthook@2.0.13, protobufjs@7.5.4.   │
│   Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.                                          │
│                                                                                                                                   │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
Done in 4.1s using pnpm v10.26.1
Already up to date
Progress: resolved 1, reused 0, downloaded 0, added 0, done
Done in 706ms using pnpm v10.28.2
[11 ms] @devcontainers/cli 0.82.0. Node.js v22.22.0. linux 6.8.0-39-generic x64.
[388 ms] Start: Run: docker compose -f /home/talawa-api/talawa-api/compose.yaml -f /home/talawa-api/talawa-api/docker/compose.testing.yaml -f /home/talawa-api/talawa-api/docker/compose.devcontainer.yaml --profile * config
[552 ms] Start: Run: docker compose -f /home/talawa-api/talawa-api/compose.yaml -f /home/talawa-api/talawa-api/docker/compose.testing.yaml -f /home/talawa-api/talawa-api/docker/compose.devcontainer.yaml --profile * config
[685 ms] name: talawa
services:
  api:
    profiles:
      - api
    build:
      context: /home/talawa-api/talawa-api
      dockerfile: ./docker/api.Containerfile
      args:
        API_DEBUGGER_HOST: 0.0.0.0
        API_DEBUGGER_PORT: "9229"
        API_GID: "1000"
        API_UID: "1000"
      target: devcontainer
    command:
      - pnpm
      - run_tests
    depends_on:
      minio:
        condition: service_healthy
        required: false
      minio-test:
        condition: service_healthy
        required: false
      postgres:
        condition: service_healthy
        required: false
      postgres-test:
        condition: service_healthy
        required: false
      redis:
        condition: service_healthy
        required: false
    healthcheck:
      test:
        - CMD-SHELL
        - node /home/talawa/api/docker/apiHealthcheck.js
      timeout: 10s
      interval: 10s
      retries: 3
      start_period: 5s
      start_interval: 1s
      disable: true
    init: true
    networks:
      api: null
      minio: null
      minio_test: null
      postgres: null
      postgres_test: null
      redis: null
      redis_test: null
    ports:
      - name: api
        mode: ingress
        host_ip: 0.0.0.0
        target: 4000
        published: "4000"
        protocol: tcp
      - name: api_debugger
        mode: ingress
        host_ip: 127.0.0.1
        target: 9229
        published: "9229"
        protocol: tcp
    restart: unless-stopped
    user: talawa
    volumes:
      - type: bind
        source: /home/talawa-api/talawa-api
        target: /home/talawa/api
        consistency: cached
      - type: bind
        source: /var/run/docker.sock
        target: /var/run/docker.sock
      - type: volume
        source: api_bash_history
        target: /commandhistory
      - type: volume
        source: api_node_modules
        target: /home/talawa/api/node_modules
      - type: volume
        source: api_pnpm_store
        target: /home/talawa/api/.pnpm-store
  caddy:
    profiles:
      - caddy
    depends_on:
      api:
        condition: service_healthy
        required: false
    environment:
      CADDY_TALAWA_API_DOMAIN_NAME: localhost
      CADDY_TALAWA_API_EMAIL: talawa@email.com
      CADDY_TALAWA_API_HOST: api
      CADDY_TALAWA_API_PORT: "4000"
    image: caddy:2.8.4-alpine
    networks:
      api: null
    ports:
      - name: caddy_http
        mode: ingress
        target: 80
        published: "8080"
        protocol: tcp
      - name: caddy_https
        mode: ingress
        target: 443
        published: "8443"
        protocol: tcp
      - name: caddy_http3
        mode: ingress
        target: 443
        published: "8443"
        protocol: udp
    restart: unless-stopped
    volumes:
      - type: volume
        source: caddy_config
        target: /config
      - type: volume
        source: caddy_data
        target: /data
      - type: bind
        source: /home/talawa-api/talawa-api/docker/Caddyfile
        target: /etc/caddy/Caddyfile
  cloudbeaver:
    profiles:
      - cloudbeaver
    depends_on:
      postgres:
        condition: service_healthy
        required: false
    environment:
      CB_ADMIN_NAME: talawa
      CB_ADMIN_PASSWORD: password
      CB_SERVER_NAME: Talawa CloudBeaver Server
      CB_SERVER_URL: http://127.0.0.1:8978
    healthcheck:
      test:
        - CMD-SHELL
        - curl -f -s http://127.0.0.1:8978
      timeout: 10s
      interval: 10s
      retries: 3
      start_period: 5s
      start_interval: 1s
    image: dbeaver/cloudbeaver:24.3.1
    networks:
      postgres: null
      postgres_test: null
    ports:
      - name: cloudbeaver
        mode: ingress
        host_ip: 127.0.0.1
        target: 8978
        published: "8978"
        protocol: tcp
    restart: unless-stopped
    volumes:
      - type: volume
        source: cloudbeaver_data
        target: /opt/cloudbeaver/workspace
  minio:
    profiles:
      - minio
    command:
      - server
      - /data
      - --console-address
      - :9001
    environment:
      MINIO_BROWSER: "on"
      MINIO_ROOT_PASSWORD: password
      MINIO_ROOT_USER: talawa
    healthcheck:
      test:
        - CMD-SHELL
        - mc ready local
      timeout: 10s
      interval: 10s
      retries: 3
      start_period: 5s
      start_interval: 1s
    image: minio/minio:RELEASE.2024-12-18T13-15-44Z
    networks:
      minio: null
    ports:
      - name: minio_api
        mode: ingress
        host_ip: 0.0.0.0
        target: 9000
        published: "9000"
        protocol: tcp
      - name: minio_console
        mode: ingress
        host_ip: 0.0.0.0
        target: 9001
        published: "9001"
        protocol: tcp
    restart: unless-stopped
    volumes:
      - type: volume
        source: minio_data
        target: /data
  minio-test:
    profiles:
      - minio_test
    command:
      - server
      - /data
      - --console-address
      - :9001
    environment:
      MINIO_BROWSER: "on"
      MINIO_ROOT_PASSWORD: password
      MINIO_ROOT_USER: talawa
    healthcheck:
      test:
        - CMD-SHELL
        - mc ready local
      timeout: 10s
      interval: 10s
      retries: 3
      start_period: 5s
      start_interval: 1s
    image: minio/minio:RELEASE.2024-12-18T13-15-44Z
    networks:
      minio_test: null
    ports:
      - name: minio_api
        mode: ingress
        host_ip: 0.0.0.0
        target: 9000
        published: "9002"
        protocol: tcp
      - name: minio_console
        mode: ingress
        host_ip: 0.0.0.0
        target: 9001
        published: "9003"
        protocol: tcp
    restart: unless-stopped
    volumes:
      - type: volume
        source: minio_test_data
        target: /data
  postgres:
    profiles:
      - postgres
    environment:
      POSTGRES_DB: talawa
      POSTGRES_PASSWORD: password
      POSTGRES_USER: talawa
    healthcheck:
      test:
        - CMD-SHELL
        - pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}
      timeout: 10s
      interval: 10s
      retries: 3
      start_period: 5s
      start_interval: 1s
    image: postgres:17.2-alpine3.21
    networks:
      postgres: null
    ports:
      - name: postgres
        mode: ingress
        host_ip: 127.0.0.1
        target: 5432
        published: "5432"
        protocol: tcp
    restart: unless-stopped
    volumes:
      - type: volume
        source: postgres_data
        target: /var/lib/postgresql/data
  postgres-test:
    profiles:
      - postgres_test
    environment:
      POSTGRES_DB: talawa
      POSTGRES_PASSWORD: password
      POSTGRES_USER: talawa
    healthcheck:
      test:
        - CMD-SHELL
        - pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}
      timeout: 10s
      interval: 10s
      retries: 3
      start_period: 5s
      start_interval: 1s
    image: postgres:17.2-alpine3.21
    networks:
      postgres_test: null
    ports:
      - name: postgres
        mode: ingress
        host_ip: 127.0.0.1
        target: 5432
        published: "5433"
        protocol: tcp
    restart: unless-stopped
    volumes:
      - type: volume
        source: postgres_test_data
        target: /var/lib/postgresql/data
  redis:
    profiles:
      - redis
    healthcheck:
      test:
        - CMD
        - redis-cli
        - ping
      timeout: 10s
      interval: 10s
      retries: 3
      start_period: 5s
      start_interval: 1s
    image: redis:8.0-M02-alpine
    networks:
      redis: null
    ports:
      - name: redis
        mode: ingress
        host_ip: 127.0.0.1
        target: 6379
        published: "6379"
        protocol: tcp
    restart: unless-stopped
    volumes:
      - type: volume
        source: redis_data
        target: /data
  redis-test:
    profiles:
      - redis_test
    healthcheck:
      test:
        - CMD
        - redis-cli
        - ping
      timeout: 10s
      interval: 10s
      retries: 3
      start_period: 5s
      start_interval: 1s
    image: redis:8.0-M02-alpine
    networks:
      redis_test: null
    ports:
      - name: redis
        mode: ingress
        host_ip: 127.0.0.1
        target: 6379
        published: "6378"
        protocol: tcp
    restart: unless-stopped
    volumes:
      - type: volume
        source: redis_test_data
        target: /data
networks:
  api:
    name: talawa_api
  minio:
    name: talawa_minio
  minio_test:
    name: talawa_minio_test
  postgres:
    name: talawa_postgres
  postgres_test:
    name: talawa_postgres_test
  redis:
    name: talawa_redis
  redis_test:
    name: talawa_redis_test
volumes:
  api_bash_history:
    name: talawa_api_bash_history
  api_node_modules:
    name: talawa_api_node_modules
  api_pnpm_store:
    name: talawa_api_pnpm_store
  caddy_config:
    name: talawa_caddy_config
  caddy_data:
    name: talawa_caddy_data
  cloudbeaver_data:
    name: talawa_cloudbeaver_data
  minio_data:
    name: talawa_minio_data
  minio_test_data:
    name: talawa_minio_test_data
  postgres_data:
    name: talawa_postgres_data
  postgres_test_data:
    name: talawa_postgres_test_data
  redis_data:
    name: talawa_redis_data
  redis_test_data:
    name: talawa_redis_test_data
[706 ms] Start: Run: docker inspect --type image mcr.microsoft.com/devcontainers/base:bookworm
[2419 ms] Resolving Feature dependencies for 'ghcr.io/devcontainers/features/common-utils'...
[2419 ms] * Processing feature: ghcr.io/devcontainers/features/common-utils
[2629 ms] Start: Run: docker-credential-secret get
[3100 ms] Resolving Feature dependencies for 'ghcr.io/devcontainers/features/git'...
[3100 ms] * Processing feature: ghcr.io/devcontainers/features/git
[3359 ms] * Processing feature: ghcr.io/devcontainers/features/common-utils
[3616 ms] Resolving Feature dependencies for 'ghcr.io/devcontainers/features/github-cli'...
[3616 ms] * Processing feature: ghcr.io/devcontainers/features/github-cli
[3857 ms] * Processing feature: ghcr.io/devcontainers/features/common-utils
[4110 ms] * Processing feature: ghcr.io/devcontainers/features/git
[4344 ms] Resolving Feature dependencies for 'ghcr.io/devcontainers/features/docker-outside-of-docker:1'...
[4344 ms] * Processing feature: ghcr.io/devcontainers/features/docker-outside-of-docker:1
[4597 ms] * Processing feature: ghcr.io/devcontainers/features/common-utils
[4843 ms] * Fetching feature: common-utils_0_oci
[5160 ms] Files to omit: ''
[5177 ms] * Fetched feature: common-utils_0_oci version 2.5.6
[5177 ms] * Fetching feature: docker-outside-of-docker_1_oci
[5488 ms] Files to omit: ''
[5491 ms] * Fetched feature: docker-outside-of-docker_1_oci version 1.6.5
[5492 ms] * Fetching feature: git_2_oci
[5806 ms] Files to omit: ''
[5811 ms] * Fetched feature: git_2_oci version 1.3.5
[5811 ms] * Fetching feature: github-cli_3_oci
[6110 ms] Files to omit: ''
[6115 ms] * Fetched feature: github-cli_3_oci version 1.1.0
[6123 ms] Docker Compose override file for building image:
services:
  api:
    build:
      dockerfile: /tmp/devcontainercli-talawa-api/container-features/0.82.0-1769813062885/Dockerfile-with-features
      target: dev_containers_target_stage
      args:
        - BUILDKIT_INLINE_CACHE=1
        - _DEV_CONTAINERS_BASE_IMAGE=devcontainer
        - _DEV_CONTAINERS_IMAGE_USER=talawa
        - _DEV_CONTAINERS_FEATURE_CONTENT_SOURCE=dev_container_feature_content_temp
      additional_contexts:
        - dev_containers_feature_content_source=/tmp/devcontainercli-talawa-api/container-features/0.82.0-1769813062885

[6126 ms] Start: Run: docker compose --project-name talawa -f /home/talawa-api/talawa-api/compose.yaml -f /home/talawa-api/talawa-api/docker/compose.testing.yaml -f /home/talawa-api/talawa-api/docker/compose.devcontainer.yaml -f /tmp/devcontainercli-talawa-api/docker-compose/docker-compose.devcontainer.build-1769813066591.yml build api
[+] Building 63.0s (30/30) FINISHED                                                                                                                                     
 => [internal] load local bake definitions                                                                                                                         0.0s
 => => reading from stdin 1.13kB                                                                                                                                   0.0s
 => [internal] load build definition from Dockerfile-with-features                                                                                                 0.0s
 => => transferring dockerfile: 12.45kB                                                                                                                            0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1                                                                                          0.6s
 => CACHED docker-image://docker.io/docker/dockerfile:1@sha256:b6afd42430b15f2d2a4c5a02b919e98a525b785b1aaff16747d2f623364e39b6                                    0.0s
 => [internal] load metadata for mcr.microsoft.com/devcontainers/base:bookworm                                                                                     0.8s
 => [context dev_containers_feature_content_source] load .dockerignore                                                                                             0.0s
 => => transferring dev_containers_feature_content_source: 2B                                                                                                      0.0s
 => [internal] load .dockerignore                                                                                                                                  0.0s
 => => transferring context: 15.45kB                                                                                                                               0.0s
 => [devcontainer 1/7] FROM mcr.microsoft.com/devcontainers/base:bookworm@sha256:15143a8c806afb8db57ae2c92876c112d7a6a1ced31cd7aa8b414201782757a4                 15.3s
 => => resolve mcr.microsoft.com/devcontainers/base:bookworm@sha256:15143a8c806afb8db57ae2c92876c112d7a6a1ced31cd7aa8b414201782757a4                               0.0s
 => => sha256:15143a8c806afb8db57ae2c92876c112d7a6a1ced31cd7aa8b414201782757a4 1.61kB / 1.61kB                                                                     0.0s
 => => sha256:c1be109a62df95316ceac87ea501079f32e17f36b636865a860841b7db06100c 48.48MB / 48.48MB                                                                   2.0s
 => => sha256:0dffdd6bcfb75f90137c4f4b87d092a053748d18a3646576b4ab616a7559a54f 3.68MB / 3.68MB                                                                     1.0s
 => => sha256:6c62dd0b80cd64f450fcaf7643bc2e4c17b12c7b1fceb59a8703b4b12be50732 2.01kB / 2.01kB                                                                     0.0s
 => => sha256:2c1079bd4cc57c00b54d7be12fb4478d28a1cc0f146c93b7d894320e865f4bda 11.40kB / 11.40kB                                                                   0.0s
 => => sha256:64538a062a61add8dc8b290fa69475e8902eb839c497a5f5dcd5a950422e493c 24.04MB / 24.04MB                                                                   1.6s
 => => sha256:456f09ef98273388eb17635dff944d08069ef156381900c1e3e50da0d7304a97 411B / 411B                                                                         1.3s
 => => sha256:717a5f132284124d1c562956fcb51e619da0fcf66c011d3d810e8d6cb0fb7433 135B / 135B                                                                         1.4s
 => => sha256:372cb1e1771b772120a01749f1ba9771b3ee5da1098348753cc3dac2f71d8f46 225B / 225B                                                                         1.7s
 => => sha256:35396602e59ac091a24ce25498f9042a00deb9f24bb682b082d399f1c23b296e 106.58MB / 106.58MB                                                                 6.8s
 => => sha256:7e7f9b3c10f826ebbf5113155cf6977c208aa395d95604d64ec4ff930808d4ab 236B / 236B                                                                         1.8s
 => => sha256:bd52b4245a466d4763980acc617d58a08f3ee1548f85bbb2ccc831f9a6002358 168.88MB / 168.88MB                                                                11.0s
 => => extracting sha256:c1be109a62df95316ceac87ea501079f32e17f36b636865a860841b7db06100c                                                                          2.2s
 => => extracting sha256:64538a062a61add8dc8b290fa69475e8902eb839c497a5f5dcd5a950422e493c                                                                          0.6s
 => => extracting sha256:0dffdd6bcfb75f90137c4f4b87d092a053748d18a3646576b4ab616a7559a54f                                                                          0.1s
 => => extracting sha256:456f09ef98273388eb17635dff944d08069ef156381900c1e3e50da0d7304a97                                                                          0.0s
 => => extracting sha256:717a5f132284124d1c562956fcb51e619da0fcf66c011d3d810e8d6cb0fb7433                                                                          0.0s
 => => extracting sha256:372cb1e1771b772120a01749f1ba9771b3ee5da1098348753cc3dac2f71d8f46                                                                          0.0s
 => => extracting sha256:7e7f9b3c10f826ebbf5113155cf6977c208aa395d95604d64ec4ff930808d4ab                                                                          0.0s
 => => extracting sha256:35396602e59ac091a24ce25498f9042a00deb9f24bb682b082d399f1c23b296e                                                                          4.7s
 => => extracting sha256:bd52b4245a466d4763980acc617d58a08f3ee1548f85bbb2ccc831f9a6002358                                                                          3.5s
 => [context dev_containers_feature_content_source] load from client                                                                                               0.0s
 => => transferring dev_containers_feature_content_source: 19.28kB                                                                                                 0.0s
 => [context dev_containers_feature_content_source] load from client                                                                                               0.0s
 => => transferring dev_containers_feature_content_source: 16.49kB                                                                                                 0.0s
 => [context dev_containers_feature_content_source] load from client                                                                                               0.1s
 => => transferring dev_containers_feature_content_source: 1.98kB                                                                                                  0.0s
 => [context dev_containers_feature_content_source] load from client                                                                                               0.0s
 => => transferring dev_containers_feature_content_source: 2.30kB                                                                                                  0.0s
 => [context dev_containers_feature_content_source] load from client                                                                                               0.1s
 => => transferring dev_containers_feature_content_source: 103B                                                                                                    0.0s
 => [devcontainer 2/7] RUN groupmod -n talawa vscode     && usermod -d /home/talawa -l talawa -m vscode     && usermod -u 1000 talawa     && groupmod -g 1000 tal  1.4s
 => [devcontainer 3/7] RUN echo '#!/bin/sh' > /etc/profile.d/fnm.sh     && echo 'export PATH="/home/talawa/.local/share/fnm:$PATH"' >> /etc/profile.d/fnm.sh       0.3s
 => [devcontainer 4/7] RUN echo "source /etc/profile.d/fnm.sh" >> /home/talawa/.bashrc                                                                             0.3s
 => [devcontainer 5/7] RUN curl -fsSL --proto '=https' --tlsv1.2 https://fnm.vercel.app/install | bash -s -- --skip-shell                                          1.0s
 => [devcontainer 6/7] RUN /home/talawa/.local/share/fnm/fnm install 24.12.0 && /home/talawa/.local/share/fnm/fnm default 24.12.0                                  5.6s
 => [devcontainer 7/7] WORKDIR /home/talawa/api                                                                                                                    0.0s
 => [dev_containers_target_stage 1/7] RUN mkdir -p /tmp/dev-container-features                                                                                     0.3s
 => [dev_containers_feature_content_normalize 1/2] COPY --from=dev_containers_feature_content_source devcontainer-features.builtin.env /tmp/build-features/        0.0s
 => [dev_containers_feature_content_normalize 2/2] RUN chmod -R 0755 /tmp/build-features/                                                                          0.3s
 => [dev_containers_target_stage 2/7] COPY --from=dev_containers_feature_content_normalize /tmp/build-features/ /tmp/dev-container-features                        0.0s
 => [dev_containers_target_stage 3/7] RUN echo "_CONTAINER_USER_HOME=$( (command -v getent >/dev/null 2>&1 && getent passwd 'talawa' || grep -E '^talawa|^[^:]*:[  0.3s
 => [dev_containers_target_stage 4/7] RUN --mount=type=bind,from=dev_containers_feature_content_source,source=common-utils_0,target=/tmp/build-features-src/comm  10.3s
 => [dev_containers_target_stage 5/7] RUN --mount=type=bind,from=dev_containers_feature_content_source,source=docker-outside-of-docker_1,target=/tmp/build-featu  22.0s
 => [dev_containers_target_stage 6/7] RUN --mount=type=bind,from=dev_containers_feature_content_source,source=git_2,target=/tmp/build-features-src/git_2     cp -  0.3s
 => [dev_containers_target_stage 7/7] RUN --mount=type=bind,from=dev_containers_feature_content_source,source=github-cli_3,target=/tmp/build-features-src/github-  2.7s
 => exporting to image                                                                                                                                             1.2s
 => => exporting layers                                                                                                                                            1.2s
 => => preparing layers for inline cache                                                                                                                           0.0s
 => => writing image sha256:4bbfad8af0804cf3edf87ec0e9ef213423c532b4c4fb5438ee2db068c037e136                                                                       0.0s
 => => naming to docker.io/library/talawa-api                                                                                                                      0.0s
 => resolving provenance for metadata file                                                                                                                         0.0s
[+] build 1/1
 ✔ Image talawa-api Built                                                                                                                                          63.1s
{"outcome":"success","imageName":"talawa-api"}
[2 ms] @devcontainers/cli 0.82.0. Node.js v22.22.0. linux 6.8.0-39-generic x64.
Running the initializeCommand from devcontainer.json...

[254 ms] Start: Run: /bin/sh -c /bin/sh -c '[ ! -f .env ] && cp ./envFiles/.env.devcontainer ./.env || true'

[329 ms] Start: Run: docker compose -f /home/talawa-api/talawa-api/compose.yaml -f /home/talawa-api/talawa-api/docker/compose.testing.yaml -f /home/talawa-api/talawa-api/docker/compose.devcontainer.yaml --profile * config
[507 ms] Start: Run: docker compose -f /home/talawa-api/talawa-api/compose.yaml -f /home/talawa-api/talawa-api/docker/compose.testing.yaml -f /home/talawa-api/talawa-api/docker/compose.devcontainer.yaml --profile * config
[662 ms] name: talawa
services:
  api:
    profiles:
      - api
    build:
      context: /home/talawa-api/talawa-api
      dockerfile: ./docker/api.Containerfile
      args:
        API_DEBUGGER_HOST: 0.0.0.0
        API_DEBUGGER_PORT: "9229"
        API_GID: "1000"
        API_UID: "1000"
      target: devcontainer
    command:
      - pnpm
      - run_tests
    depends_on:
      minio:
        condition: service_healthy
        required: false
      minio-test:
        condition: service_healthy
        required: false
      postgres:
        condition: service_healthy
        required: false
      postgres-test:
        condition: service_healthy
        required: false
      redis:
        condition: service_healthy
        required: false
    healthcheck:
      test:
        - CMD-SHELL
        - node /home/talawa/api/docker/apiHealthcheck.js
      timeout: 10s
      interval: 10s
      retries: 3
      start_period: 5s
      start_interval: 1s
      disable: true
    init: true
    networks:
      api: null
      minio: null
      minio_test: null
      postgres: null
      postgres_test: null
      redis: null
      redis_test: null
    ports:
      - name: api
        mode: ingress
        host_ip: 0.0.0.0
        target: 4000
        published: "4000"
        protocol: tcp
      - name: api_debugger
        mode: ingress
        host_ip: 127.0.0.1
        target: 9229
        published: "9229"
        protocol: tcp
    restart: unless-stopped
    user: talawa
    volumes:
      - type: bind
        source: /home/talawa-api/talawa-api
        target: /home/talawa/api
        consistency: cached
      - type: bind
        source: /var/run/docker.sock
        target: /var/run/docker.sock
      - type: volume
        source: api_bash_history
        target: /commandhistory
      - type: volume
        source: api_node_modules
        target: /home/talawa/api/node_modules
      - type: volume
        source: api_pnpm_store
        target: /home/talawa/api/.pnpm-store
  caddy:
    profiles:
      - caddy
    depends_on:
      api:
        condition: service_healthy
        required: false
    environment:
      CADDY_TALAWA_API_DOMAIN_NAME: localhost
      CADDY_TALAWA_API_EMAIL: talawa@email.com
      CADDY_TALAWA_API_HOST: api
      CADDY_TALAWA_API_PORT: "4000"
    image: caddy:2.8.4-alpine
    networks:
      api: null
    ports:
      - name: caddy_http
        mode: ingress
        target: 80
        published: "8080"
        protocol: tcp
      - name: caddy_https
        mode: ingress
        target: 443
        published: "8443"
        protocol: tcp
      - name: caddy_http3
        mode: ingress
        target: 443
        published: "8443"
        protocol: udp
    restart: unless-stopped
    volumes:
      - type: volume
        source: caddy_config
        target: /config
      - type: volume
        source: caddy_data
        target: /data
      - type: bind
        source: /home/talawa-api/talawa-api/docker/Caddyfile
        target: /etc/caddy/Caddyfile
  cloudbeaver:
    profiles:
      - cloudbeaver
    depends_on:
      postgres:
        condition: service_healthy
        required: false
    environment:
      CB_ADMIN_NAME: talawa
      CB_ADMIN_PASSWORD: password
      CB_SERVER_NAME: Talawa CloudBeaver Server
      CB_SERVER_URL: http://127.0.0.1:8978
    healthcheck:
      test:
        - CMD-SHELL
        - curl -f -s http://127.0.0.1:8978
      timeout: 10s
      interval: 10s
      retries: 3
      start_period: 5s
      start_interval: 1s
    image: dbeaver/cloudbeaver:24.3.1
    networks:
      postgres: null
      postgres_test: null
    ports:
      - name: cloudbeaver
        mode: ingress
        host_ip: 127.0.0.1
        target: 8978
        published: "8978"
        protocol: tcp
    restart: unless-stopped
    volumes:
      - type: volume
        source: cloudbeaver_data
        target: /opt/cloudbeaver/workspace
  minio:
    profiles:
      - minio
    command:
      - server
      - /data
      - --console-address
      - :9001
    environment:
      MINIO_BROWSER: "on"
      MINIO_ROOT_PASSWORD: password
      MINIO_ROOT_USER: talawa
    healthcheck:
      test:
        - CMD-SHELL
        - mc ready local
      timeout: 10s
      interval: 10s
      retries: 3
      start_period: 5s
      start_interval: 1s
    image: minio/minio:RELEASE.2024-12-18T13-15-44Z
    networks:
      minio: null
    ports:
      - name: minio_api
        mode: ingress
        host_ip: 0.0.0.0
        target: 9000
        published: "9000"
        protocol: tcp
      - name: minio_console
        mode: ingress
        host_ip: 0.0.0.0
        target: 9001
        published: "9001"
        protocol: tcp
    restart: unless-stopped
    volumes:
      - type: volume
        source: minio_data
        target: /data
  minio-test:
    profiles:
      - minio_test
    command:
      - server
      - /data
      - --console-address
      - :9001
    environment:
      MINIO_BROWSER: "on"
      MINIO_ROOT_PASSWORD: password
      MINIO_ROOT_USER: talawa
    healthcheck:
      test:
        - CMD-SHELL
        - mc ready local
      timeout: 10s
      interval: 10s
      retries: 3
      start_period: 5s
      start_interval: 1s
    image: minio/minio:RELEASE.2024-12-18T13-15-44Z
    networks:
      minio_test: null
    ports:
      - name: minio_api
        mode: ingress
        host_ip: 0.0.0.0
        target: 9000
        published: "9002"
        protocol: tcp
      - name: minio_console
        mode: ingress
        host_ip: 0.0.0.0
        target: 9001
        published: "9003"
        protocol: tcp
    restart: unless-stopped
    volumes:
      - type: volume
        source: minio_test_data
        target: /data
  postgres:
    profiles:
      - postgres
    environment:
      POSTGRES_DB: talawa
      POSTGRES_PASSWORD: password
      POSTGRES_USER: talawa
    healthcheck:
      test:
        - CMD-SHELL
        - pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}
      timeout: 10s
      interval: 10s
      retries: 3
      start_period: 5s
      start_interval: 1s
    image: postgres:17.2-alpine3.21
    networks:
      postgres: null
    ports:
      - name: postgres
        mode: ingress
        host_ip: 127.0.0.1
        target: 5432
        published: "5432"
        protocol: tcp
    restart: unless-stopped
    volumes:
      - type: volume
        source: postgres_data
        target: /var/lib/postgresql/data
  postgres-test:
    profiles:
      - postgres_test
    environment:
      POSTGRES_DB: talawa
      POSTGRES_PASSWORD: password
      POSTGRES_USER: talawa
    healthcheck:
      test:
        - CMD-SHELL
        - pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}
      timeout: 10s
      interval: 10s
      retries: 3
      start_period: 5s
      start_interval: 1s
    image: postgres:17.2-alpine3.21
    networks:
      postgres_test: null
    ports:
      - name: postgres
        mode: ingress
        host_ip: 127.0.0.1
        target: 5432
        published: "5433"
        protocol: tcp
    restart: unless-stopped
    volumes:
      - type: volume
        source: postgres_test_data
        target: /var/lib/postgresql/data
  redis:
    profiles:
      - redis
    healthcheck:
      test:
        - CMD
        - redis-cli
        - ping
      timeout: 10s
      interval: 10s
      retries: 3
      start_period: 5s
      start_interval: 1s
    image: redis:8.0-M02-alpine
    networks:
      redis: null
    ports:
      - name: redis
        mode: ingress
        host_ip: 127.0.0.1
        target: 6379
        published: "6379"
        protocol: tcp
    restart: unless-stopped
    volumes:
      - type: volume
        source: redis_data
        target: /data
  redis-test:
    profiles:
      - redis_test
    healthcheck:
      test:
        - CMD
        - redis-cli
        - ping
      timeout: 10s
      interval: 10s
      retries: 3
      start_period: 5s
      start_interval: 1s
    image: redis:8.0-M02-alpine
    networks:
      redis_test: null
    ports:
      - name: redis
        mode: ingress
        host_ip: 127.0.0.1
        target: 6379
        published: "6378"
        protocol: tcp
    restart: unless-stopped
    volumes:
      - type: volume
        source: redis_test_data
        target: /data
networks:
  api:
    name: talawa_api
  minio:
    name: talawa_minio
  minio_test:
    name: talawa_minio_test
  postgres:
    name: talawa_postgres
  postgres_test:
    name: talawa_postgres_test
  redis:
    name: talawa_redis
  redis_test:
    name: talawa_redis_test
volumes:
  api_bash_history:
    name: talawa_api_bash_history
  api_node_modules:
    name: talawa_api_node_modules
  api_pnpm_store:
    name: talawa_api_pnpm_store
  caddy_config:
    name: talawa_caddy_config
  caddy_data:
    name: talawa_caddy_data
  cloudbeaver_data:
    name: talawa_cloudbeaver_data
  minio_data:
    name: talawa_minio_data
  minio_test_data:
    name: talawa_minio_test_data
  postgres_data:
    name: talawa_postgres_data
  postgres_test_data:
    name: talawa_postgres_test_data
  redis_data:
    name: talawa_redis_data
  redis_test_data:
    name: talawa_redis_test_data
[678 ms] Start: Run: docker inspect --type image mcr.microsoft.com/devcontainers/base:bookworm
[2924 ms] Resolving Feature dependencies for 'ghcr.io/devcontainers/features/common-utils'...
[2925 ms] * Processing feature: ghcr.io/devcontainers/features/common-utils
[3149 ms] Start: Run: docker-credential-secret get
[3614 ms] Resolving Feature dependencies for 'ghcr.io/devcontainers/features/git'...
[3614 ms] * Processing feature: ghcr.io/devcontainers/features/git
[3874 ms] * Processing feature: ghcr.io/devcontainers/features/common-utils
[4136 ms] Resolving Feature dependencies for 'ghcr.io/devcontainers/features/github-cli'...
[4136 ms] * Processing feature: ghcr.io/devcontainers/features/github-cli
[4390 ms] * Processing feature: ghcr.io/devcontainers/features/common-utils
[4629 ms] * Processing feature: ghcr.io/devcontainers/features/git
[4858 ms] Resolving Feature dependencies for 'ghcr.io/devcontainers/features/docker-outside-of-docker:1'...
[4858 ms] * Processing feature: ghcr.io/devcontainers/features/docker-outside-of-docker:1
[5110 ms] * Processing feature: ghcr.io/devcontainers/features/common-utils
[5349 ms] * Fetching feature: common-utils_0_oci
[5641 ms] Files to omit: ''
[5662 ms] * Fetched feature: common-utils_0_oci version 2.5.6
[5662 ms] * Fetching feature: docker-outside-of-docker_1_oci
[5967 ms] Files to omit: ''
[5971 ms] * Fetched feature: docker-outside-of-docker_1_oci version 1.6.5
[5971 ms] * Fetching feature: git_2_oci
[6279 ms] Files to omit: ''
[6282 ms] * Fetched feature: git_2_oci version 1.3.5
[6283 ms] * Fetching feature: github-cli_3_oci
[6602 ms] Files to omit: ''
[6607 ms] * Fetched feature: github-cli_3_oci version 1.1.0
[6615 ms] Docker Compose override file for building image:
services:
  api:
    build:
      dockerfile: /tmp/devcontainercli-talawa-api/container-features/0.82.0-1769813153014/Dockerfile-with-features
      target: dev_containers_target_stage
      args:
        - BUILDKIT_INLINE_CACHE=1
        - _DEV_CONTAINERS_BASE_IMAGE=devcontainer
        - _DEV_CONTAINERS_IMAGE_USER=talawa
        - _DEV_CONTAINERS_FEATURE_CONTENT_SOURCE=dev_container_feature_content_temp
      additional_contexts:
        - dev_containers_feature_content_source=/tmp/devcontainercli-talawa-api/container-features/0.82.0-1769813153014

[6615 ms] Start: Run: docker compose --project-name talawa -f /home/talawa-api/talawa-api/compose.yaml -f /home/talawa-api/talawa-api/docker/compose.testing.yaml -f /home/talawa-api/talawa-api/docker/compose.devcontainer.yaml -f /tmp/devcontainercli-talawa-api/docker-compose/docker-compose.devcontainer.build-1769813156707.yml build api minio postgres redis
[+] Building 1.0s (30/30) FINISHED                                                                                                                                      
 => [internal] load local bake definitions                                                                                                                         0.0s
 => => reading from stdin 1.13kB                                                                                                                                   0.0s
 => [internal] load build definition from Dockerfile-with-features                                                                                                 0.0s
 => => transferring dockerfile: 12.45kB                                                                                                                            0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1                                                                                          0.3s
 => CACHED docker-image://docker.io/docker/dockerfile:1@sha256:b6afd42430b15f2d2a4c5a02b919e98a525b785b1aaff16747d2f623364e39b6                                    0.0s
 => [internal] load metadata for mcr.microsoft.com/devcontainers/base:bookworm                                                                                     0.3s
 => [context dev_containers_feature_content_source] load .dockerignore                                                                                             0.0s
 => => transferring dev_containers_feature_content_source: 2B                                                                                                      0.0s
 => [internal] load .dockerignore                                                                                                                                  0.0s
 => => transferring context: 15.45kB                                                                                                                               0.0s
 => [devcontainer 1/7] FROM mcr.microsoft.com/devcontainers/base:bookworm@sha256:15143a8c806afb8db57ae2c92876c112d7a6a1ced31cd7aa8b414201782757a4                  0.0s
 => [context dev_containers_feature_content_source] load from client                                                                                               0.0s
 => => transferring dev_containers_feature_content_source: 1.56kB                                                                                                  0.0s
 => [context dev_containers_feature_content_source] load from client                                                                                               0.0s
 => => transferring dev_containers_feature_content_source: 103B                                                                                                    0.0s
 => [context dev_containers_feature_content_source] load from client                                                                                               0.0s
 => => transferring dev_containers_feature_content_source: 16.49kB                                                                                                 0.0s
 => [context dev_containers_feature_content_source] load from client                                                                                               0.1s
 => => transferring dev_containers_feature_content_source: 37.13kB                                                                                                 0.0s
 => [context dev_containers_feature_content_source] load from client                                                                                               0.0s
 => => transferring dev_containers_feature_content_source: 42.23kB                                                                                                 0.0s
 => CACHED [devcontainer 2/7] RUN groupmod -n talawa vscode     && usermod -d /home/talawa -l talawa -m vscode     && usermod -u 1000 talawa     && groupmod -g 1  0.0s
 => CACHED [devcontainer 3/7] RUN echo '#!/bin/sh' > /etc/profile.d/fnm.sh     && echo 'export PATH="/home/talawa/.local/share/fnm:$PATH"' >> /etc/profile.d/fnm.  0.0s
 => CACHED [devcontainer 4/7] RUN echo "source /etc/profile.d/fnm.sh" >> /home/talawa/.bashrc                                                                      0.0s
 => CACHED [devcontainer 5/7] RUN curl -fsSL --proto '=https' --tlsv1.2 https://fnm.vercel.app/install | bash -s -- --skip-shell                                   0.0s
 => CACHED [devcontainer 6/7] RUN /home/talawa/.local/share/fnm/fnm install 24.12.0 && /home/talawa/.local/share/fnm/fnm default 24.12.0                           0.0s
 => CACHED [devcontainer 7/7] WORKDIR /home/talawa/api                                                                                                             0.0s
 => CACHED [dev_containers_target_stage 1/7] RUN mkdir -p /tmp/dev-container-features                                                                              0.0s
 => CACHED [dev_containers_feature_content_normalize 1/2] COPY --from=dev_containers_feature_content_source devcontainer-features.builtin.env /tmp/build-features  0.0s
 => CACHED [dev_containers_feature_content_normalize 2/2] RUN chmod -R 0755 /tmp/build-features/                                                                   0.0s
 => CACHED [dev_containers_target_stage 2/7] COPY --from=dev_containers_feature_content_normalize /tmp/build-features/ /tmp/dev-container-features                 0.0s
 => CACHED [dev_containers_target_stage 3/7] RUN echo "_CONTAINER_USER_HOME=$( (command -v getent >/dev/null 2>&1 && getent passwd 'talawa' || grep -E '^talawa|^  0.0s
 => CACHED [dev_containers_target_stage 4/7] RUN --mount=type=bind,from=dev_containers_feature_content_source,source=common-utils_0,target=/tmp/build-features-sr  0.0s
 => CACHED [dev_containers_target_stage 5/7] RUN --mount=type=bind,from=dev_containers_feature_content_source,source=docker-outside-of-docker_1,target=/tmp/build  0.0s
 => CACHED [dev_containers_target_stage 6/7] RUN --mount=type=bind,from=dev_containers_feature_content_source,source=git_2,target=/tmp/build-features-src/git_2    0.0s
 => CACHED [dev_containers_target_stage 7/7] RUN --mount=type=bind,from=dev_containers_feature_content_source,source=github-cli_3,target=/tmp/build-features-src/  0.0s
 => exporting to image                                                                                                                                             0.0s
 => => exporting layers                                                                                                                                            0.0s
 => => preparing layers for inline cache                                                                                                                           0.0s
 => => writing image sha256:4bbfad8af0804cf3edf87ec0e9ef213423c532b4c4fb5438ee2db068c037e136                                                                       0.0s
 => => naming to docker.io/library/talawa-api                                                                                                                      0.0s
 => resolving provenance for metadata file                                                                                                                         0.0s
[+] build 1/1
 ✔ Image talawa-api Built                                                                                                                                           1.1s
[+] Building 14.4s (6/6) FINISHED                                                                                                                        docker:default
 => [internal] load build definition from updateUID.Dockerfile-0.82.0                                                                                              0.0s
 => => transferring dockerfile: 1.52kB                                                                                                                             0.0s
 => WARN: InvalidDefaultArgInFrom: Default value for ARG $BASE_IMAGE results in empty or invalid base image name (line 4)                                          0.0s
 => [internal] load metadata for docker.io/library/talawa-api:latest                                                                                               0.0s
 => [internal] load .dockerignore                                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                                    0.0s
 => [1/2] FROM docker.io/library/talawa-api:latest                                                                                                                 0.1s
 => [2/2] RUN eval $(sed -n "s/talawa:[^:]*:\([^:]*\):\([^:]*\):[^:]*:\([^:]*\).*/OLD_UID=\1;OLD_GID=\2;HOME_FOLDER=\3/p" /etc/passwd);  eval $(sed -n "s/\([^:]  12.8s
 => exporting to image                                                                                                                                             1.3s 
 => => exporting layers                                                                                                                                            1.3s
 => => writing image sha256:a2488f8c7ff6475fcbafc7afedf8a83ba9abe6af2d750b2783e1817a01356738                                                                       0.0s
 => => naming to docker.io/library/vsc-talawa-api-1b37966068a2af274206ed38553f860976dce8af997b967fa671d3e8e1d6847a-uid                                             0.0s

 1 warning found (use docker --debug to expand):
 - InvalidDefaultArgInFrom: Default value for ARG $BASE_IMAGE results in empty or invalid base image name (line 4)
[22526 ms] Start: Run: docker compose --project-name talawa -f /home/talawa-api/talawa-api/compose.yaml -f /home/talawa-api/talawa-api/docker/compose.testing.yaml -f /home/talawa-api/talawa-api/docker/compose.devcontainer.yaml -f /tmp/devcontainercli-talawa-api/docker-compose/docker-compose.devcontainer.build-1769813156707.yml -f /tmp/devcontainercli-talawa-api/docker-compose/docker-compose.devcontainer.containerFeatures-1769813172617-3c6b7c70-fb31-4d05-b6fe-be9316efa411.yml up -d api minio postgres redis
[+] up 51/51
 ✔ Image redis:8.0-M02-alpine                     Pulled                                                                                                            7.8s
 ✔ Image minio/minio:RELEASE.2024-12-18T13-15-44Z Pulled                                                                                                            6.9s
 ✔ Image postgres:17.2-alpine3.21                 Pulled                                                                                                            7.9s
 ✔ Network talawa_minio_test                      Created                                                                                                           0.0s
 ✔ Network talawa_postgres                        Created                                                                                                           0.0s
 ✔ Network talawa_redis                           Created                                                                                                           0.0s
 ✔ Network talawa_postgres_test                   Created                                                                                                           0.0s
 ✔ Network talawa_redis_test                      Created                                                                                                           0.0s
 ✔ Network talawa_api                             Created                                                                                                           0.0s
 ✔ Network talawa_minio                           Created                                                                                                           0.1s
 ✔ Volume talawa_api_pnpm_store                   Created                                                                                                           0.0s
 ✔ Volume talawa_minio_test_data                  Created                                                                                                           0.0s
 ✔ Volume talawa_minio_data                       Created                                                                                                           0.0s
 ✔ Volume talawa_postgres_test_data               Created                                                                                                           0.0s
 ✔ Volume talawa_postgres_data                    Created                                                                                                           0.0s
 ✔ Volume talawa_redis_data                       Created                                                                                                           0.0s
 ✔ Volume talawa_api_bash_history                 Created                                                                                                           0.0s
 ✔ Volume talawa_api_node_modules                 Created                                                                                                           0.0s
 ✔ Container talawa-postgres-test-1               Healthy                                                                                                           4.4s
 ✔ Container talawa-minio-test-1                  Healthy                                                                                                           2.4s
 ✔ Container talawa-redis-1                       Healthy                                                                                                           2.4s
 ✔ Container talawa-minio-1                       Healthy                                                                                                           2.9s
 ✔ Container talawa-postgres-1                    Healthy                                                                                                           3.9s
 ✔ Container talawa-api-1                         Created                                                                                                           0.0s
Running the postCreateCommand from devcontainer.json...

[devcontainer] Starting post-create setup...
[devcontainer] Installing Node version: 24.12.0
Installing Node v24.12.0 (x64)
warning: Version already installed at "/home/talawa/.local/share/fnm/node-versions/v24.12.0"
Enabling corepack for Node v24.12.0
Using Node v24.12.0
[devcontainer] Enabling corepack...
[devcontainer] Activating pnpm@10.26.1...
Preparing pnpm@10.26.1 for immediate activation...
[devcontainer] pnpm is ready (v10.26.1)
[devcontainer] Installing dependencies...
Lockfile is up to date, resolution step is skipped
Progress: resolved 1, reused 0, downloaded 0, added 0
Packages: +823
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 823, reused 0, downloaded 84, added 75
Progress: resolved 823, reused 0, downloaded 190, added 147
Progress: resolved 823, reused 0, downloaded 322, added 240
Progress: resolved 823, reused 0, downloaded 462, added 385
Progress: resolved 823, reused 0, downloaded 548, added 453
Progress: resolved 823, reused 0, downloaded 678, added 582
Progress: resolved 823, reused 0, downloaded 813, added 740
Progress: resolved 823, reused 0, downloaded 822, added 822
Progress: resolved 823, reused 0, downloaded 823, added 822
Progress: resolved 823, reused 0, downloaded 823, added 823, done

dependencies:
+ @aws-sdk/client-ses 3.962.0
+ @fastify/cookie 11.0.2
+ @fastify/cors 11.2.0
+ @fastify/helmet 13.0.2
+ @fastify/jwt 10.0.0
+ @fastify/otel 0.16.0
+ @fastify/redis 7.1.0
+ @fastify/type-provider-typebox 6.1.0
+ @node-rs/argon2 2.0.2
+ @opentelemetry/api 1.9.0
+ @opentelemetry/core 2.2.0
+ @opentelemetry/exporter-trace-otlp-http 0.208.0
+ @opentelemetry/instrumentation-http 0.208.0
+ @opentelemetry/resources 2.2.0
+ @opentelemetry/sdk-node 0.208.0
+ @opentelemetry/sdk-trace-base 2.2.0
+ @pothos/core 4.12.0
+ @pothos/plugin-complexity 4.1.2
+ @pothos/plugin-relay 4.6.2
+ ajv-formats 3.0.1
+ axios 1.13.2
+ close-with-grace 2.4.0
+ dataloader 2.2.3
+ dotenv 17.2.3
+ drizzle-orm 0.44.7
+ drizzle-zod 0.8.3
+ env-schema 7.0.0
+ fastify 5.6.2
+ fastify-plugin 5.1.0
+ graphql 16.12.0
+ graphql-scalars 1.25.0
+ graphql-tag 2.12.6
+ graphql-upload-minimal 1.6.4
+ inquirer 12.11.1
+ mercurius 16.6.0
+ mercurius-upload 8.0.0
+ minio 8.0.6
+ node-cron 3.0.3
+ nodemailer 6.10.1
+ pino 9.14.0
+ postgres 3.4.7
+ typebox 1.0.71
+ ulidx 2.4.1
+ uuidv7 1.1.0
+ yauzl 3.2.0
+ zod 4.3.4

devDependencies:
+ @biomejs/biome 2.3.11
+ @faker-js/faker 10.1.0
+ @microsoft/tsdoc 0.16.0
+ @swc/cli 0.7.9
+ @swc/core 1.15.8
+ @types/node 22.19.3
+ @types/node-cron 3.0.11
+ @types/nodemailer 6.4.21
+ @types/yauzl 2.10.3
+ @vitest/coverage-v8 3.2.4
+ drizzle-kit 0.31.8
+ drizzle-seed 0.3.1
+ glob 13.0.0
+ gql.tada 1.9.0
+ knip 5.79.0
+ lefthook 2.0.13
+ mercurius-integration-testing 9.0.1
+ nyc 17.1.0
+ pino-pretty 13.1.3
+ tsx 4.21.0
+ typedoc 0.28.15
+ typedoc-plugin-markdown 4.9.0
+ typescript 5.9.3
+ vite-tsconfig-paths 5.1.4
+ vitest 3.2.4

╭ Warning ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                   │
│   Ignored build scripts: @swc/core@1.15.8, esbuild@0.18.20, esbuild@0.25.12, esbuild@0.27.2, lefthook@2.0.13, protobufjs@7.5.4.   │
│   Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.                                          │
│                                                                                                                                   │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
Done in 13.4s using pnpm v10.26.1
[devcontainer] Post-create setup complete.
{"outcome":"success","containerId":"959674e0d427c5fcb1a6dd7d1403145f6556957c205730a0ebe35a51a922f335","composeProjectName":"talawa","remoteUser":"talawa","remoteWorkspaceFolder":"/home/talawa/api"}
error: list of process IDs must follow -p

Usage:
 ps [options]

 Try 'ps --help <simple|list|output|threads|misc|all>'
  or 'ps --help <s|l|o|t|m|a>'
 for additional help text.

For more details see ps(1).
Talawa API application failed to start (exit code: 1)
    PID    PPID CMD
    248     233 ps -eo pid,ppid,cmd --sort=-start_time
    249     233 head -n 25
    233       0 /bin/bash -lc ps -eo pid,ppid,cmd --sort=-start_time | head -n 25 || true
    232       7 sleep 1
      7       1 /bin/sh -c echo Container started  trap "exit 0" 15  /usr/local/share/docker-init.sh  exec "$@"  while sleep 1 & wait $!; do :; done -
      1       0 /sbin/docker-init -- /bin/sh -c echo Container started  trap "exit 0" 15  /usr/local/share/docker-init.sh  exec "$@"  while sleep 1 & wait $!; do :; done -

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development container configuration for improved setup process.
  * Enhanced initialization script with simplified environment setup and improved error handling for permission and ownership issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->