### PR TITLE
feat(install): logging spinner, timer, and timing summary

### DIFF
--- a/scripts/install/common/logging.test.sh
+++ b/scripts/install/common/logging.test.sh
@@ -142,6 +142,21 @@ else
 fi
 
 ##############################################################################
+# Test: warn (stderr) writes to stderr and appends to LOG_FILE
+##############################################################################
+
+test_start "warn writes to stderr and appends to log file"
+set +e
+unique_msg="logging-test-warn-$$"
+stderr_capture=$(warn "$unique_msg" 2>&1)
+set -e
+if echo "$stderr_capture" | grep -q "WARNING:.*$unique_msg" && grep -q "WARNING:.*$unique_msg" "$LOG_FILE"; then
+  test_pass
+else
+  test_fail "Expected '$unique_msg' on stderr and in $LOG_FILE. stderr=$stderr_capture"
+fi
+
+##############################################################################
 # Test: print_timing_summary parses labels containing colons
 ##############################################################################
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature — adds progress feedback and timing summaries to the install logging library.

**Issue Number:**

Fixes #4794 
**Snapshots/Videos:**

N/A — changes are in Bash logging helpers and tests. Spinner and timing output can be seen by running the install script or `./scripts/install/common/logging.test.sh`.

**If relevant, did you update the documentation?**

No. Documentation will be updated in a follow-up (e.g. Install2Fix – Update Documentation #4796). This PR only adds the logging API and tests.

**Summary**

Long-running install steps currently give no progress feedback or timing, so users can’t tell if a step is still running or how long it took. This PR extends the shared logging library so install scripts can show an ASCII spinner during a command and record per-step timings with a final summary.

Changes:

- **logging.sh:** Added `with_spinner <msg> <cmd...>` (spinner while the command runs), `with_timer <label> <cmd...>` (records elapsed time and prints a success line, returns the command’s exit code), `print_timing_summary`, and `print_installation_summary`. All summary output goes through `_log_write` so it appears on console and in the log file. Used an indexed array of `"label:seconds"` for Bash 3.2 compatibility (e.g. macOS). Added guards so `with_timer` and `with_spinner` error and return 1 when no command is given; timing entries are parsed by the last colon so labels can contain `:`.
- **logging.test.sh:** New test suite with 8 cases: timer records time and exit code, spinner runs and completes, no-command guards for both, labels with colons in the timing summary, and both summary functions printing the expected content. Tests follow the same style as the other `common/*.test.sh` scripts.

**Does this PR introduce a breaking change?**

No. New functions are additive; existing callers of the logging library are unchanged.

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass

**Other information**

Depends on the existing Logging Library and Error Handling Library (Install2Fix). Blocking PR for documentation updates (#4796). `install-macos.sh` and other install scripts are not updated in this PR; they can be wired to these helpers in a follow-up.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time progress spinner during installation steps for clearer feedback
  * Per-operation timing captured and displayed so each step shows elapsed time
  * Installation summary now includes timings and the log file location
  * Logging output can target stdout or stderr for clearer console/log separation

* **Tests**
  * Added an automated test suite verifying spinner, timing, error handling, and summary output

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->