### PR TITLE
test: add unit tests for User.employmentStatus resolver (#5081)

### DIFF
--- a/docs/docs/auto-docs/graphql/types/User/employmentStatus/functions/employmentStatusResolver.md
+++ b/docs/docs/auto-docs/graphql/types/User/employmentStatus/functions/employmentStatusResolver.md
@@ -1,0 +1,163 @@
+[API Docs](/)
+
+***
+
+# Function: employmentStatusResolver()
+
+> **employmentStatusResolver**(`parent`, `_args`, `ctx`): `Promise`\<`"full_time"` \| `"part_time"` \| `"unemployed"` \| `null`\>
+
+Defined in: [src/graphql/types/User/employmentStatus.ts:19](https://github.com/PalisadoesFoundation/talawa-api/tree/mainsrc/graphql/types/User/employmentStatus.ts#L19)
+
+Resolver for the `employmentStatus` field of the `User` type.
+
+## Parameters
+
+### parent
+
+The parent `User` object.
+
+#### addressLine1
+
+`string` \| `null`
+
+#### addressLine2
+
+`string` \| `null`
+
+#### avatarMimeType
+
+`string` \| `null`
+
+#### avatarName
+
+`string` \| `null`
+
+#### birthDate
+
+`Date` \| `null`
+
+#### city
+
+`string` \| `null`
+
+#### countryCode
+
+`string` \| `null`
+
+#### createdAt
+
+`Date`
+
+#### creatorId
+
+`string` \| `null`
+
+#### description
+
+`string` \| `null`
+
+#### educationGrade
+
+`string` \| `null`
+
+#### emailAddress
+
+`string`
+
+#### employmentStatus
+
+`string` \| `null`
+
+#### failedLoginAttempts
+
+`number`
+
+#### homePhoneNumber
+
+`string` \| `null`
+
+#### id
+
+`string`
+
+#### isEmailAddressVerified
+
+`boolean`
+
+#### lastFailedLoginAt
+
+`Date` \| `null`
+
+#### lockedUntil
+
+`Date` \| `null`
+
+#### maritalStatus
+
+`string` \| `null`
+
+#### mobilePhoneNumber
+
+`string` \| `null`
+
+#### name
+
+`string`
+
+#### natalSex
+
+`string` \| `null`
+
+#### naturalLanguageCode
+
+`string` \| `null`
+
+#### passwordHash
+
+`string`
+
+#### postalCode
+
+`string` \| `null`
+
+#### role
+
+`string`
+
+#### state
+
+`string` \| `null`
+
+#### updatedAt
+
+`Date` \| `null`
+
+#### updaterId
+
+`string` \| `null`
+
+#### workPhoneNumber
+
+`string` \| `null`
+
+### \_args
+
+`Record`\<`string`, `never`\>
+
+The arguments for the field (unused).
+
+### ctx
+
+[`GraphQLContext`](../../../../context/type-aliases/GraphQLContext.md)
+
+The GraphQL context containing the current client and Drizzle client.
+
+## Returns
+
+`Promise`\<`"full_time"` \| `"part_time"` \| `"unemployed"` \| `null`\>
+
+The employment status of the user, or null if not set.
+
+## Throws
+
+if the user is unauthenticated or unauthorized.

--- a/src/graphql/types/User/employmentStatus.ts
+++ b/src/graphql/types/User/employmentStatus.ts
@@ -1,9 +1,78 @@
 import type { z } from "zod";
 import type { userEmploymentStatusEnum } from "~/src/drizzle/enums/userEmploymentStatus";
+import type { GraphQLContext } from "~/src/graphql/context";
 import { UserEmploymentStatus } from "~/src/graphql/enums/UserEmploymentStatus";
+import type { User as UserType } from "~/src/graphql/types/User/User";
+import { User } from "~/src/graphql/types/User/User";
 import envConfig from "~/src/utilities/graphqLimits";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
-import { User } from "./User";
+
+/**
+ * Resolver for the `employmentStatus` field of the `User` type.
+ *
+ * @param parent - The parent `User` object.
+ * @param _args - The arguments for the field (unused).
+ * @param ctx - The GraphQL context containing the current client and Drizzle client.
+ * @returns The employment status of the user, or null if not set.
+ * @throws {TalawaGraphQLError} if the user is unauthenticated or unauthorized.
+ */
+export const employmentStatusResolver = async (
+	parent: UserType,
+	_args: Record<string, never>,
+	ctx: GraphQLContext,
+): Promise<z.infer<typeof userEmploymentStatusEnum> | null> => {
+	try {
+		if (!ctx.currentClient.isAuthenticated) {
+			throw new TalawaGraphQLError({
+				extensions: {
+					code: "unauthenticated",
+				},
+			});
+		}
+
+		const currentUserId = ctx.currentClient.user.id;
+
+		const currentUser = await ctx.drizzleClient.query.usersTable.findFirst({
+			columns: {
+				role: true,
+			},
+			where: (fields, operators) => operators.eq(fields.id, currentUserId),
+		});
+
+		if (currentUser === undefined) {
+			throw new TalawaGraphQLError({
+				extensions: {
+					code: "unauthenticated",
+				},
+			});
+		}
+
+		if (currentUser.role !== "administrator" && parent.id !== currentUserId) {
+			throw new TalawaGraphQLError({
+				extensions: {
+					code: "unauthorized_action",
+				},
+			});
+		}
+
+		return parent.employmentStatus as z.infer<
+			typeof userEmploymentStatusEnum
+		> | null;
+	} catch (error) {
+		if (error instanceof TalawaGraphQLError) {
+			throw error;
+		}
+
+		ctx.log.error(error);
+
+		throw new TalawaGraphQLError({
+			message: "Internal server error",
+			extensions: {
+				code: "unexpected",
+			},
+		});
+	}
+};
 
 User.implement({
 	fields: (t) => ({
@@ -11,47 +80,7 @@ User.implement({
 			description: "Employment status of the user.",
 			complexity: envConfig.API_GRAPHQL_SCALAR_RESOLVER_FIELD_COST,
 			nullable: true,
-			resolve: async (parent, _args, ctx) => {
-				if (!ctx.currentClient.isAuthenticated) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthenticated",
-						},
-					});
-				}
-
-				const currentUserId = ctx.currentClient.user.id;
-
-				const currentUser = await ctx.drizzleClient.query.usersTable.findFirst({
-					columns: {
-						role: true,
-					},
-					where: (fields, operators) => operators.eq(fields.id, currentUserId),
-				});
-
-				if (currentUser === undefined) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthenticated",
-						},
-					});
-				}
-
-				if (
-					currentUser.role !== "administrator" &&
-					parent.id !== currentUserId
-				) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthorized_action",
-						},
-					});
-				}
-
-				return parent.employmentStatus as z.infer<
-					typeof userEmploymentStatusEnum
-				> | null;
-			},
+			resolve: employmentStatusResolver,
 			type: UserEmploymentStatus,
 		}),
 	}),

--- a/test/graphql/types/User/employmentStatus.test.ts
+++ b/test/graphql/types/User/employmentStatus.test.ts
@@ -1,0 +1,162 @@
+import { faker } from "@faker-js/faker";
+import { createMockGraphQLContext } from "test/_Mocks_/mockContextCreator/mockContextCreator";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GraphQLContext } from "~/src/graphql/context";
+import { employmentStatusResolver } from "~/src/graphql/types/User/employmentStatus";
+import type { User as UserType } from "~/src/graphql/types/User/User";
+import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
+
+describe("User field employmentStatus resolver", () => {
+	let ctx: GraphQLContext;
+	let mocks: ReturnType<typeof createMockGraphQLContext>["mocks"];
+	let parent: UserType;
+
+	beforeEach(() => {
+		const _userId = faker.string.ulid();
+		const { context, mocks: newMocks } = createMockGraphQLContext(
+			true,
+			_userId,
+		);
+		ctx = context;
+		mocks = newMocks;
+
+		parent = {
+			id: _userId,
+			name: "Test User",
+			emailAddress: "test@example.com",
+			isEmailAddressVerified: true,
+			employmentStatus: "full_time",
+			role: "regular",
+			createdAt: new Date("2025-01-01T10:00:00Z"),
+			updatedAt: null,
+			creatorId: "creator-1",
+			updaterId: null,
+		} as UserType;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("throws unauthenticated error when client is not authenticated", async () => {
+		const { context: unauthCtx } = createMockGraphQLContext(false);
+
+		await expect(
+			employmentStatusResolver(parent, {}, unauthCtx),
+		).rejects.toThrow(
+			expect.objectContaining({
+				extensions: expect.objectContaining({
+					code: "unauthenticated",
+				}),
+			}),
+		);
+	});
+
+	it("throws unauthenticated error when authenticated user does not exist in database", async () => {
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue(undefined);
+
+		await expect(employmentStatusResolver(parent, {}, ctx)).rejects.toThrow(
+			expect.objectContaining({
+				extensions: expect.objectContaining({
+					code: "unauthenticated",
+				}),
+			}),
+		);
+	});
+
+	it("throws unauthorized_action when non-admin accesses another user's employmentStatus", async () => {
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+			role: "regular",
+		});
+
+		const anotherUser = {
+			...parent,
+			id: faker.string.ulid(),
+		} as UserType;
+
+		await expect(
+			employmentStatusResolver(anotherUser, {}, ctx),
+		).rejects.toThrow(
+			expect.objectContaining({
+				extensions: expect.objectContaining({
+					code: "unauthorized_action",
+				}),
+			}),
+		);
+	});
+
+	it("returns employmentStatus when user accesses their own data", async () => {
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+			role: "regular",
+		});
+
+		const result = await employmentStatusResolver(parent, {}, ctx);
+
+		expect(result).toBe("full_time");
+	});
+
+	it("returns null when user's employmentStatus is null", async () => {
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+			role: "regular",
+		});
+
+		const nullStatusParent = {
+			...parent,
+			employmentStatus: null,
+		} as UserType;
+
+		const result = await employmentStatusResolver(nullStatusParent, {}, ctx);
+
+		expect(result).toBeNull();
+	});
+
+	it("returns employmentStatus when administrator accesses another user's data", async () => {
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+			role: "administrator",
+		});
+
+		const anotherUser = {
+			...parent,
+			id: faker.string.ulid(),
+			employmentStatus: "part_time",
+		} as UserType;
+
+		const result = await employmentStatusResolver(anotherUser, {}, ctx);
+
+		expect(result).toBe("part_time");
+	});
+
+	it("rethrows TalawaGraphQLError from database layer without logging", async () => {
+		const talawaError = new TalawaGraphQLError({
+			extensions: { code: "unauthenticated" },
+		});
+
+		mocks.drizzleClient.query.usersTable.findFirst.mockRejectedValue(
+			talawaError,
+		);
+
+		await expect(employmentStatusResolver(parent, {}, ctx)).rejects.toBe(
+			talawaError,
+		);
+
+		expect(ctx.log.error).not.toHaveBeenCalled();
+	});
+
+	it("logs and wraps unknown database errors as unexpected", async () => {
+		const unknownError = new Error("DB crash");
+
+		mocks.drizzleClient.query.usersTable.findFirst.mockRejectedValue(
+			unknownError,
+		);
+
+		await expect(employmentStatusResolver(parent, {}, ctx)).rejects.toThrow(
+			expect.objectContaining({
+				extensions: expect.objectContaining({
+					code: "unexpected",
+				}),
+			}),
+		);
+
+		expect(ctx.log.error).toHaveBeenCalledWith(unknownError);
+	});
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Test coverage improvement

**Issue Number:**

Fixes #5081

**Snapshots/Videos:**

N/A

**If relevant, did you update the documentation?**

Auto-generated docs updated via `pnpm run generate-docs`.

**Summary**

Adds unit tests for the `User.employmentStatus` field resolver to achieve 100% code coverage. The resolver was also refactored to export the resolver function (`employmentStatusResolver`) and wrapped with try-catch error handling consistent with sibling resolvers.

Tests cover: unauthenticated access, user not found in DB, unauthorized access by non-admin, self-access with a valid status, null employment status, admin access to another user's data, TalawaGraphQLError passthrough, and unknown error wrapping.

**Does this PR introduce a breaking change?**

No

## Checklist

### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [x] I have implemented or provided justification for each non-critical suggestion
- [x] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass

**Other information**

8 unit tests added using `createMockGraphQLContext()`, all passing locally.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Tightened access controls for viewing user employment status with explicit checks for self vs. administrator and clearer error responses.
  * Standardized error handling: known errors passed through, unexpected issues logged and wrapped with uniform internal-error responses.

* **Tests**
  * Added comprehensive unit tests covering unauthenticated, missing-user, unauthorized, self-access, admin access, null values, and error propagation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->