### PR TITLE
cross-platform package management support for package-manager.sh

### DIFF
--- a/scripts/install/common/package-manager.sh
+++ b/scripts/install/common/package-manager.sh
@@ -1,75 +1,229 @@
-#!/bin/bash
-
-# Check external dependencies
-# Required commands:
-# - brew: Homebrew package manager (on macOS)
-# - curl: For downloading files
-# - command: Shell builtin
-# Environment Variables:
-# - OS_TYPE: 'macos' or 'linux' (from os-detection.sh)
-
+#!/usr/bin/env bash
 set -euo pipefail
 
-# scripts/install/common/package-manager.sh
-# Shared package management functions
+##############################################################################
+# Talawa - Shared Package Manager Library
+#
+# Supports:
+#   - apt (Debian/Ubuntu)
+#   - dnf / yum (RedHat family)
+#   - pacman (Arch/Manjaro)
+#   - brew (macOS)
+#
+# Depends on:
+#   - os-detection.sh
+#   - logging.sh
+#   - validation.sh (for run_cmd + helpers)
+##############################################################################
 
-# Check if OS_TYPE is set
-require_os_type() {
-    if [ -z "${OS_TYPE:-}" ]; then
-        error "OS_TYPE must be set (e.g., macos/linux)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/os-detection.sh"
+
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/logging.sh"
+
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/validation.sh"
+
+##############################################################################
+# Internal Helpers
+##############################################################################
+
+_require_package_name() {
+    local pkg="${1:-}"
+    if [ -z "${pkg}" ]; then
+        error "Package name is required"
         return 1
     fi
+    return 0
 }
 
-# Update package index
+_use_sudo() {
+    if [ "$(id -u)" -ne 0 ]; then
+        if command_exists sudo; then
+            return 0
+        fi
+        error "Root privileges required but sudo is not available"
+        return 1
+    fi
+    return 1
+}
+
+_pm_cmd() {
+    local family
+    family="$(detect_distro_family)"
+
+    case "${family}" in
+        debian)
+            echo "apt"
+            ;;
+        redhat)
+            if command_exists dnf; then
+                echo "dnf"
+            elif command_exists yum; then
+                echo "yum"
+            else
+                echo "unknown"
+            fi
+            ;;
+        arch)
+            echo "pacman"
+            ;;
+        macos)
+            echo "brew"
+            ;;
+        *)
+            echo "unknown"
+            ;;
+    esac
+}
+
+##############################################################################
+# Public API
+##############################################################################
+
+get_package_manager() {
+    _pm_cmd
+}
+
 update_package_index() {
-    require_os_type || return 1
-    if [[ "$OS_TYPE" == "macos" ]]; then
-        info "Updating Homebrew..."
-        brew update
-    else
+    local pm
+    pm="$(_pm_cmd)"
+
+    if [ "${pm}" = "unknown" ]; then
+        error "Unsupported package manager"
+        return 1
+    fi
+
+    info "Updating package index using ${pm}..."
+
+    case "${pm}" in
+        apt)
+            if _use_sudo; then
+                run_cmd sudo apt-get update -y
+            else
+                run_cmd apt-get update -y
+            fi
+            ;;
+        dnf)
+            if _use_sudo; then
+                run_cmd sudo dnf makecache -y
+            else
+                run_cmd dnf makecache -y
+            fi
+            ;;
+        yum)
+            if _use_sudo; then
+                run_cmd sudo yum makecache -y
+            else
+                run_cmd yum makecache -y
+            fi
+            ;;
+        pacman)
+            if _use_sudo; then
+                run_cmd sudo pacman -Sy --noconfirm
+            else
+                run_cmd pacman -Sy --noconfirm
+            fi
+            ;;
+        brew)
+            run_cmd brew update
+            ;;
+        *)
+            error "Unsupported package manager: ${pm}"
+            return 1
+            ;;
+    esac
+
+    success "Package index updated"
+    return 0
+}
+
+is_package_installed() {
+    local pkg="${1:-}"
+    _require_package_name "${pkg}" || return 1
+
+    local pm
+    pm="$(_pm_cmd)"
+
+    case "${pm}" in
+        apt)
+            dpkg -s "${pkg}" >/dev/null 2>&1
+            ;;
+        dnf|yum)
+            rpm -q "${pkg}" >/dev/null 2>&1
+            ;;
+        pacman)
+            pacman -Q "${pkg}" >/dev/null 2>&1
+            ;;
+        brew)
+            brew list --versions "${pkg}" >/dev/null 2>&1
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+install_package() {
+    local pkg="${1:-}"
+    _require_package_name "${pkg}" || return 1
+
+    local pm
+    pm="$(_pm_cmd)"
+
+    if [ "${pm}" = "unknown" ]; then
+        error "Unsupported package manager"
+        return 1
+    fi
+
+    if is_package_installed "${pkg}"; then
+        success "${pkg} is already installed"
         return 0
     fi
-}
 
-# Check if a package is installed
-# Arguments:
-#   $1: package_name
-is_package_installed() {
-    require_os_type || return 1
-    local package="$1"
-    if [[ "$OS_TYPE" == "macos" ]]; then
-        if brew list --versions "$package" >/dev/null 2>&1; then
-            return 0
-        else
-            return 1
-        fi
-    else
-        # Fallback to command check
-        if command -v "$package" >/dev/null 2>&1; then
-            return 0
-        else
-            return 1
-        fi
-    fi
-}
+    info "Installing ${pkg} using ${pm}..."
 
-# Install a package
-# Arguments:
-#   $1: package_name
-install_package() {
-    require_os_type || return 1
-    local package="$1"
-    if [[ "$OS_TYPE" == "macos" ]]; then
-        info "Installing $package..."
-        if brew install "$package"; then
-            success "$package installed successfully"
-        else
-            error "Failed to install $package"
+    case "${pm}" in
+        apt)
+            if _use_sudo; then
+                run_cmd sudo apt-get install -y "${pkg}"
+            else
+                run_cmd apt-get install -y "${pkg}"
+            fi
+            ;;
+        dnf)
+            if _use_sudo; then
+                run_cmd sudo dnf install -y "${pkg}"
+            else
+                run_cmd dnf install -y "${pkg}"
+            fi
+            ;;
+        yum)
+            if _use_sudo; then
+                run_cmd sudo yum install -y "${pkg}"
+            else
+                run_cmd yum install -y "${pkg}"
+            fi
+            ;;
+        pacman)
+            if _use_sudo; then
+                run_cmd sudo pacman -S --noconfirm "${pkg}"
+            else
+                run_cmd pacman -S --noconfirm "${pkg}"
+            fi
+            ;;
+        brew)
+            run_cmd brew install "${pkg}"
+            ;;
+        *)
+            error "Unsupported package manager: ${pm}"
             return 1
-        fi
-    else
-        warn "Package installation not supported for this OS in this script version."
-        return 1
-    fi
+            ;;
+    esac
+
+    success "${pkg} installed successfully"
+    return 0
 }


### PR DESCRIPTION
Fixes: #4785

### Summary

This PR introduces a fully cross-platform package management library at `scripts/install/common/package-manager.sh`, eliminating duplicated installation logic across distributions and providing a unified abstraction for dependency management.

The new implementation supports Debian-based, RedHat-based, Arch-based Linux distributions, and macOS using their native package managers.

### Problem

Package installation logic was duplicated across installation scripts and only partially implemented. The existing `package-manager.sh`:

- Supported Homebrew (macOS) only
- Lacked Linux package manager support
- Relied on `OS_TYPE` instead of distribution detection
- Used `command -v` instead of proper package database checks
- Did not consistently handle privilege escalation
- Did not integrate cleanly with shared logging and validation libraries

This prevented reuse and blocked refactoring efforts in upcoming installation scripts.

### Root Cause

The previous implementation abstracted only macOS behavior and treated Linux as a single category without accounting for distribution differences (apt, dnf/yum, pacman). As a result, installation logic was either duplicated elsewhere or not implemented at all.

### What This PR Does

Introduces a distribution-aware, reusable package management layer that:

- Detects distro family using `detect_distro_family`
- Selects appropriate package manager automatically
- Supports:
  - `apt` (Debian/Ubuntu)
  - `dnf` / `yum` (Fedora/RHEL/CentOS)
  - `pacman` (Arch/Manjaro)
  - `brew` (macOS)
- Uses proper package database queries for installation checks
- Handles privilege escalation safely and conditionally
- Integrates with:
  - `logging.sh` (info/success/error)
  - `validation.sh` (`run_cmd`, DRY_RUN support)
  - `os-detection.sh`
- Avoids `exit` calls inside the library
- Returns deterministic exit codes
- Is idempotent (does not reinstall existing packages)

### Key Changes

- Replaced OS_TYPE-based detection with `detect_distro_family`
- Implemented `get_package_manager`
- Implemented cross-platform `update_package_index`
- Implemented proper `is_package_installed`:
  - `dpkg -s` for apt
  - `rpm -q` for dnf/yum
  - `pacman -Q` for pacman
  - `brew list --versions` for brew
- Implemented safe `install_package` with:
  - Idempotency check
  - Conditional sudo usage
  - DRY_RUN compatibility
- Added internal validation for package name presence
- Removed duplicated and unsupported Linux warning behavior
- Ensured full compatibility with `set -euo pipefail`

This implementation unblocks the Core Libraries phase and enables safe refactoring of Linux and macOS installation scripts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Installer now detects distro family and selects the appropriate package manager (apt, dnf/yum, pacman, or brew).
  * Consolidated update/check/install flows into a unified, package-manager-driven surface with pre-install checks and standardized user messages.
  * Improved privilege escalation and error handling for more reliable installs and clearer feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->