### PR TITLE
fix(tests): delete by user id in updateVenue unauthenticated test

### DIFF
--- a/test/graphql/types/Mutation/updateVenue.test.ts
+++ b/test/graphql/types/Mutation/updateVenue.test.ts
@@ -1651,6 +1651,9 @@ suite("Mutation field updateVenue", () => {
 		});
 
 		assertToBeNonNullish(signUpResult.data?.signUp?.authenticationToken);
+		assertToBeNonNullish(signUpResult.data?.signUp?.user?.id);
+		const tempUserId = signUpResult.data.signUp.user.id;
+
 		const tempSignIn = await mercuriusClient.query(Query_signIn, {
 			variables: {
 				input: { emailAddress: tempEmail, password: "Passw0rd!23" },
@@ -1658,10 +1661,10 @@ suite("Mutation field updateVenue", () => {
 		});
 		assertToBeNonNullish(tempSignIn.data?.signIn?.authenticationToken);
 
-		// Remove user record from DB so lookup returns undefined
+		// Remove user record from DB so lookup returns undefined (delete by primary key for reliability)
 		await server.drizzleClient
 			.delete(usersTable)
-			.where(eq(usersTable.emailAddress, tempEmail));
+			.where(eq(usersTable.id, tempUserId));
 
 		const res = await mercuriusClient.mutate(Mutation_updateVenue, {
 			headers: {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix — fixes a flaky CI test in the updateVenue mutation suite.

**Issue Number:**

Fixes #5192 
**Snapshots/Videos:**

N/A — test-only change; no UI or behavior change.

**If relevant, did you update the documentation?**

N/A — no documentation changes required.

**Summary**

The Shard 3 CI was intermittently failing on the updateVenue test "throws unauthenticated when current user no longer exists". The test expects the error code "unauthenticated", but sometimes the resolver returned "unauthorized_action_on_arguments_associated_resources" because the "current user no longer exists" setup was not reliable.

The test creates a temporary user, signs in, then deletes that user from the DB and calls updateVenue with the same token. The resolver returns "unauthenticated" only when the DB lookup for the current user returns undefined. Previously the test deleted the temp user by email. In some runs that delete did not affect the row the resolver later looked up by user id (e.g. timing or connection behavior), so the resolver still saw a user and hit the membership check, which returns "unauthorized_action_on_arguments_associated_resources".

This PR makes the setup reliable by: (1) taking the temp user's id from the signUp response, and (2) deleting that user by primary key (usersTable.id) instead of email. That matches how similar tests are written in updateAgendaFolder.test.ts and createOrganizationMembership.test.ts, and ensures the resolver consistently sees currentUser === undefined and returns "unauthenticated". No resolver or API contract changes; only the test is updated.

**Does this PR introduce a breaking change?**

No.

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass

**Other information**

This PR only adjusts an existing test (no new production code). The "written tests for all new changes/features" item is N/A. The full updateVenue.test.ts suite (19 tests) was run locally and all passed.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved temporary sign-up validation to capture and reuse the created user’s id for subsequent steps.
  * Preserved existing sign-in flow while switching cleanup to remove the temporary user by primary key for deterministic deletion.
  * Clarified test cleanup comments to reflect deletion by id for reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->