### PR TITLE
test: add edge case tests for maskEmail utility

### DIFF
--- a/test/utilities/maskEmail.test.ts
+++ b/test/utilities/maskEmail.test.ts
@@ -17,4 +17,25 @@ describe("maskEmail", () => {
 		expect(maskEmail("invalid-email")).toBe("***");
 		expect(maskEmail("")).toBe("***");
 	});
+
+	it("should mask unicode/internationalized email addresses", () => {
+		expect(maskEmail("用户@example.com")).toBe("用***@example.com");
+		expect(maskEmail("münchen@test.de")).toBe("m***@test.de");
+	});
+
+	it("should handle quoted local parts (uses first @ found)", () => {
+		// Current implementation uses indexOf("@") which finds first @
+		expect(maskEmail('"user@local"@example.com')).toBe(
+			'"***@local"@example.com',
+		);
+	});
+
+	it("should mask emails with nested subdomains", () => {
+		expect(maskEmail("a@sub.domain.example.com")).toBe(
+			"a***@sub.domain.example.com",
+		);
+		expect(maskEmail("user@mail.corp.company.org")).toBe(
+			"u***@mail.corp.company.org",
+		);
+	});
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Test coverage improvement - adding edge case tests for the [maskEmail](cci:7://file:///home/h30s/Project/talawa-api/docs/docs/auto-docs/utilities/maskEmail:0:0-0:0) utility.

**Issue Number:**

Fixes #4974

**Snapshots/Videos:**

N/A - test-only changes

**If relevant, did you update the documentation?**

N/A

**Summary**

Added test cases for edge cases not currently covered by the [maskEmail](cci:7://file:///home/h30s/Project/talawa-api/docs/docs/auto-docs/utilities/maskEmail:0:0-0:0) utility tests:
- Unicode/internationalized email addresses (RFC 6531): `用户@example.com`, `münchen@test.de`
- Quoted local parts containing `@` symbols (RFC 5321): `"user@local"@example.com`
- Email addresses with nested subdomains: `a@sub.domain.example.com`

These tests document the current implementation behavior without requiring production code changes.

**Does this PR introduce a breaking change?**

No

## Checklist

### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [x] I have implemented or provided justification for each non-critical suggestion
- [x] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass (verified manually / in CI)

**Other information**

The quoted local parts test documents a known limitation of the current implementation (uses `indexOf("@")` instead of `lastIndexOf("@")`). This is intentional per issue requirements.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for email masking to include internationalized (Unicode) addresses, quoted local-part formats, and nested subdomain scenarios.

* **Note**
  * No user-facing behavior changes in this release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->