### PR TITLE
feat: add rate limiting to updateUserPassword mutation (#5226)

### DIFF
--- a/docs/docs/auto-docs/services/auth/tokens/functions/verifyToken.md
+++ b/docs/docs/auto-docs/services/auth/tokens/functions/verifyToken.md
@@ -14,7 +14,7 @@ Verifies a JWT and returns the payload. Throws on expired, wrong secret, or wron
 
 ### T
 
-`T` = [`AccessClaims`](../type-aliases/AccessClaims.md) \| [`RefreshClaims`](../type-aliases/RefreshClaims.md)
+`T` = `any`
 
 ## Parameters
 

--- a/docs/docs/auto-docs/utilities/passwordChangeRateLimit/functions/checkPasswordChangeRateLimit.md
+++ b/docs/docs/auto-docs/utilities/passwordChangeRateLimit/functions/checkPasswordChangeRateLimit.md
@@ -1,0 +1,26 @@
+[API Docs](/)
+
+***
+
+# Function: checkPasswordChangeRateLimit()
+
+> **checkPasswordChangeRateLimit**(`userId`): `boolean`
+
+Defined in: [src/utilities/passwordChangeRateLimit.ts:51](https://github.com/PalisadoesFoundation/talawa-api/tree/mainsrc/utilities/passwordChangeRateLimit.ts#L51)
+
+Checks if a user is currently under the rate limit for password change requests.
+This is a pure check that does not mutate state.
+
+## Parameters
+
+### userId
+
+`string`
+
+The user ID to check
+
+## Returns
+
+`boolean`
+
+true if request is allowed, false if rate limit exceeded

--- a/docs/docs/auto-docs/utilities/passwordChangeRateLimit/functions/consumePasswordChangeRateLimit.md
+++ b/docs/docs/auto-docs/utilities/passwordChangeRateLimit/functions/consumePasswordChangeRateLimit.md
@@ -1,0 +1,27 @@
+[API Docs](/)
+
+***
+
+# Function: consumePasswordChangeRateLimit()
+
+> **consumePasswordChangeRateLimit**(`userId`): `void`
+
+Defined in: [src/utilities/passwordChangeRateLimit.ts:76](https://github.com/PalisadoesFoundation/talawa-api/tree/mainsrc/utilities/passwordChangeRateLimit.ts#L76)
+
+Consumes one rate limit slot for the given user.
+Creates or resets the entry as needed and increments the count.
+Should be called only after a successful password update.
+
+## Parameters
+
+### userId
+
+`string`
+
+The user ID to record a consumption for
+
+## Returns
+
+`void`
+
+void

--- a/docs/docs/auto-docs/utilities/passwordChangeRateLimit/functions/resetLastCleanupAtForTests.md
+++ b/docs/docs/auto-docs/utilities/passwordChangeRateLimit/functions/resetLastCleanupAtForTests.md
@@ -1,0 +1,28 @@
+[API Docs](/)
+
+***
+
+# Function: \_\_resetLastCleanupAtForTests()
+
+> **\_\_resetLastCleanupAtForTests**(`value`): `void`
+
+Defined in: [src/utilities/passwordChangeRateLimit.ts:129](https://github.com/PalisadoesFoundation/talawa-api/tree/mainsrc/utilities/passwordChangeRateLimit.ts#L129)
+
+**`Internal`**
+
+Resets the last cleanup timestamp (useful for testing).
+
+## Parameters
+
+### value
+
+`number` = `0`
+
+The value to set lastCleanupAt to (default 0)
+
+## Returns
+
+`void`
+
+void
+ This function is for testing purposes only.

--- a/docs/docs/auto-docs/utilities/passwordChangeRateLimit/functions/resetPasswordChangeRateLimit.md
+++ b/docs/docs/auto-docs/utilities/passwordChangeRateLimit/functions/resetPasswordChangeRateLimit.md
@@ -1,0 +1,25 @@
+[API Docs](/)
+
+***
+
+# Function: resetPasswordChangeRateLimit()
+
+> **resetPasswordChangeRateLimit**(`userId`): `void`
+
+Defined in: [src/utilities/passwordChangeRateLimit.ts:119](https://github.com/PalisadoesFoundation/talawa-api/tree/mainsrc/utilities/passwordChangeRateLimit.ts#L119)
+
+Resets the rate limit for a specific user (useful for testing).
+
+## Parameters
+
+### userId
+
+`string`
+
+The user ID to reset
+
+## Returns
+
+`void`
+
+void

--- a/docs/docs/auto-docs/utilities/passwordChangeRateLimit/variables/CLEANUP_INTERVAL_MS.md
+++ b/docs/docs/auto-docs/utilities/passwordChangeRateLimit/variables/CLEANUP_INTERVAL_MS.md
@@ -1,0 +1,9 @@
+[API Docs](/)
+
+***
+
+# Variable: CLEANUP\_INTERVAL\_MS
+
+> `const` **CLEANUP\_INTERVAL\_MS**: `number`
+
+Defined in: [src/utilities/passwordChangeRateLimit.ts:37](https://github.com/PalisadoesFoundation/talawa-api/tree/mainsrc/utilities/passwordChangeRateLimit.ts#L37)

--- a/docs/docs/auto-docs/utilities/passwordChangeRateLimit/variables/MAX_REQUESTS_PER_WINDOW.md
+++ b/docs/docs/auto-docs/utilities/passwordChangeRateLimit/variables/MAX_REQUESTS_PER_WINDOW.md
@@ -1,0 +1,9 @@
+[API Docs](/)
+
+***
+
+# Variable: MAX\_REQUESTS\_PER\_WINDOW
+
+> `const` **MAX\_REQUESTS\_PER\_WINDOW**: `number`
+
+Defined in: [src/utilities/passwordChangeRateLimit.ts:33](https://github.com/PalisadoesFoundation/talawa-api/tree/mainsrc/utilities/passwordChangeRateLimit.ts#L33)

--- a/docs/docs/auto-docs/utilities/passwordChangeRateLimit/variables/PASSWORD_CHANGE_RATE_LIMITS.md
+++ b/docs/docs/auto-docs/utilities/passwordChangeRateLimit/variables/PASSWORD_CHANGE_RATE_LIMITS.md
@@ -1,0 +1,9 @@
+[API Docs](/)
+
+***
+
+# Variable: PASSWORD\_CHANGE\_RATE\_LIMITS
+
+> `const` **PASSWORD\_CHANGE\_RATE\_LIMITS**: `Map`\<`string`, `RateLimitEntry`\>
+
+Defined in: [src/utilities/passwordChangeRateLimit.ts:13](https://github.com/PalisadoesFoundation/talawa-api/tree/mainsrc/utilities/passwordChangeRateLimit.ts#L13)

--- a/docs/docs/auto-docs/utilities/passwordChangeRateLimit/variables/RATE_LIMIT_WINDOW_MS.md
+++ b/docs/docs/auto-docs/utilities/passwordChangeRateLimit/variables/RATE_LIMIT_WINDOW_MS.md
@@ -1,0 +1,9 @@
+[API Docs](/)
+
+***
+
+# Variable: RATE\_LIMIT\_WINDOW\_MS
+
+> `const` **RATE\_LIMIT\_WINDOW\_MS**: `number`
+
+Defined in: [src/utilities/passwordChangeRateLimit.ts:29](https://github.com/PalisadoesFoundation/talawa-api/tree/mainsrc/utilities/passwordChangeRateLimit.ts#L29)

--- a/docs/docs/auto-schema/operations/mutations/update-user-password.mdx
+++ b/docs/docs/auto-schema/operations/mutations/update-user-password.mdx
@@ -83,6 +83,8 @@ updateUserPassword(
 
 #### [<code style={{ fontWeight: 'normal' }}>updateUserPassword.<b>input</b></code>](#)<Bullet />[<code style={{ fontWeight: 'normal' }}><b>MutationUpdateUserPasswordInput!</b></code>](/auto-schema/types/inputs/mutation-update-user-password-input.mdx) <Badge class="badge badge--secondary badge--non_null" text="non-null"/> <Badge class="badge badge--secondary " text="input"/>
 
+Input for updating the current user's password.
+
 ### Type
 
 #### [<code style={{ fontWeight: 'normal' }}><b>Boolean</b></code>](/auto-schema/types/scalars/boolean.mdx) <Badge class="badge badge--secondary " text="scalar"/>

--- a/schema.graphql
+++ b/schema.graphql
@@ -2753,7 +2753,10 @@ type Mutation {
   updateUser(input: MutationUpdateUserInput!): User
 
   """Mutation field to update a user password."""
-  updateUserPassword(input: MutationUpdateUserPasswordInput!): Boolean
+  updateUserPassword(
+    """Input for updating the current user's password."""
+    input: MutationUpdateUserPasswordInput!
+  ): Boolean
 
   """Mutation field to update a venue."""
   updateVenue(input: MutationUpdateVenueInput!): Venue

--- a/src/utilities/passwordChangeRateLimit.ts
+++ b/src/utilities/passwordChangeRateLimit.ts
@@ -1,0 +1,131 @@
+/**
+ * Simple in-memory rate limiter for password change requests.
+ *
+ * Note: This is an in-memory solution that won't work across multiple server instances.
+ * For production multi-instance deployments, consider using Redis-based rate limiting.
+ */
+
+interface RateLimitEntry {
+	count: number;
+	windowStart: number;
+}
+
+export const PASSWORD_CHANGE_RATE_LIMITS = new Map<string, RateLimitEntry>();
+
+function parsePositiveInt(
+	envValue: string | undefined,
+	fallback: number,
+): number {
+	if (envValue == null) {
+		return fallback;
+	}
+	const parsed = Number.parseInt(envValue, 10);
+	if (Number.isNaN(parsed) || parsed <= 0) {
+		return fallback;
+	}
+	return parsed;
+}
+
+export const RATE_LIMIT_WINDOW_MS = parsePositiveInt(
+	process.env.PASSWORD_RATE_WINDOW_MS,
+	3_600_000,
+); // default 1 hour
+export const MAX_REQUESTS_PER_WINDOW = parsePositiveInt(
+	process.env.PASSWORD_MAX_REQUESTS,
+	3,
+); // default 3
+export const CLEANUP_INTERVAL_MS = parsePositiveInt(
+	process.env.PASSWORD_RATE_CLEANUP_INTERVAL_MS,
+	300_000,
+); // default 5 minutes
+
+let lastCleanupAt = 0;
+
+/**
+ * Checks if a user is currently under the rate limit for password change requests.
+ * This is a pure check that does not mutate state.
+ *
+ * @param userId - The user ID to check
+ * @returns true if request is allowed, false if rate limit exceeded
+ */
+export function checkPasswordChangeRateLimit(userId: string): boolean {
+	const now = Date.now();
+	const entry = PASSWORD_CHANGE_RATE_LIMITS.get(userId);
+
+	if (!entry) {
+		return true;
+	}
+
+	// Window has expired — user is allowed
+	if (now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) {
+		return true;
+	}
+
+	// Within window — check count
+	return entry.count < MAX_REQUESTS_PER_WINDOW;
+}
+
+/**
+ * Consumes one rate limit slot for the given user.
+ * Creates or resets the entry as needed and increments the count.
+ * Should be called only after a successful password update.
+ *
+ * @param userId - The user ID to record a consumption for
+ * @returns void
+ */
+export function consumePasswordChangeRateLimit(userId: string): void {
+	const now = Date.now();
+	const entry = PASSWORD_CHANGE_RATE_LIMITS.get(userId);
+
+	// Perform time-based cleanup every CLEANUP_INTERVAL_MS
+	if (now - lastCleanupAt >= CLEANUP_INTERVAL_MS) {
+		cleanupOldEntries(now);
+		lastCleanupAt = now;
+	}
+
+	if (!entry || now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) {
+		// First request or window expired — start a new window
+		PASSWORD_CHANGE_RATE_LIMITS.set(userId, {
+			count: 1,
+			windowStart: now,
+		});
+		return;
+	}
+
+	// Within window — increment count
+	entry.count++;
+}
+
+/**
+ * Removes stale entries from {@link PASSWORD_CHANGE_RATE_LIMITS}.
+ * An entry is considered stale when its age exceeds twice
+ * {@link RATE_LIMIT_WINDOW_MS} (i.e., `now - entry.windowStart >= RATE_LIMIT_WINDOW_MS * 2`).
+ *
+ * @param now - Current timestamp
+ */
+function cleanupOldEntries(now: number): void {
+	for (const [userId, entry] of PASSWORD_CHANGE_RATE_LIMITS.entries()) {
+		if (now - entry.windowStart >= RATE_LIMIT_WINDOW_MS * 2) {
+			PASSWORD_CHANGE_RATE_LIMITS.delete(userId);
+		}
+	}
+}
+
+/**
+ * Resets the rate limit for a specific user (useful for testing).
+ * @param userId - The user ID to reset
+ * @returns void
+ */
+export function resetPasswordChangeRateLimit(userId: string): void {
+	PASSWORD_CHANGE_RATE_LIMITS.delete(userId);
+}
+
+/**
+ * Resets the last cleanup timestamp (useful for testing).
+ * @param value - The value to set lastCleanupAt to (default 0)
+ * @returns void
+ * @internal This function is for testing purposes only.
+ */
+export function __resetLastCleanupAtForTests(value = 0): void {
+	lastCleanupAt = value;
+}

--- a/test/graphql/types/Mutation/updateUserPassword.test.ts
+++ b/test/graphql/types/Mutation/updateUserPassword.test.ts
@@ -2,6 +2,8 @@ import { eq } from "drizzle-orm";
 import { afterEach, expect, suite, test, vi } from "vitest";
 
 import { usersTable } from "~/src/drizzle/tables/users";
+import * as passwordChangeRateLimitModule from "~/src/utilities/passwordChangeRateLimit";
+import { PASSWORD_CHANGE_RATE_LIMITS } from "~/src/utilities/passwordChangeRateLimit";
 import { server } from "../../../server";
 import { mercuriusClient } from "../client";
 import { createRegularUserUsingAdmin } from "../createRegularUserUsingAdmin";
@@ -28,6 +30,7 @@ suite("Mutation field updateUserPassword", () => {
 
 	afterEach(async () => {
 		vi.restoreAllMocks();
+		PASSWORD_CHANGE_RATE_LIMITS.clear();
 		for (const fn of cleanupFns.reverse()) {
 			try {
 				await fn();
@@ -36,6 +39,35 @@ suite("Mutation field updateUserPassword", () => {
 			}
 		}
 		cleanupFns.length = 0;
+	});
+
+	test("Returns too_many_requests when rate limit exceeded", async () => {
+		const user = await createUserWithCleanup();
+
+		vi.spyOn(
+			passwordChangeRateLimitModule,
+			"checkPasswordChangeRateLimit",
+		).mockReturnValue(false);
+
+		const result = await mercuriusClient.mutate(Mutation_updateUserPassword, {
+			headers: { authorization: `bearer ${user.authToken}` },
+			variables: {
+				input: {
+					oldPassword: "password",
+					newPassword: "newPassword123",
+					confirmNewPassword: "newPassword123",
+				},
+			},
+		});
+
+		expect(result.data?.updateUserPassword ?? null).toEqual(null);
+		expect(result.errors).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					extensions: expect.objectContaining({ code: "too_many_requests" }),
+				}),
+			]),
+		);
 	});
 
 	test("Returns unauthenticated when client is not authenticated", async () => {

--- a/test/utilities/passwordChangeRateLimit.test.ts
+++ b/test/utilities/passwordChangeRateLimit.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	__resetLastCleanupAtForTests,
+	checkPasswordChangeRateLimit,
+	consumePasswordChangeRateLimit,
+	PASSWORD_CHANGE_RATE_LIMITS,
+	resetPasswordChangeRateLimit,
+} from "~/src/utilities/passwordChangeRateLimit";
+
+describe("passwordChangeRateLimit", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		// Clear rate limit state between tests for isolation
+		PASSWORD_CHANGE_RATE_LIMITS.clear();
+		__resetLastCleanupAtForTests(0);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	describe("checkPasswordChangeRateLimit", () => {
+		it("should allow first request", () => {
+			const userId = "user1";
+			const result = checkPasswordChangeRateLimit(userId);
+			expect(result).toBe(true);
+		});
+
+		it("should allow up to 3 consumed requests within the window", () => {
+			const userId = "user2";
+
+			for (let i = 0; i < 3; i++) {
+				expect(checkPasswordChangeRateLimit(userId)).toBe(true);
+				consumePasswordChangeRateLimit(userId);
+			}
+		});
+
+		it("should block after 3 consumed requests within the same window", () => {
+			const userId = "user3";
+
+			for (let i = 0; i < 3; i++) {
+				consumePasswordChangeRateLimit(userId);
+			}
+
+			expect(checkPasswordChangeRateLimit(userId)).toBe(false);
+		});
+
+		it("should not consume a slot on check alone", () => {
+			const userId = "user-check-only";
+
+			// Multiple checks without consume should all pass
+			for (let i = 0; i < 10; i++) {
+				expect(checkPasswordChangeRateLimit(userId)).toBe(true);
+			}
+		});
+
+		it("should handle multiple users independently", () => {
+			const userId1 = "user4";
+			const userId2 = "user5";
+
+			// User 1 consumes 3 slots
+			for (let i = 0; i < 3; i++) {
+				consumePasswordChangeRateLimit(userId1);
+			}
+
+			// User 2 should still be allowed
+			expect(checkPasswordChangeRateLimit(userId2)).toBe(true);
+
+			// User 1 should be blocked
+			expect(checkPasswordChangeRateLimit(userId1)).toBe(false);
+		});
+
+		it("should reset window after expiry", () => {
+			const userId = "user6";
+			const startTime = 1000000000;
+
+			vi.setSystemTime(startTime);
+
+			for (let i = 0; i < 3; i++) {
+				consumePasswordChangeRateLimit(userId);
+			}
+
+			expect(checkPasswordChangeRateLimit(userId)).toBe(false);
+
+			// Advance time by 1 hour + 1ms (window expired)
+			vi.advanceTimersByTime(60 * 60 * 1000 + 1);
+
+			expect(checkPasswordChangeRateLimit(userId)).toBe(true);
+		});
+
+		it("should test exact window boundary at expiry time", () => {
+			const userId = "user-boundary";
+			const startTime = 2000000000;
+
+			vi.setSystemTime(startTime);
+
+			for (let i = 0; i < 3; i++) {
+				consumePasswordChangeRateLimit(userId);
+			}
+
+			expect(checkPasswordChangeRateLimit(userId)).toBe(false);
+
+			// Exactly at expiry (window just ends — allowed as new window)
+			vi.setSystemTime(startTime + 60 * 60 * 1000);
+			expect(checkPasswordChangeRateLimit(userId)).toBe(true);
+
+			// 1ms after expiry (new window)
+			vi.setSystemTime(startTime + 60 * 60 * 1000 + 1);
+			expect(checkPasswordChangeRateLimit(userId)).toBe(true);
+		});
+	});
+
+	describe("consumePasswordChangeRateLimit", () => {
+		it("should create an entry on first consume", () => {
+			const userId = "consume-first";
+
+			consumePasswordChangeRateLimit(userId);
+
+			expect(PASSWORD_CHANGE_RATE_LIMITS.has(userId)).toBe(true);
+			expect(PASSWORD_CHANGE_RATE_LIMITS.get(userId)?.count).toBe(1);
+		});
+
+		it("should increment count on subsequent consumes", () => {
+			const userId = "consume-inc";
+
+			consumePasswordChangeRateLimit(userId);
+			consumePasswordChangeRateLimit(userId);
+
+			expect(PASSWORD_CHANGE_RATE_LIMITS.get(userId)?.count).toBe(2);
+		});
+
+		it("should reset window on consume after expiry", () => {
+			const userId = "consume-expiry";
+			const startTime = 1000000000;
+
+			vi.setSystemTime(startTime);
+			consumePasswordChangeRateLimit(userId);
+			consumePasswordChangeRateLimit(userId);
+			consumePasswordChangeRateLimit(userId);
+
+			expect(PASSWORD_CHANGE_RATE_LIMITS.get(userId)?.count).toBe(3);
+
+			// Advance past window
+			vi.advanceTimersByTime(60 * 60 * 1000 + 1);
+			consumePasswordChangeRateLimit(userId);
+
+			// Should have reset to a new window with count 1
+			expect(PASSWORD_CHANGE_RATE_LIMITS.get(userId)?.count).toBe(1);
+		});
+	});
+
+	describe("cleanup mechanism", () => {
+		it("should cleanup old entries", () => {
+			const userId = "cleanup_test";
+			const startTime = 1000000;
+
+			vi.setSystemTime(startTime);
+
+			consumePasswordChangeRateLimit(userId);
+			expect(PASSWORD_CHANGE_RATE_LIMITS.has(userId)).toBe(true);
+
+			// Advance time beyond cleanup threshold (2 hours)
+			vi.advanceTimersByTime(2 * 60 * 60 * 1000 + 1000);
+
+			// Trigger cleanup (it runs every 5 minutes on consume)
+			consumePasswordChangeRateLimit("trigger_user");
+
+			// Old entry should be gone
+			expect(PASSWORD_CHANGE_RATE_LIMITS.has(userId)).toBe(false);
+		});
+	});
+
+	describe("resetPasswordChangeRateLimit", () => {
+		it("should reset rate limit for a specific user", () => {
+			const userId = "user7";
+
+			for (let i = 0; i < 3; i++) {
+				consumePasswordChangeRateLimit(userId);
+			}
+
+			expect(checkPasswordChangeRateLimit(userId)).toBe(false);
+
+			resetPasswordChangeRateLimit(userId);
+
+			expect(checkPasswordChangeRateLimit(userId)).toBe(true);
+		});
+
+		it("should not affect other users when resetting", () => {
+			const userId1 = "user8";
+			const userId2 = "user9";
+
+			for (let i = 0; i < 3; i++) {
+				consumePasswordChangeRateLimit(userId1);
+				consumePasswordChangeRateLimit(userId2);
+			}
+
+			resetPasswordChangeRateLimit(userId1);
+
+			expect(checkPasswordChangeRateLimit(userId1)).toBe(true);
+			expect(checkPasswordChangeRateLimit(userId2)).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature — adds rate limiting to the `updateUserPassword` mutation.

**Issue Number:**

Fixes #5226

**Snapshots/Videos:**

N/A — backend-only change with no UI impact.

**If relevant, did you update the documentation?**

No documentation update needed. The rate limiter follows the same in-memory pattern already used by `passwordResetRateLimit` and `emailVerificationRateLimit`.

**Summary**

The `updateUserPassword` mutation had no rate limiting, allowing unlimited password change requests. This is a security concern because:
- Rapid password changes on a compromised account can evade detection
- Each request triggers argon2 hashing, which is CPU-intensive by design
- Unlimited requests could be used for resource exhaustion

This PR adds an in-memory rate limiter (3 password changes per hour per user), following the exact same pattern as the existing `passwordResetRateLimit.ts` and `emailVerificationRateLimit.ts` utilities.

**Changes:**
- **`src/utilities/passwordChangeRateLimit.ts`** — New rate limiter: fixed window, 3 requests/hour per userId, with periodic cleanup
- **`src/graphql/types/Mutation/updateUserPassword.ts`** — Integrated rate limit check after authentication, returns `too_many_requests` error when exceeded
- **`test/utilities/passwordChangeRateLimit.test.ts`** — Unit tests covering: allow/block thresholds, independent users, window expiry, boundary conditions, cleanup, and reset
- **`test/graphql/types/Mutation/updateUserPassword.test.ts`** — Integration test verifying the mutation returns `too_many_requests` when rate limited

**Does this PR introduce a breaking change?**

No. Authenticated users can still change their password up to 3 times per hour, which is well above normal usage.

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass

**Other information**

The rate limiter is keyed by `userId` (rather than email or IP) since the mutation requires authentication. The implementation mirrors `src/utilities/passwordResetRateLimit.ts` exactly, only differing in the limit (3 vs 5) and the key type (userId vs email).

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password change requests are now rate-limited (defaults: 3 attempts per window); excess attempts return "Too many password change attempts. Please try again later." with error code "too_many_requests".

* **Documentation**
  * Added a clearer description for the password-change mutation argument in the GraphQL schema.

* **Tests**
  * Added unit and integration tests covering the rate limiter and mutation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->