### PR TITLE
test: add unit tests for User isEmailAddressVerified resolver

### DIFF
--- a/src/graphql/types/User/isEmailAddressVerified.ts
+++ b/src/graphql/types/User/isEmailAddressVerified.ts
@@ -1,51 +1,69 @@
+import type { GraphQLContext } from "~/src/graphql/context";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 import envConfig from "~/src/utilities/graphqLimits";
+import type { User as UserType } from "./User";
 import { User } from "./User";
+
+/**
+ * Resolver for the isEmailAddressVerified field of User type.
+ * Validates user authentication and authorization before returning the email verification status.
+ * Only administrators or the user themselves can access this field.
+ *
+ * @param parent - The parent User object containing the isEmailAddressVerified field
+ * @param _args - GraphQL arguments (unused)
+ * @param ctx - GraphQL context containing authentication and database clients
+ * @returns The boolean indicating whether the user's email address is verified
+ * @throws {TalawaGraphQLError} With code 'unauthenticated' if user is not logged in
+ * @throws {TalawaGraphQLError} With code 'unauthorized_action' if user lacks required permissions
+ */
+export const isEmailAddressVerifiedResolver = async (
+	parent: UserType,
+	_args: Record<string, never>,
+	ctx: GraphQLContext,
+): Promise<boolean> => {
+	if (!ctx.currentClient.isAuthenticated) {
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "unauthenticated",
+			},
+		});
+	}
+
+	const currentUserId = ctx.currentClient.user.id;
+
+	const currentUser = await ctx.drizzleClient.query.usersTable.findFirst({
+		columns: {
+			role: true,
+		},
+		where: (fields, operators) => operators.eq(fields.id, currentUserId),
+	});
+
+	if (currentUser === undefined) {
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "unauthenticated",
+			},
+		});
+	}
+
+	if (currentUser.role !== "administrator" && parent.id !== currentUserId) {
+		throw new TalawaGraphQLError({
+			extensions: {
+				code: "unauthorized_action",
+			},
+		});
+	}
+
+	return parent.isEmailAddressVerified;
+};
+
 User.implement({
 	fields: (t) => ({
 		isEmailAddressVerified: t.field({
 			description:
 				"Boolean to tell whether the user has verified their email address.",
 			complexity: envConfig.API_GRAPHQL_SCALAR_RESOLVER_FIELD_COST,
-			resolve: async (parent, _args, ctx) => {
-				if (!ctx.currentClient.isAuthenticated) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthenticated",
-						},
-					});
-				}
-
-				const currentUserId = ctx.currentClient.user.id;
-
-				const currentUser = await ctx.drizzleClient.query.usersTable.findFirst({
-					columns: {
-						role: true,
-					},
-					where: (fields, operators) => operators.eq(fields.id, currentUserId),
-				});
-
-				if (currentUser === undefined) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthenticated",
-						},
-					});
-				}
-
-				if (
-					currentUser.role !== "administrator" &&
-					parent.id !== currentUserId
-				) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthorized_action",
-						},
-					});
-				}
-
-				return parent.isEmailAddressVerified;
-			},
+			resolve: isEmailAddressVerifiedResolver,
 			type: "Boolean",
 		}),
 	}),

--- a/test/graphql/types/User/isEmailAddressVerified.test.ts
+++ b/test/graphql/types/User/isEmailAddressVerified.test.ts
@@ -1,0 +1,156 @@
+import { faker } from "@faker-js/faker";
+import { createMockGraphQLContext } from "test/_Mocks_/mockContextCreator/mockContextCreator";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { GraphQLContext } from "~/src/graphql/context";
+import type { User as UserType } from "~/src/graphql/types/User/User";
+import { isEmailAddressVerifiedResolver } from "~/src/graphql/types/User/isEmailAddressVerified";
+import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
+
+describe("isEmailAddressVerifiedResolver", () => {
+	let ctx: GraphQLContext;
+	let mocks: ReturnType<typeof createMockGraphQLContext>["mocks"];
+	let mockParentUser: UserType;
+	let authenticatedUserId: string;
+
+	beforeEach(() => {
+		authenticatedUserId = faker.string.uuid();
+		const { context, mocks: newMocks } = createMockGraphQLContext(
+			true,
+			authenticatedUserId,
+		);
+		ctx = context;
+		mocks = newMocks;
+		mockParentUser = {
+			id: faker.string.uuid(),
+			isEmailAddressVerified: faker.datatype.boolean(),
+		} as UserType;
+	});
+
+	describe("Authentication check", () => {
+		it("should throw unauthenticated error when client is not authenticated", async () => {
+			ctx.currentClient.isAuthenticated = false;
+
+			await expect(
+				isEmailAddressVerifiedResolver(mockParentUser, {}, ctx),
+			).rejects.toThrow(
+				new TalawaGraphQLError({ extensions: { code: "unauthenticated" } }),
+			);
+		});
+
+		it("should throw unauthenticated error when current user does not exist in database", async () => {
+			mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue(
+				undefined,
+			);
+
+			await expect(
+				isEmailAddressVerifiedResolver(mockParentUser, {}, ctx),
+			).rejects.toThrow(
+				new TalawaGraphQLError({ extensions: { code: "unauthenticated" } }),
+			);
+		});
+	});
+
+	describe("Authorization checks", () => {
+		it("should throw unauthorized_action when regular user queries another user's isEmailAddressVerified", async () => {
+			mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+				role: "regular",
+			});
+
+			await expect(
+				isEmailAddressVerifiedResolver(mockParentUser, {}, ctx),
+			).rejects.toThrow(
+				new TalawaGraphQLError({
+					extensions: { code: "unauthorized_action" },
+				}),
+			);
+		});
+
+		it("should return value when administrator queries any user's isEmailAddressVerified", async () => {
+			mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+				role: "administrator",
+			});
+
+			const result = await isEmailAddressVerifiedResolver(
+				mockParentUser,
+				{},
+				ctx,
+			);
+			expect(result).toBe(mockParentUser.isEmailAddressVerified);
+		});
+
+		it("should return value when user queries their own isEmailAddressVerified", async () => {
+			const parentAsSelf = {
+				...mockParentUser,
+				id: authenticatedUserId,
+				isEmailAddressVerified: true,
+			} as UserType;
+			mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+				role: "regular",
+			});
+
+			const result = await isEmailAddressVerifiedResolver(
+				parentAsSelf,
+				{},
+				ctx,
+			);
+			expect(result).toBe(true);
+		});
+	});
+
+	describe("Successful data retrieval", () => {
+		it("should return true when isEmailAddressVerified is true", async () => {
+			mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+				role: "administrator",
+			});
+			const parentVerified = {
+				...mockParentUser,
+				isEmailAddressVerified: true,
+			} as UserType;
+
+			const result = await isEmailAddressVerifiedResolver(
+				parentVerified,
+				{},
+				ctx,
+			);
+			expect(result).toBe(true);
+		});
+
+		it("should return false when isEmailAddressVerified is false", async () => {
+			mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+				role: "administrator",
+			});
+			const parentUnverified = {
+				...mockParentUser,
+				isEmailAddressVerified: false,
+			} as UserType;
+
+			const result = await isEmailAddressVerifiedResolver(
+				parentUnverified,
+				{},
+				ctx,
+			);
+			expect(result).toBe(false);
+		});
+	});
+
+	describe("Concurrent test safety", () => {
+		it("should use unique parent and context per test without shared state", async () => {
+			const parentId = faker.string.uuid();
+			const currentUserId = faker.string.uuid();
+			const { context, mocks: testMocks } = createMockGraphQLContext(
+				true,
+				currentUserId,
+			);
+			testMocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+				role: "administrator",
+			});
+			const parent = {
+				id: parentId,
+				isEmailAddressVerified: true,
+			} as UserType;
+
+			const result = await isEmailAddressVerifiedResolver(parent, {}, context);
+			expect(result).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
Adds unit tests for the `User` field resolver `isEmailAddressVerified` (improves code coverage for `src/graphql/types/User/isEmailAddressVerified.ts`).

## Changes
- Refactored `isEmailAddressVerified.ts` to export `isEmailAddressVerifiedResolver` for testability.
- Added `test/graphql/types/User/isEmailAddressVerified.test.ts` using `createMockGraphQLContext()` and mocked drizzle client.

## Test coverage
- Authentication (unauthenticated, missing user in DB)
- Authorization (unauthorized for other user, admin/self access)
- Success (true/false), concurrent safety (faker uuid)

Fixes #5083

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test suite for email verification resolution with coverage for authentication checks, authorization enforcement, data retrieval scenarios, and concurrent safety.

* **Refactor**
  * Enhanced email verification field resolver with improved structure and explicit error handling for unauthenticated and unauthorized access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->