### PR TITLE
feat(test): add unit tests for seedInitialData plugin functionality

### DIFF
--- a/test/unit/fastifyPlugins/seedInitialData.test.ts
+++ b/test/unit/fastifyPlugins/seedInitialData.test.ts
@@ -15,15 +15,15 @@ vi.mock("uuidv7", () => ({
 
 import { hash } from "@node-rs/argon2";
 import { eq } from "drizzle-orm";
-import { uuidv7 } from "uuidv7";
-import seedInitialData from "~/src/fastifyPlugins/seedInitialData";
 import { createMockDrizzleClient } from "test/_Mocks_/drizzleClientMock";
+import { uuidv7 } from "uuidv7";
 import { communitiesTable } from "~/src/drizzle/tables/communities";
 import { usersTable } from "~/src/drizzle/tables/users";
+import seedInitialData from "~/src/fastifyPlugins/seedInitialData";
 
 type MockDrizzleClient = ReturnType<typeof createMockDrizzleClient>;
 
-type MockFastifyInstance = Partial<FastifyInstance> & {
+type MockFastifyInstance = {
 	log: {
 		info: ReturnType<typeof vi.fn>;
 	};
@@ -98,7 +98,7 @@ describe("seedInitialData plugin", () => {
 				},
 			);
 
-			await seedInitialData(mockFastify as unknown as FastifyInstance);
+			await seedInitialData(mockFastify as unknown as FastifyInstance, {});
 
 			expect(mockFastify.log.info).toHaveBeenCalledWith(
 				"Checking if the administrator user already exists in the database.",
@@ -120,14 +120,12 @@ describe("seedInitialData plugin", () => {
 				},
 			);
 
-			await seedInitialData(mockFastify as unknown as FastifyInstance);
+			await seedInitialData(mockFastify as unknown as FastifyInstance, {});
 
 			expect(mockFastify.log.info).toHaveBeenCalledWith(
 				"Administrator user already exists in the database with an invalid role. Assigning the correct role to the administrator user.",
 			);
-			expect(mockFastify.drizzleClient.update).toHaveBeenCalledWith(
-				usersTable,
-			);
+			expect(mockFastify.drizzleClient.update).toHaveBeenCalledWith(usersTable);
 			const updateChain =
 				mockFastify.drizzleClient.update.mock.results[0]?.value;
 			expect(updateChain.set).toHaveBeenCalledWith({
@@ -152,16 +150,14 @@ describe("seedInitialData plugin", () => {
 				},
 			);
 
-			await seedInitialData(mockFastify as unknown as FastifyInstance);
+			await seedInitialData(mockFastify as unknown as FastifyInstance, {});
 
 			expect(mockFastify.log.info).toHaveBeenCalledWith(
 				"Administrator user does not exist in the database. Creating the administrator.",
 			);
 			expect(hash).toHaveBeenCalledWith("testPassword123");
 			expect(uuidv7).toHaveBeenCalled();
-			expect(mockFastify.drizzleClient.insert).toHaveBeenCalledWith(
-				usersTable,
-			);
+			expect(mockFastify.drizzleClient.insert).toHaveBeenCalledWith(usersTable);
 			const insertChain =
 				mockFastify.drizzleClient.insert.mock.results[0]?.value;
 			expect(insertChain.values).toHaveBeenCalledWith(
@@ -187,7 +183,7 @@ describe("seedInitialData plugin", () => {
 			);
 
 			await expect(
-				seedInitialData(mockFastify as unknown as FastifyInstance),
+				seedInitialData(mockFastify as unknown as FastifyInstance, {}),
 			).rejects.toThrow(
 				"Failed to check if the administrator user already exists in the database.",
 			);
@@ -202,7 +198,7 @@ describe("seedInitialData plugin", () => {
 			});
 
 			await expect(
-				seedInitialData(mockFastify as unknown as FastifyInstance),
+				seedInitialData(mockFastify as unknown as FastifyInstance, {}),
 			).rejects.toThrow(
 				"Failed to assign the correct role to the existing administrator user.",
 			);
@@ -217,10 +213,8 @@ describe("seedInitialData plugin", () => {
 			});
 
 			await expect(
-				seedInitialData(mockFastify as unknown as FastifyInstance),
-			).rejects.toThrow(
-				"Failed to create the administrator in the database.",
-			);
+				seedInitialData(mockFastify as unknown as FastifyInstance, {}),
+			).rejects.toThrow("Failed to create the administrator in the database.");
 		});
 	});
 
@@ -238,7 +232,7 @@ describe("seedInitialData plugin", () => {
 				},
 			);
 
-			await seedInitialData(mockFastify as unknown as FastifyInstance);
+			await seedInitialData(mockFastify as unknown as FastifyInstance, {});
 
 			expect(mockFastify.log.info).toHaveBeenCalledWith(
 				"Checking if the community already exists in the database.",
@@ -254,7 +248,7 @@ describe("seedInitialData plugin", () => {
 				undefined,
 			);
 
-			await seedInitialData(mockFastify as unknown as FastifyInstance);
+			await seedInitialData(mockFastify as unknown as FastifyInstance, {});
 
 			expect(mockFastify.log.info).toHaveBeenCalledWith(
 				"Community does not exist in the database. Creating the community.",
@@ -290,7 +284,7 @@ describe("seedInitialData plugin", () => {
 			);
 
 			await expect(
-				seedInitialData(mockFastify as unknown as FastifyInstance),
+				seedInitialData(mockFastify as unknown as FastifyInstance, {}),
 			).rejects.toThrow(
 				"Failed to check if the community already exists in the database.",
 			);
@@ -305,10 +299,8 @@ describe("seedInitialData plugin", () => {
 			});
 
 			await expect(
-				seedInitialData(mockFastify as unknown as FastifyInstance),
-			).rejects.toThrow(
-				"Failed to create the community in the database.",
-			);
+				seedInitialData(mockFastify as unknown as FastifyInstance, {}),
+			).rejects.toThrow("Failed to create the community in the database.");
 		});
 	});
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Test coverage improvement for `src/fastifyPlugins/seedInitialData.ts`.

**Issue Number:**

Fixes #4981

**Snapshots/Videos:**

Test results:

```
 ✓ test/unit/fastifyPlugins/seedInitialData.test.ts (10 tests) 17ms

 Test Files  1 passed (1)
       Tests  10 passed (10)
```

Coverage report:

```
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-------------------|---------|----------|---------|---------|-------------------
All files          |     100 |      100 |     100 |     100 |
 seedInitialData.ts|     100 |      100 |     100 |     100 |
-------------------|---------|----------|---------|---------|-------------------
```

**If relevant, did you update the documentation?**

Not applicable. No documentation changes needed for test-only additions.

**Summary**

This PR adds comprehensive unit tests for `src/fastifyPlugins/seedInitialData.ts` to achieve 100% code coverage as requested in issue #4981.

The `seedInitialData` plugin handles seeding the initial administrator user and community into the database at API startup. The test file covers all business logic paths and error handling scenarios:

**Administrator User Seeding (6 tests):**
- Skips creation when admin already exists with correct `"administrator"` role
- Updates role when admin exists with an incorrect role (e.g. `"regular"`)
- Creates a new admin when user does not exist (verifies password hashing, UUID generation, and database insert)
- Error handling: user query failure, user role update failure, user insert failure

**Community Seeding (4 tests):**
- Skips creation when community already exists
- Creates community when it does not exist
- Error handling: community query failure, community insert failure

**Testing approach:**
- Unit testing with mocked external dependencies following the project's black-box testing philosophy
- Mocked modules: `fastify-plugin`, `@node-rs/argon2` (hash), `uuidv7`
- Custom inline drizzle client mock to avoid deep import chains
- Each test is self-contained with isolated mock setup via `beforeEach`

**Does this PR introduce a breaking change?**

No. This is a test-only change with no modifications to source code.

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass

**Other information**

**New file created:**
- `test/unit/fastifyPlugins/seedInitialData.test.ts`

The test is placed in `test/unit/` rather than `test/fastifyPlugins/` so it runs as a pure unit test without requiring the global setup (database, Redis, etc.).

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for initial-data seeding covering administrator and community flows: creation, role updates, skips when present, and detailed failure/error paths. Global mocks provide deterministic hashing and ID values. Environment values and external utilities are mocked to simulate success and failure scenarios. Tests assert expected informational logging for each path to ensure observable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->