### PR TITLE
Revert "Revert "fix(devcontainer): ensure setup is non-interactive""

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -73,9 +73,10 @@
 	"initializeCommand": "/bin/sh -c '[ ! -f .env ] && cp ./envFiles/.env.devcontainer ./.env || true'",
 	"name": "talawa_api",
 	"overrideCommand": true,
-	"postCreateCommand": "./.devcontainer/post-create.sh",
+	"postCreateCommand": "bash ./.devcontainer/post-create.sh",
 	"remoteUser": "talawa",
 	"service": "api",
 	"shutdownAction": "stopCompose",
-	"workspaceFolder": "/home/talawa/api"
+	"workspaceFolder": "/home/talawa/api",
+	"runServices": ["api", "minio", "postgres", "redis"]
 }

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,35 +1,83 @@
-#!/bin/sh
-set -eu
+#!/usr/bin/env bash
+set -eu -o pipefail
 
-# Preflight checks
-for cmd in fnm corepack pnpm; do
+echo "[devcontainer] Starting post-create setup..."
+
+# --------------------------------------------------------------------
+# Preflight: required base tools
+# --------------------------------------------------------------------
+for cmd in fnm corepack node; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
-    echo "Error: Required command '$cmd' is not installed." >&2
+    echo "[ERROR] Required command '$cmd' is not installed." >&2
     exit 1
   fi
 done
 
-# Create directories if they don't exist
+# --------------------------------------------------------------------
+# Node.js setup via fnm (non-interactive)
+# --------------------------------------------------------------------
+# fnm env outputs shell code; eval is required
+eval "$(fnm env --shell bash)"
+# Extract exact node version from package.json
+NODE_VERSION=$(node -p "require('./package.json').engines.node" 2>/dev/null || echo "lts/*")
+echo "[devcontainer] Installing Node version: $NODE_VERSION"
+fnm install "$NODE_VERSION"
+fnm use "$NODE_VERSION"
+
+# --------------------------------------------------------------------
+# Corepack + pnpm (STRICTLY NON-INTERACTIVE)
+# --------------------------------------------------------------------
+# These MUST be set BEFORE any corepack invocation
+export CI=true
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+
+echo "[devcontainer] Enabling corepack..."
+corepack enable
+
+# --------------------------------------------------------------------
+# Validate and extract pnpm version from package.json
+# --------------------------------------------------------------------
+PNPM_VERSION="$(node -e '
+  const pkg = require("./package.json");
+  const pm = pkg.packageManager;
+  if (!pm || !pm.startsWith("pnpm@")) {
+    console.error("[ERROR] package.json packageManager must be pnpm@<version>.");
+    process.exit(1);
+  }
+  console.log(pm.split("@")[1]);
+')"
+
+echo "[devcontainer] Activating pnpm@${PNPM_VERSION}..."
+corepack prepare "pnpm@${PNPM_VERSION}" --activate
+
+# --------------------------------------------------------------------
+# Verify pnpm is usable WITHOUT triggering a prompt
+# --------------------------------------------------------------------
+PNPM_ACTUAL_VERSION="$(pnpm --version)"
+echo "[devcontainer] pnpm is ready (v${PNPM_ACTUAL_VERSION})"
+
+# --------------------------------------------------------------------
+# Workspace directories
+# --------------------------------------------------------------------
 mkdir -p .pnpm-store node_modules
 
+# --------------------------------------------------------------------
+# Permissions (fail fast, non-interactive sudo)
+# --------------------------------------------------------------------
 # Fix permissions
 # We check writability first to avoid unnecessary sudo usage.
-# If chown fails on a non-writable directory, we fail fast to prevent hidden issues.
 if [ ! -w ".pnpm-store" ] || [ ! -w "node_modules" ]; then
-  # Use current user's UID:GID for ownership to ensure portability
   if ! sudo -n chown -R "$(id -u):$(id -g)" .pnpm-store node_modules; then
-    echo "
-[ERROR] 'chown' failed for .pnpm-store or node_modules.
-Directories are not writable and sudo failed to change ownership to $(id -u):$(id -g).
-Please fix ownership permissions via Docker Compose volumes options or ensure
-the container user has write access.
-" >&2
+    echo "[ERROR] Failed to fix pnpm directory permissions." >&2
+    echo "Directories are not writable and sudo failed to change ownership to $(id -u):$(id -g)." >&2
     exit 1
   fi
 fi
 
-# Install dependencies and tools
-fnm install
-fnm use
-corepack enable
-pnpm install
+# --------------------------------------------------------------------
+# Install dependencies
+# --------------------------------------------------------------------
+echo "[devcontainer] Installing dependencies..."
+pnpm install --frozen-lockfile
+
+echo "[devcontainer] Post-create setup complete."


### PR DESCRIPTION
Reverts PalisadoesFoundation/talawa-api#4963

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development container configuration to explicitly define services (api, minio, postgres, redis) for automatic startup
  * Enhanced development setup script with improved error handling, clearer logging, and more robust dependency management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->