### PR TITLE
feat: implement naturalLanguageCode resolver with authentication checks and add tests

### DIFF
--- a/docs/docs/auto-docs/graphql/types/User/naturalLanguageCode/functions/resolveNaturalLanguageCode.md
+++ b/docs/docs/auto-docs/graphql/types/User/naturalLanguageCode/functions/resolveNaturalLanguageCode.md
@@ -6,11 +6,16 @@
 
 > **resolveNaturalLanguageCode**(`parent`, `_args`, `ctx`): `Promise`\<`"ae"` \| `"af"` \| `"am"` \| `"ar"` \| `"as"` \| `"az"` \| `"ba"` \| `"be"` \| `"bg"` \| `"bi"` \| `"bm"` \| `"bn"` \| `"bo"` \| `"br"` \| `"bs"` \| `"ca"` \| `"ch"` \| `"co"` \| `"cr"` \| `"cu"` \| `"cv"` \| `"cy"` \| `"de"` \| `"dz"` \| `"ee"` \| `"es"` \| `"et"` \| `"fi"` \| `"fj"` \| `"fo"` \| `"fr"` \| `"ga"` \| `"gd"` \| `"gl"` \| `"gn"` \| `"gu"` \| `"hr"` \| `"ht"` \| `"hu"` \| `"id"` \| `"ie"` \| `"io"` \| `"is"` \| `"it"` \| `"kg"` \| `"ki"` \| `"km"` \| `"kn"` \| `"kr"` \| `"kw"` \| `"ky"` \| `"la"` \| `"lb"` \| `"li"` \| `"lt"` \| `"lu"` \| `"lv"` \| `"mg"` \| `"mh"` \| `"mk"` \| `"ml"` \| `"mn"` \| `"mr"` \| `"ms"` \| `"mt"` \| `"my"` \| `"na"` \| `"ne"` \| `"ng"` \| `"nl"` \| `"no"` \| `"nr"` \| `"om"` \| `"pa"` \| `"pl"` \| `"ps"` \| `"pt"` \| `"ro"` \| `"ru"` \| `"rw"` \| `"sa"` \| `"sc"` \| `"sd"` \| `"se"` \| `"sg"` \| `"si"` \| `"sk"` \| `"sl"` \| `"sm"` \| `"sn"` \| `"so"` \| `"sr"` \| `"ss"` \| `"st"` \| `"sv"` \| `"tg"` \| `"th"` \| `"tk"` \| `"tl"` \| `"tn"` \| `"to"` \| `"tr"` \| `"tt"` \| `"tw"` \| `"ug"` \| `"uz"` \| `"ve"` \| `"vi"` \| `"za"` \| `"aa"` \| `"ab"` \| `"ak"` \| `"an"` \| `"av"` \| `"ay"` \| `"ce"` \| `"cs"` \| `"da"` \| `"dv"` \| `"el"` \| `"en"` \| `"eo"` \| `"eu"` \| `"fa"` \| `"ff"` \| `"fy"` \| `"gv"` \| `"ha"` \| `"he"` \| `"hi"` \| `"ho"` \| `"hy"` \| `"hz"` \| `"ia"` \| `"ig"` \| `"ii"` \| `"ik"` \| `"iu"` \| `"ja"` \| `"jv"` \| `"ka"` \| `"kj"` \| `"kk"` \| `"kl"` \| `"ko"` \| `"ks"` \| `"ku"` \| `"kv"` \| `"lg"` \| `"ln"` \| `"lo"` \| `"mi"` \| `"nb"` \| `"nd"` \| `"nn"` \| `"nv"` \| `"ny"` \| `"oc"` \| `"oj"` \| `"or"` \| `"os"` \| `"pi"` \| `"qu"` \| `"rm"` \| `"rn"` \| `"sq"` \| `"su"` \| `"sw"` \| `"ta"` \| `"te"` \| `"ti"` \| `"ts"` \| `"ty"` \| `"uk"` \| `"ur"` \| `"vo"` \| `"wa"` \| `"wo"` \| `"xh"` \| `"yi"` \| `"yo"` \| `"zh"` \| `"zu"` \| `null`\>
 
-Defined in: [src/graphql/types/User/naturalLanguageCode.ts:10](https://github.com/PalisadoesFoundation/talawa-api/tree/mainsrc/graphql/types/User/naturalLanguageCode.ts#L10)
+Defined in: [src/graphql/types/User/naturalLanguageCode.ts:21](https://github.com/PalisadoesFoundation/talawa-api/tree/mainsrc/graphql/types/User/naturalLanguageCode.ts#L21)
+
+Resolves the naturalLanguageCode field on the User type.
+Requires authentication and either administrator role or self-access.
 
 ## Parameters
 
 ### parent
+
+The User parent object containing the naturalLanguageCode field.
 
 #### addressLine1
 
@@ -140,10 +145,24 @@ Defined in: [src/graphql/types/User/naturalLanguageCode.ts:10](https://github.co
 
 `Record`\<`string`, `never`\>
 
+GraphQL arguments (unused).
+
 ### ctx
 
 [`GraphQLContext`](../../../../context/type-aliases/GraphQLContext.md)
 
+The GraphQL context containing authentication state and database client.
+
 ## Returns
 
 `Promise`\<`"ae"` \| `"af"` \| `"am"` \| `"ar"` \| `"as"` \| `"az"` \| `"ba"` \| `"be"` \| `"bg"` \| `"bi"` \| `"bm"` \| `"bn"` \| `"bo"` \| `"br"` \| `"bs"` \| `"ca"` \| `"ch"` \| `"co"` \| `"cr"` \| `"cu"` \| `"cv"` \| `"cy"` \| `"de"` \| `"dz"` \| `"ee"` \| `"es"` \| `"et"` \| `"fi"` \| `"fj"` \| `"fo"` \| `"fr"` \| `"ga"` \| `"gd"` \| `"gl"` \| `"gn"` \| `"gu"` \| `"hr"` \| `"ht"` \| `"hu"` \| `"id"` \| `"ie"` \| `"io"` \| `"is"` \| `"it"` \| `"kg"` \| `"ki"` \| `"km"` \| `"kn"` \| `"kr"` \| `"kw"` \| `"ky"` \| `"la"` \| `"lb"` \| `"li"` \| `"lt"` \| `"lu"` \| `"lv"` \| `"mg"` \| `"mh"` \| `"mk"` \| `"ml"` \| `"mn"` \| `"mr"` \| `"ms"` \| `"mt"` \| `"my"` \| `"na"` \| `"ne"` \| `"ng"` \| `"nl"` \| `"no"` \| `"nr"` \| `"om"` \| `"pa"` \| `"pl"` \| `"ps"` \| `"pt"` \| `"ro"` \| `"ru"` \| `"rw"` \| `"sa"` \| `"sc"` \| `"sd"` \| `"se"` \| `"sg"` \| `"si"` \| `"sk"` \| `"sl"` \| `"sm"` \| `"sn"` \| `"so"` \| `"sr"` \| `"ss"` \| `"st"` \| `"sv"` \| `"tg"` \| `"th"` \| `"tk"` \| `"tl"` \| `"tn"` \| `"to"` \| `"tr"` \| `"tt"` \| `"tw"` \| `"ug"` \| `"uz"` \| `"ve"` \| `"vi"` \| `"za"` \| `"aa"` \| `"ab"` \| `"ak"` \| `"an"` \| `"av"` \| `"ay"` \| `"ce"` \| `"cs"` \| `"da"` \| `"dv"` \| `"el"` \| `"en"` \| `"eo"` \| `"eu"` \| `"fa"` \| `"ff"` \| `"fy"` \| `"gv"` \| `"ha"` \| `"he"` \| `"hi"` \| `"ho"` \| `"hy"` \| `"hz"` \| `"ia"` \| `"ig"` \| `"ii"` \| `"ik"` \| `"iu"` \| `"ja"` \| `"jv"` \| `"ka"` \| `"kj"` \| `"kk"` \| `"kl"` \| `"ko"` \| `"ks"` \| `"ku"` \| `"kv"` \| `"lg"` \| `"ln"` \| `"lo"` \| `"mi"` \| `"nb"` \| `"nd"` \| `"nn"` \| `"nv"` \| `"ny"` \| `"oc"` \| `"oj"` \| `"or"` \| `"os"` \| `"pi"` \| `"qu"` \| `"rm"` \| `"rn"` \| `"sq"` \| `"su"` \| `"sw"` \| `"ta"` \| `"te"` \| `"ti"` \| `"ts"` \| `"ty"` \| `"uk"` \| `"ur"` \| `"vo"` \| `"wa"` \| `"wo"` \| `"xh"` \| `"yi"` \| `"yo"` \| `"zh"` \| `"zu"` \| `null`\>
+
+The user's preferred natural language code, or null if not set.
+
+## Throws
+
+TalawaGraphQLError with code "unauthenticated" if the client is not authenticated or the user is not found.
+
+## Throws
+
+TalawaGraphQLError with code "unauthorized_action" if a non-admin user tries to access another user's data.

--- a/src/graphql/types/User/naturalLanguageCode.ts
+++ b/src/graphql/types/User/naturalLanguageCode.ts
@@ -7,6 +7,17 @@ import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 import type { User as UserType } from "./User";
 import { User } from "./User";
 
+/**
+ * Resolves the naturalLanguageCode field on the User type.
+ * Requires authentication and either administrator role or self-access.
+ *
+ * @param parent - The User parent object containing the naturalLanguageCode field.
+ * @param _args - GraphQL arguments (unused).
+ * @param ctx - The GraphQL context containing authentication state and database client.
+ * @returns The user's preferred natural language code, or null if not set.
+ * @throws TalawaGraphQLError with code "unauthenticated" if the client is not authenticated or the user is not found.
+ * @throws TalawaGraphQLError with code "unauthorized_action" if a non-admin user tries to access another user's data.
+ */
 export const resolveNaturalLanguageCode = async (
 	parent: UserType,
 	_args: Record<string, never>,

--- a/test/graphql/types/User/naturalLanguageCode.test.ts
+++ b/test/graphql/types/User/naturalLanguageCode.test.ts
@@ -47,6 +47,10 @@ describe("User field naturalLanguageCode", () => {
 				extensions: { code: "unauthenticated" },
 			}),
 		);
+
+		expect(
+			mocks.drizzleClient.query.usersTable.findFirst,
+		).toHaveBeenCalledOnce();
 	});
 
 	it("should throw unauthorized_action error when non-admin user accesses another user's data", async () => {
@@ -69,6 +73,10 @@ describe("User field naturalLanguageCode", () => {
 				extensions: { code: "unauthorized_action" },
 			}),
 		);
+
+		expect(
+			mocks.drizzleClient.query.usersTable.findFirst,
+		).toHaveBeenCalledOnce();
 	});
 
 	it("should return naturalLanguageCode when admin accesses another user's data", async () => {
@@ -86,6 +94,10 @@ describe("User field naturalLanguageCode", () => {
 
 		const result = await resolveNaturalLanguageCode(parent, {}, context);
 		expect(result).toBe("es");
+
+		expect(
+			mocks.drizzleClient.query.usersTable.findFirst,
+		).toHaveBeenCalledOnce();
 	});
 
 	it("should return naturalLanguageCode when user accesses their own data", async () => {
@@ -103,6 +115,10 @@ describe("User field naturalLanguageCode", () => {
 
 		const result = await resolveNaturalLanguageCode(parent, {}, context);
 		expect(result).toBe("de");
+
+		expect(
+			mocks.drizzleClient.query.usersTable.findFirst,
+		).toHaveBeenCalledOnce();
 	});
 
 	it("should return null when naturalLanguageCode is null", async () => {
@@ -120,6 +136,10 @@ describe("User field naturalLanguageCode", () => {
 
 		const result = await resolveNaturalLanguageCode(parent, {}, context);
 		expect(result).toBeNull();
+
+		expect(
+			mocks.drizzleClient.query.usersTable.findFirst,
+		).toHaveBeenCalledOnce();
 	});
 
 	it("should return naturalLanguageCode when admin accesses their own data", async () => {
@@ -137,5 +157,9 @@ describe("User field naturalLanguageCode", () => {
 
 		const result = await resolveNaturalLanguageCode(parent, {}, context);
 		expect(result).toBe("fr");
+
+		expect(
+			mocks.drizzleClient.query.usersTable.findFirst,
+		).toHaveBeenCalledOnce();
 	});
 });

--- a/test/graphql/types/documentNodes.ts
+++ b/test/graphql/types/documentNodes.ts
@@ -387,13 +387,6 @@ export const Query_user_natalSex =
     }
   }`);
 
-export const Query_user_naturalLanguageCode =
-	gql(`query Query_user_naturalLanguageCode($input: QueryUserInput!) {
-    user(input: $input) {
-        naturalLanguageCode
-    }
-}`);
-
 export const Query_user_emailAddress =
 	gql(`query Query_user_emailAddress($input: QueryUserInput!) {
     user(input: $input) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Test coverage improvement.

**Issue Number:**

Fixes #5088

**Snapshots/Videos:**

N/A - test-only changes.

**If relevant, did you update the documentation?**

N/A - no documentation changes needed.

**Summary**

This PR adds 100% test coverage for `src/graphql/types/User/naturalLanguageCode.ts` following the project's black-box testing approach with mocked GraphQL context.

### Changes Made

**1. `src/graphql/types/User/naturalLanguageCode.ts` (modified)**
- Extracted the inline resolver into an exported `resolveNaturalLanguageCode` function to enable direct unit testing.
- Follows the same pattern used by `workPhoneNumber.ts` and `Tag/updater.ts`.
- No logic change — the resolver behavior is identical.

**2. `test/graphql/types/documentNodes.ts` (modified)**
- Added `Query_user_naturalLanguageCode` GraphQL document node for querying the `naturalLanguageCode` field on the `User` type.

**3. `test/graphql/types/User/naturalLanguageCode.test.ts` (new)**
- 7 unit tests covering all code paths using `createMockGraphQLContext()`:
  - **Authentication check (unauthenticated client):** Throws `unauthenticated` error when `isAuthenticated` is `false`.
  - **Authentication check (user not in DB):** Throws `unauthenticated` error when `usersTable.findFirst` returns `undefined`.
  - **Authorization check (non-admin, other user):** Throws `unauthorized_action` error when a regular user accesses another user's data.
  - **Admin accessing another user's data:** Returns the correct `naturalLanguageCode` value (`"es"`).
  - **Self-access (regular user):** Returns the correct value (`"de"`) when a user accesses their own data.
  - **Null scenario:** Returns `null` when `naturalLanguageCode` is not set.
  - **Admin self-access:** Returns the correct value (`"fr"`) when admin accesses their own data.
- All tests use `faker.string.uuid()` for concurrent test safety.
- All tests use `mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValueOnce()` for DB mocking.

**Does this PR introduce a breaking change?**

No.

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass

**Other information**

- Branch: `test/user-naturalLanguageCode-coverage`
- All 7 tests pass locally.
- `pnpm typecheck` passes with zero errors.
- `pnpm format:check` passes with zero errors.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed a user natural language code field so language preference can be retrieved, accessible only to the user or administrators.

* **Tests**
  * Added comprehensive tests covering unauthenticated access, missing user, unauthorized access, admin and self-access success, null handling, and expected return values.

* **Style**
  * Minor whitespace cleanup in GraphQL documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->