### PR TITLE
test: Remove redundant signIn in updateVenue auth test

### DIFF
--- a/test/graphql/types/Mutation/updateVenue.test.ts
+++ b/test/graphql/types/Mutation/updateVenue.test.ts
@@ -1650,14 +1650,14 @@ suite("Mutation field updateVenue", () => {
 				},
 			},
 		});
-
+		assertToBeNonNullish(signUpResult.data?.signUp?.user);
 		assertToBeNonNullish(signUpResult.data?.signUp?.authenticationToken);
 		const tempUserToken = signUpResult.data.signUp.authenticationToken;
 
 		// delete user from DB
 		await server.drizzleClient
 			.delete(usersTable)
-			.where(eq(usersTable.emailAddress, tempEmail));
+			.where(eq(usersTable.id, signUpResult.data.signUp.user.id));
 
 		// call mutation using now-invalid user token
 		const res = await mercuriusClient.mutate(Mutation_updateVenue, {


### PR DESCRIPTION
What kind of change does this PR introduce?
Bugfix

Issue Number:

Fixes #5207 

Snapshots/Videos:

If relevant, did you update the documentation?

Summary

Does this PR introduce a breaking change?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated authentication workflow in venue mutation tests
  * Refactored test setup sequence
  * Modified user cleanup process
  * Simplified test assertions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->