### PR TITLE
Test:  Add unit tests for  User/addressLine1.ts #5074

### DIFF
--- a/src/graphql/types/User/addressLine1.ts
+++ b/src/graphql/types/User/addressLine1.ts
@@ -2,14 +2,26 @@ import envConfig from "~/src/utilities/graphqLimits";
 import { escapeHTML } from "~/src/utilities/sanitizer";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 import { User } from "./User";
+import { GraphQLContext } from "../../context";
+import { GraphQLError } from "graphql";
 
-User.implement({
-	fields: (t) => ({
-		addressLine1: t.field({
-			description: "Address line 1 of the user's address.",
-			complexity: envConfig.API_GRAPHQL_SCALAR_RESOLVER_FIELD_COST,
-			resolve: async (parent, _args, ctx) => {
-				if (!ctx.currentClient.isAuthenticated) {
+/**
+ * Resolver for the User.addressLine1 field with access control.
+ * Only administrators or the user themselves can access this field.
+ *
+ * @param parent - The parent User object being resolved
+ * @param _args - GraphQL arguments (not used)
+ * @param ctx - The GraphQL context 
+ * @returns The user's address first line or throws an error if unauthorized
+*/
+export const addressLine1Resolver = async(
+  parent : User,
+  _args: Record<string, never>,
+  ctx: GraphQLContext
+
+)=> {
+    try{
+		if (!ctx.currentClient.isAuthenticated) {
 					throw new TalawaGraphQLError({
 						extensions: {
 							code: "unauthenticated",
@@ -46,7 +58,29 @@ User.implement({
 				}
 
 				return escapeHTML(parent.addressLine1);
-			},
+	}
+	
+	catch(error){
+       if(error instanceof GraphQLError){
+		throw error
+	   }
+
+	   ctx.log.error(error);
+
+       throw new TalawaGraphQLError({
+		message: "internal server error",
+		extensions :{
+         code :"unexpected" 
+		 },
+	   });
+	}
+ };
+User.implement({
+	fields: (t) => ({
+		addressLine1: t.field({
+			description: "Address line 1 of the user's address.",
+			complexity: envConfig.API_GRAPHQL_SCALAR_RESOLVER_FIELD_COST,
+			resolve:addressLine1Resolver,
 			type: "String",
 		}),
 	}),

--- a/src/graphql/types/User/addressLine1.ts
+++ b/src/graphql/types/User/addressLine1.ts
@@ -75,6 +75,7 @@ User.implement({
     addressLine1: t.field({
       description: "Address line 1 of the user's address.",
       complexity: envConfig.API_GRAPHQL_SCALAR_RESOLVER_FIELD_COST,
+	  nullable: true,
       resolve: addressLine1Resolver,
       type: "String",
     }),

--- a/src/graphql/types/User/addressLine1.ts
+++ b/src/graphql/types/User/addressLine1.ts
@@ -1,9 +1,9 @@
+import { GraphQLError } from "graphql";
 import envConfig from "~/src/utilities/graphqLimits";
 import { escapeHTML } from "~/src/utilities/sanitizer";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
+import type { GraphQLContext } from "../../context";
 import { User } from "./User";
-import { GraphQLContext } from "../../context";
-import { GraphQLError } from "graphql";
 
 /**
  * Resolver for the User.addressLine1 field with access control.
@@ -11,76 +11,70 @@ import { GraphQLError } from "graphql";
  *
  * @param parent - The parent User object being resolved
  * @param _args - GraphQL arguments (not used)
- * @param ctx - The GraphQL context 
+ * @param ctx - The GraphQL context
  * @returns The user's address first line or throws an error if unauthorized
-*/
-export const addressLine1Resolver = async(
-  parent : User,
-  _args: Record<string, never>,
-  ctx: GraphQLContext
-
-)=> {
-    try{
+ */
+export const addressLine1Resolver = async (
+	parent: User,
+	_args: Record<string, never>,
+	ctx: GraphQLContext,
+) => {
+	try {
 		if (!ctx.currentClient.isAuthenticated) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthenticated",
-						},
-					});
-				}
+			throw new TalawaGraphQLError({
+				extensions: {
+					code: "unauthenticated",
+				},
+			});
+		}
 
-				const currentUserId = ctx.currentClient.user.id;
+		const currentUserId = ctx.currentClient.user.id;
 
-				const currentUser = await ctx.drizzleClient.query.usersTable.findFirst({
-					columns: {
-						role: true,
-					},
-					where: (fields, operators) => operators.eq(fields.id, currentUserId),
-				});
+		const currentUser = await ctx.drizzleClient.query.usersTable.findFirst({
+			columns: {
+				role: true,
+			},
+			where: (fields, operators) => operators.eq(fields.id, currentUserId),
+		});
 
-				if (currentUser === undefined) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthenticated",
-						},
-					});
-				}
+		if (currentUser === undefined) {
+			throw new TalawaGraphQLError({
+				extensions: {
+					code: "unauthenticated",
+				},
+			});
+		}
 
-				if (
-					currentUser.role !== "administrator" &&
-					parent.id !== currentUserId
-				) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthorized_action",
-						},
-					});
-				}
+		if (currentUser.role !== "administrator" && parent.id !== currentUserId) {
+			throw new TalawaGraphQLError({
+				extensions: {
+					code: "unauthorized_action",
+				},
+			});
+		}
 
-				return escapeHTML(parent.addressLine1);
+		return escapeHTML(parent.addressLine1);
+	} catch (error) {
+		if (error instanceof GraphQLError) {
+			throw error;
+		}
+
+		ctx.log.error(error);
+
+		throw new TalawaGraphQLError({
+			message: "internal server error",
+			extensions: {
+				code: "unexpected",
+			},
+		});
 	}
-	
-	catch(error){
-       if(error instanceof GraphQLError){
-		throw error
-	   }
-
-	   ctx.log.error(error);
-
-       throw new TalawaGraphQLError({
-		message: "internal server error",
-		extensions :{
-         code :"unexpected" 
-		 },
-	   });
-	}
- };
+};
 User.implement({
 	fields: (t) => ({
 		addressLine1: t.field({
 			description: "Address line 1 of the user's address.",
 			complexity: envConfig.API_GRAPHQL_SCALAR_RESOLVER_FIELD_COST,
-			resolve:addressLine1Resolver,
+			resolve: addressLine1Resolver,
 			type: "String",
 		}),
 	}),

--- a/src/graphql/types/User/addressLine1.ts
+++ b/src/graphql/types/User/addressLine1.ts
@@ -12,7 +12,8 @@ import { User } from "./User";
  * @param parent - The parent User object being resolved
  * @param _args - GraphQL arguments (not used)
  * @param ctx - The GraphQL context
- * @returns The user's address first line or throws an error if unauthorized
+ * @returns The HTML-escaped addressLine1 string, or null if not set.
+ * @throws {TalawaGraphQLError} if the user is unauthenticated or unauthorized.
  */
 export const addressLine1Resolver = async (
   parent: User,

--- a/src/graphql/types/User/addressLine1.ts
+++ b/src/graphql/types/User/addressLine1.ts
@@ -14,13 +14,13 @@ import { User } from "./User";
  * @param ctx - The GraphQL context 
  * @returns The user's address first line or throws an error if unauthorized
 */
-export const addressLine1Resolver = async(
-  parent : User,
+export const addressLine1Resolver = async (
+  parent: User,
   _args: Record<string, never>,
   ctx: GraphQLContext
 
-  )=> {
-    try{
+  ) => {
+    try {
 		if (!ctx.currentClient.isAuthenticated) {
 					throw new TalawaGraphQLError({
 						extensions: {
@@ -60,7 +60,7 @@ export const addressLine1Resolver = async(
 				return escapeHTML(parent.addressLine1);
 	}
 
-	catch(error){
+	catch (error) {
        if(error instanceof GraphQLError){
 		throw error
 	   }
@@ -69,8 +69,8 @@ export const addressLine1Resolver = async(
 
        throw new TalawaGraphQLError({
 		message: "internal server error",
-		extensions :{
-         code :"unexpected" 
+		extensions: {
+         code: "unexpected" 
 		 },
 	   });
 	}
@@ -80,7 +80,7 @@ User.implement({
 		addressLine1: t.field({
 			description: "Address line 1 of the user's address.",
 			complexity: envConfig.API_GRAPHQL_SCALAR_RESOLVER_FIELD_COST,
-			resolve:addressLine1Resolver,
+			resolve: addressLine1Resolver,
 			type: "String",
 		}),
 	}),

--- a/src/graphql/types/User/addressLine1.ts
+++ b/src/graphql/types/User/addressLine1.ts
@@ -75,7 +75,7 @@ User.implement({
     addressLine1: t.field({
       description: "Address line 1 of the user's address.",
       complexity: envConfig.API_GRAPHQL_SCALAR_RESOLVER_FIELD_COST,
-	  nullable: true,
+      nullable: true,
       resolve: addressLine1Resolver,
       type: "String",
     }),

--- a/src/graphql/types/User/addressLine1.ts
+++ b/src/graphql/types/User/addressLine1.ts
@@ -2,7 +2,7 @@ import { GraphQLError } from "graphql";
 import envConfig from "~/src/utilities/graphqLimits";
 import { escapeHTML } from "~/src/utilities/sanitizer";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
-import type { GraphQLContext } from "../../context";
+import  { GraphQLContext } from "../../context";
 import { User } from "./User";
 
 /**
@@ -11,70 +11,76 @@ import { User } from "./User";
  *
  * @param parent - The parent User object being resolved
  * @param _args - GraphQL arguments (not used)
- * @param ctx - The GraphQL context
+ * @param ctx - The GraphQL context 
  * @returns The user's address first line or throws an error if unauthorized
- */
-export const addressLine1Resolver = async (
-	parent: User,
-	_args: Record<string, never>,
-	ctx: GraphQLContext,
-) => {
-	try {
+*/
+export const addressLine1Resolver = async(
+  parent : User,
+  _args: Record<string, never>,
+  ctx: GraphQLContext
+
+  )=> {
+    try{
 		if (!ctx.currentClient.isAuthenticated) {
-			throw new TalawaGraphQLError({
-				extensions: {
-					code: "unauthenticated",
-				},
-			});
-		}
+					throw new TalawaGraphQLError({
+						extensions: {
+							code: "unauthenticated",
+						},
+					});
+				}
 
-		const currentUserId = ctx.currentClient.user.id;
+				const currentUserId = ctx.currentClient.user.id;
 
-		const currentUser = await ctx.drizzleClient.query.usersTable.findFirst({
-			columns: {
-				role: true,
-			},
-			where: (fields, operators) => operators.eq(fields.id, currentUserId),
-		});
+				const currentUser = await ctx.drizzleClient.query.usersTable.findFirst({
+					columns: {
+						role: true,
+					},
+					where: (fields, operators) => operators.eq(fields.id, currentUserId),
+				});
 
-		if (currentUser === undefined) {
-			throw new TalawaGraphQLError({
-				extensions: {
-					code: "unauthenticated",
-				},
-			});
-		}
+				if (currentUser === undefined) {
+					throw new TalawaGraphQLError({
+						extensions: {
+							code: "unauthenticated",
+						},
+					});
+				}
 
-		if (currentUser.role !== "administrator" && parent.id !== currentUserId) {
-			throw new TalawaGraphQLError({
-				extensions: {
-					code: "unauthorized_action",
-				},
-			});
-		}
+				if (
+					currentUser.role !== "administrator" &&
+					parent.id !== currentUserId
+				) {
+					throw new TalawaGraphQLError({
+						extensions: {
+							code: "unauthorized_action",
+						},
+					});
+				}
 
-		return escapeHTML(parent.addressLine1);
-	} catch (error) {
-		if (error instanceof GraphQLError) {
-			throw error;
-		}
-
-		ctx.log.error(error);
-
-		throw new TalawaGraphQLError({
-			message: "internal server error",
-			extensions: {
-				code: "unexpected",
-			},
-		});
+				return escapeHTML(parent.addressLine1);
 	}
-};
+
+	catch(error){
+       if(error instanceof GraphQLError){
+		throw error
+	   }
+
+	   ctx.log.error(error);
+
+       throw new TalawaGraphQLError({
+		message: "internal server error",
+		extensions :{
+         code :"unexpected" 
+		 },
+	   });
+	}
+ };
 User.implement({
 	fields: (t) => ({
 		addressLine1: t.field({
 			description: "Address line 1 of the user's address.",
 			complexity: envConfig.API_GRAPHQL_SCALAR_RESOLVER_FIELD_COST,
-			resolve: addressLine1Resolver,
+			resolve:addressLine1Resolver,
 			type: "String",
 		}),
 	}),

--- a/src/graphql/types/User/addressLine1.ts
+++ b/src/graphql/types/User/addressLine1.ts
@@ -11,77 +11,71 @@ import { User } from "./User";
  *
  * @param parent - The parent User object being resolved
  * @param _args - GraphQL arguments (not used)
- * @param ctx - The GraphQL context 
+ * @param ctx - The GraphQL context
  * @returns The user's address first line or throws an error if unauthorized
-*/
+ */
 export const addressLine1Resolver = async (
   parent: User,
   _args: Record<string, never>,
-  ctx: GraphQLContext
+  ctx: GraphQLContext,
+) => {
+  try {
+    if (!ctx.currentClient.isAuthenticated) {
+      throw new TalawaGraphQLError({
+        extensions: {
+          code: "unauthenticated",
+        },
+      });
+    }
 
-  ) => {
-    try {
-		if (!ctx.currentClient.isAuthenticated) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthenticated",
-						},
-					});
-				}
+    const currentUserId = ctx.currentClient.user.id;
 
-				const currentUserId = ctx.currentClient.user.id;
+    const currentUser = await ctx.drizzleClient.query.usersTable.findFirst({
+      columns: {
+        role: true,
+      },
+      where: (fields, operators) => operators.eq(fields.id, currentUserId),
+    });
 
-				const currentUser = await ctx.drizzleClient.query.usersTable.findFirst({
-					columns: {
-						role: true,
-					},
-					where: (fields, operators) => operators.eq(fields.id, currentUserId),
-				});
+    if (currentUser === undefined) {
+      throw new TalawaGraphQLError({
+        extensions: {
+          code: "unauthenticated",
+        },
+      });
+    }
 
-				if (currentUser === undefined) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthenticated",
-						},
-					});
-				}
+    if (currentUser.role !== "administrator" && parent.id !== currentUserId) {
+      throw new TalawaGraphQLError({
+        extensions: {
+          code: "unauthorized_action",
+        },
+      });
+    }
 
-				if (
-					currentUser.role !== "administrator" &&
-					parent.id !== currentUserId
-				) {
-					throw new TalawaGraphQLError({
-						extensions: {
-							code: "unauthorized_action",
-						},
-					});
-				}
+    return escapeHTML(parent.addressLine1);
+  } catch (error) {
+    if (error instanceof GraphQLError) {
+      throw error;
+    }
 
-				return escapeHTML(parent.addressLine1);
-	}
+    ctx.log.error(error);
 
-	catch (error) {
-       if(error instanceof GraphQLError){
-		throw error
-	   }
-
-	   ctx.log.error(error);
-
-       throw new TalawaGraphQLError({
-		message: "internal server error",
-		extensions: {
-         code: "unexpected" 
-		 },
-	   });
-	}
- };
+    throw new TalawaGraphQLError({
+      message: "internal server error",
+      extensions: {
+        code: "unexpected",
+      },
+    });
+  }
+};
 User.implement({
-	fields: (t) => ({
-		addressLine1: t.field({
-			description: "Address line 1 of the user's address.",
-			complexity: envConfig.API_GRAPHQL_SCALAR_RESOLVER_FIELD_COST,
-			resolve: addressLine1Resolver,
-			type: "String",
-		}),
-	}),
+  fields: (t) => ({
+    addressLine1: t.field({
+      description: "Address line 1 of the user's address.",
+      complexity: envConfig.API_GRAPHQL_SCALAR_RESOLVER_FIELD_COST,
+      resolve: addressLine1Resolver,
+      type: "String",
+    }),
+  }),
 });

--- a/src/graphql/types/User/addressLine1.ts
+++ b/src/graphql/types/User/addressLine1.ts
@@ -2,7 +2,7 @@ import { GraphQLError } from "graphql";
 import envConfig from "~/src/utilities/graphqLimits";
 import { escapeHTML } from "~/src/utilities/sanitizer";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
-import  { GraphQLContext } from "../../context";
+import type { GraphQLContext } from "../../context";
 import { User } from "./User";
 
 /**

--- a/test/graphql/types/User/addressLine1.test.ts
+++ b/test/graphql/types/User/addressLine1.test.ts
@@ -143,12 +143,12 @@ describe("user field addressLine1 resolver", () => {
 			role: "regular",
 		});
 
-		const UserWithHtml = {
+		const userWithHtml = {
 			...parent,
 			addressLine1: "<script>alert('xss')</script>",
 		} as UserType;
 
-		const result = await addressLine1Resolver(UserWithHtml, {}, ctx);
+		const result = await addressLine1Resolver(userWithHtml, {}, ctx);
 
 		expect(result).not.toContain("<script>");
 		expect(result).toContain("&lt;script&gt;");

--- a/test/graphql/types/User/addressLine1.test.ts
+++ b/test/graphql/types/User/addressLine1.test.ts
@@ -204,18 +204,3 @@ beforeEach(()=>{
             expect(ctx.log.error).toHaveBeenCalledWith(unknownError);
         });
 });
-//
-//});
-
-
-/*
-1- test  for unauth [1]
-2- test for non exist [1]
-3- test for non admin try to get anther user addres[1]
-4- test for  Successful data retrieval[1]
-5- test for null [1]
-6- test for undefined[1]
-7- test for admin retrive data[1]
-8- test for escape HTML [1]
-9- test for rest
-*/

--- a/test/graphql/types/User/addressLine1.test.ts
+++ b/test/graphql/types/User/addressLine1.test.ts
@@ -86,12 +86,12 @@ describe("user field addressLine1 resolver", () => {
 			role: "regular",
 		});
 
-		const userwithNull = {
+		const userWithNull = {
 			...parent,
 			addressLine1: null,
 		};
 
-		const result = await addressLine1Resolver(userwithNull, {}, ctx);
+		const result = await addressLine1Resolver(userWithNull, {}, ctx);
 		expect(result).toBeNull();
 	});
 
@@ -100,12 +100,12 @@ describe("user field addressLine1 resolver", () => {
 			role: "regular",
 		});
 
-		const userwithUndefined = {
+		const userWithUndefined = {
 			...parent,
 			addressLine1: undefined,
 		} as unknown as UserType;
 
-		const result = await addressLine1Resolver(userwithUndefined, {}, ctx);
+		const result = await addressLine1Resolver(userWithUndefined, {}, ctx);
 		expect(result).toBeUndefined();
 	});
 
@@ -114,12 +114,12 @@ describe("user field addressLine1 resolver", () => {
 			role: "regular",
 		});
 
-		const userwithEmptystring = {
+		const userWithEmptyString = {
 			...parent,
 			addressLine1: "",
 		};
 
-		const result = await addressLine1Resolver(userwithEmptystring, {}, ctx);
+		const result = await addressLine1Resolver(userWithEmptyString, {}, ctx);
 		expect(result).toBe("");
 	});
 

--- a/test/graphql/types/User/addressLine1.test.ts
+++ b/test/graphql/types/User/addressLine1.test.ts
@@ -1,0 +1,221 @@
+import { faker } from "@faker-js/faker";
+import { addressLine1Resolver } from "~/src/graphql/types/User/addressLine1";
+import { User as UserType } from "~/src/graphql/types/User/User";
+import { beforeEach , vi , afterEach , it , expect, describe  } from "vitest";
+import { createMockGraphQLContext } from "test/_Mocks_/mockContextCreator/mockContextCreator";
+import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
+import { GraphQLContext } from "~/src/graphql/context";
+
+describe("user field addressLine1 resolver" , () =>{
+
+let mocks : ReturnType <typeof createMockGraphQLContext> ["mocks"];
+let parent : UserType;
+let ctx :GraphQLContext;
+beforeEach(()=>{
+ const _userId = faker.string.ulid();
+ const {context , mocks : newMocks} = createMockGraphQLContext(
+        true,
+        _userId,
+     );
+     ctx=context;
+     mocks=newMocks;
+     parent = {
+      id : _userId,
+      name : "Test User",
+      role : "regular" ,
+      addressLine1 : "123 Main St",
+     } as UserType ;   
+  });
+
+  afterEach(()=>{
+  vi.clearAllMocks();  
+  });
+
+  it("throws unauthenticated error when client is not authenticated" , async() =>{
+    const {context : unauthCtx } = createMockGraphQLContext(false);
+
+    await expect(addressLine1Resolver(parent,{},unauthCtx)).rejects.toThrow(
+          expect.objectContaining({
+            message : expect.any(String),
+            extensions :expect.objectContaining({
+                code : "unauthenticated",
+             })
+          }),
+      );
+  });
+
+  it("throws unauthenticated error when authenticated user does not exist in database" , async() =>  {
+    mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue(undefined);
+    
+    await expect(addressLine1Resolver(parent, {} , ctx)).rejects.toThrow(
+          expect.objectContaining({
+          extensions: expect.objectContaining({
+               code : "unauthenticated", 
+            })   
+          }), 
+      );
+  });
+  
+  it("throws unauthorized_action when non-admin accesses another user's addressLine1", async() => {
+  const anotherUser = {
+    ...parent ,
+    id : faker.string.ulid(),
+    } as UserType
+
+    mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+        role : "regular",
+    });
+    await expect(addressLine1Resolver(anotherUser,{},ctx)).rejects.toThrow(
+          expect.objectContaining({
+           extensions : expect.objectContaining({
+            code : "unauthorized_action",
+          })    
+        }),
+      );
+   });
+
+   it("returns addressLine1 when user accesses their own data",async () =>{
+       mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+       role : "regular",
+       });
+       const result = await addressLine1Resolver(parent,{},ctx);
+       expect(result).toBe("123 Main St");
+   });
+
+   it("returns null when addressLine1 is null" , async () => {
+      mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+      role : "regular",
+      });
+
+      const userwithNull = {
+       ...parent,
+       addressLine1 : null, 
+      };
+
+      const result = await addressLine1Resolver(userwithNull ,{},ctx);
+      expect(result).toBeNull();
+   });
+
+   it("returns undefined when addressLine1 is undefined" , async () => {
+      mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+      role : "regular",
+      });
+      
+      const userwithUndefined ={
+       ...parent,
+       addressLine1 : undefined, 
+      } as unknown as UserType ;
+
+      const result = await addressLine1Resolver(userwithUndefined,{},ctx);
+      expect(result).toBeUndefined();
+   });
+
+   it("returns empty string when addressLine1 is empty string" , async () => {
+      mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+      role : "regular",
+      });
+      
+      const userwithEmptystring ={
+       ...parent,
+       addressLine1 :"", 
+      }
+
+      const result = await addressLine1Resolver(userwithEmptystring,{},ctx);
+      expect(result).toBe("");
+   });
+
+   it("returns addressLine1 when admin accesses another user's data" , async () => {
+      mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+      role : "administrator",
+      });
+      
+      const anotherUser ={
+       ...parent,
+       id : faker.string.ulid(),
+       addressLine1 : "345 Main St <script>alert('xss')</script>" 
+      } 
+
+      const result = await addressLine1Resolver(anotherUser,{},ctx);
+      expect(result).toBe("345 Main St &lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;");
+   });
+
+   it("escapes HTML characters in addressLine1 to prevent XSS", async () => {
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+			role: "regular",
+		});
+
+		const UserWithHtml = {
+		...parent,
+		addressLine1: "<script>alert('xss')</script>",
+		} as UserType; 
+
+		const result = await addressLine1Resolver(UserWithHtml, {}, ctx);
+
+		expect(result).not.toContain("<script>");
+		expect(result).toContain("&lt;script&gt;");
+	});
+
+        it("rethrows TalawaGraphQLError from database layer without logging", async () => {
+            const talawaError = new TalawaGraphQLError({
+                extensions: { code: "unauthenticated" },
+            });
+    
+            mocks.drizzleClient.query.usersTable.findFirst.mockRejectedValue(
+                talawaError,
+            );
+    
+            await expect(addressLine1Resolver(parent, {}, ctx)).rejects.toBe(
+                talawaError,
+            );
+    
+            expect(ctx.log.error).not.toHaveBeenCalled();
+        });
+
+        it("wraps unknown database errors as unexpected", async () => {
+            const dbError = new Error("DB crashed");
+    
+            mocks.drizzleClient.query.usersTable.findFirst.mockRejectedValue(dbError);
+    
+            await expect(addressLine1Resolver(parent, {}, ctx)).rejects.toThrow(
+                expect.objectContaining({
+                    extensions: expect.objectContaining({
+                        code: "unexpected",
+                    }),
+                }),
+            );
+            expect(ctx.log.error).toHaveBeenCalledWith(dbError);
+        });
+    
+        it("logs and wraps unknown database errors", async () => {
+            const unknownError = new Error("DB crash");
+    
+            mocks.drizzleClient.query.usersTable.findFirst.mockRejectedValue(
+                unknownError,
+            );
+    
+            await expect(addressLine1Resolver(parent, {}, ctx)).rejects.toThrow(
+                expect.objectContaining({
+                    extensions: expect.objectContaining({
+                        code: "unexpected",
+                    }),
+                }),
+            );
+    
+            expect(ctx.log.error).toHaveBeenCalledWith(unknownError);
+        });
+});
+//
+//});
+
+
+/*
+1- test  for unauth [1]
+2- test for non exist [1]
+3- test for non admin try to get anther user addres[1]
+4- test for  Successful data retrieval[1]
+5- test for null [1]
+6- test for undefined[1]
+7- test for admin retrive data[1]
+8- test for escape HTML [1]
+9- test for rest
+*/

--- a/test/graphql/types/User/addressLine1.test.ts
+++ b/test/graphql/types/User/addressLine1.test.ts
@@ -1,153 +1,154 @@
 import { faker } from "@faker-js/faker";
-import { addressLine1Resolver } from "~/src/graphql/types/User/addressLine1";
-import { User as UserType } from "~/src/graphql/types/User/User";
-import { beforeEach , vi , afterEach , it , expect, describe  } from "vitest";
 import { createMockGraphQLContext } from "test/_Mocks_/mockContextCreator/mockContextCreator";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GraphQLContext } from "~/src/graphql/context";
+import { addressLine1Resolver } from "~/src/graphql/types/User/addressLine1";
+import type { User as UserType } from "~/src/graphql/types/User/User";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
-import { GraphQLContext } from "~/src/graphql/context";
 
-describe("user field addressLine1 resolver" , () =>{
+describe("user field addressLine1 resolver", () => {
+	let mocks: ReturnType<typeof createMockGraphQLContext>["mocks"];
+	let parent: UserType;
+	let ctx: GraphQLContext;
+	beforeEach(() => {
+		const _userId = faker.string.ulid();
+		const { context, mocks: newMocks } = createMockGraphQLContext(
+			true,
+			_userId,
+		);
+		ctx = context;
+		mocks = newMocks;
+		parent = {
+			id: _userId,
+			name: "Test User",
+			role: "regular",
+			addressLine1: "123 Main St",
+		} as UserType;
+	});
 
-let mocks : ReturnType <typeof createMockGraphQLContext> ["mocks"];
-let parent : UserType;
-let ctx :GraphQLContext;
-beforeEach(()=>{
- const _userId = faker.string.ulid();
- const {context , mocks : newMocks} = createMockGraphQLContext(
-        true,
-        _userId,
-     );
-     ctx=context;
-     mocks=newMocks;
-     parent = {
-      id : _userId,
-      name : "Test User",
-      role : "regular" ,
-      addressLine1 : "123 Main St",
-     } as UserType ;   
-  });
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
 
-  afterEach(()=>{
-  vi.clearAllMocks();  
-  });
+	it("throws unauthenticated error when client is not authenticated", async () => {
+		const { context: unauthCtx } = createMockGraphQLContext(false);
 
-  it("throws unauthenticated error when client is not authenticated" , async() =>{
-    const {context : unauthCtx } = createMockGraphQLContext(false);
+		await expect(addressLine1Resolver(parent, {}, unauthCtx)).rejects.toThrow(
+			expect.objectContaining({
+				message: expect.any(String),
+				extensions: expect.objectContaining({
+					code: "unauthenticated",
+				}),
+			}),
+		);
+	});
 
-    await expect(addressLine1Resolver(parent,{},unauthCtx)).rejects.toThrow(
-          expect.objectContaining({
-            message : expect.any(String),
-            extensions :expect.objectContaining({
-                code : "unauthenticated",
-             })
-          }),
-      );
-  });
+	it("throws unauthenticated error when authenticated user does not exist in database", async () => {
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue(undefined);
 
-  it("throws unauthenticated error when authenticated user does not exist in database" , async() =>  {
-    mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue(undefined);
-    
-    await expect(addressLine1Resolver(parent, {} , ctx)).rejects.toThrow(
-          expect.objectContaining({
-          extensions: expect.objectContaining({
-               code : "unauthenticated", 
-            })   
-          }), 
-      );
-  });
-  
-  it("throws unauthorized_action when non-admin accesses another user's addressLine1", async() => {
-  const anotherUser = {
-    ...parent ,
-    id : faker.string.ulid(),
-    } as UserType
+		await expect(addressLine1Resolver(parent, {}, ctx)).rejects.toThrow(
+			expect.objectContaining({
+				extensions: expect.objectContaining({
+					code: "unauthenticated",
+				}),
+			}),
+		);
+	});
 
-    mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
-        role : "regular",
-    });
-    await expect(addressLine1Resolver(anotherUser,{},ctx)).rejects.toThrow(
-          expect.objectContaining({
-           extensions : expect.objectContaining({
-            code : "unauthorized_action",
-          })    
-        }),
-      );
-   });
+	it("throws unauthorized_action when non-admin accesses another user's addressLine1", async () => {
+		const anotherUser = {
+			...parent,
+			id: faker.string.ulid(),
+		} as UserType;
 
-   it("returns addressLine1 when user accesses their own data",async () =>{
-       mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
-       role : "regular",
-       });
-       const result = await addressLine1Resolver(parent,{},ctx);
-       expect(result).toBe("123 Main St");
-   });
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+			role: "regular",
+		});
+		await expect(addressLine1Resolver(anotherUser, {}, ctx)).rejects.toThrow(
+			expect.objectContaining({
+				extensions: expect.objectContaining({
+					code: "unauthorized_action",
+				}),
+			}),
+		);
+	});
 
-   it("returns null when addressLine1 is null" , async () => {
-      mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
-      role : "regular",
-      });
+	it("returns addressLine1 when user accesses their own data", async () => {
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+			role: "regular",
+		});
+		const result = await addressLine1Resolver(parent, {}, ctx);
+		expect(result).toBe("123 Main St");
+	});
 
-      const userwithNull = {
-       ...parent,
-       addressLine1 : null, 
-      };
+	it("returns null when addressLine1 is null", async () => {
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+			role: "regular",
+		});
 
-      const result = await addressLine1Resolver(userwithNull ,{},ctx);
-      expect(result).toBeNull();
-   });
+		const userwithNull = {
+			...parent,
+			addressLine1: null,
+		};
 
-   it("returns undefined when addressLine1 is undefined" , async () => {
-      mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
-      role : "regular",
-      });
-      
-      const userwithUndefined ={
-       ...parent,
-       addressLine1 : undefined, 
-      } as unknown as UserType ;
+		const result = await addressLine1Resolver(userwithNull, {}, ctx);
+		expect(result).toBeNull();
+	});
 
-      const result = await addressLine1Resolver(userwithUndefined,{},ctx);
-      expect(result).toBeUndefined();
-   });
+	it("returns undefined when addressLine1 is undefined", async () => {
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+			role: "regular",
+		});
 
-   it("returns empty string when addressLine1 is empty string" , async () => {
-      mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
-      role : "regular",
-      });
-      
-      const userwithEmptystring ={
-       ...parent,
-       addressLine1 :"", 
-      }
+		const userwithUndefined = {
+			...parent,
+			addressLine1: undefined,
+		} as unknown as UserType;
 
-      const result = await addressLine1Resolver(userwithEmptystring,{},ctx);
-      expect(result).toBe("");
-   });
+		const result = await addressLine1Resolver(userwithUndefined, {}, ctx);
+		expect(result).toBeUndefined();
+	});
 
-   it("returns addressLine1 when admin accesses another user's data" , async () => {
-      mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
-      role : "administrator",
-      });
-      
-      const anotherUser ={
-       ...parent,
-       id : faker.string.ulid(),
-       addressLine1 : "345 Main St <script>alert('xss')</script>" 
-      } 
+	it("returns empty string when addressLine1 is empty string", async () => {
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+			role: "regular",
+		});
 
-      const result = await addressLine1Resolver(anotherUser,{},ctx);
-      expect(result).toBe("345 Main St &lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;");
-   });
+		const userwithEmptystring = {
+			...parent,
+			addressLine1: "",
+		};
 
-   it("escapes HTML characters in addressLine1 to prevent XSS", async () => {
+		const result = await addressLine1Resolver(userwithEmptystring, {}, ctx);
+		expect(result).toBe("");
+	});
+
+	it("returns addressLine1 when admin accesses another user's data", async () => {
+		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
+			role: "administrator",
+		});
+
+		const anotherUser = {
+			...parent,
+			id: faker.string.ulid(),
+			addressLine1: "345 Main St <script>alert('xss')</script>",
+		};
+
+		const result = await addressLine1Resolver(anotherUser, {}, ctx);
+		expect(result).toBe(
+			"345 Main St &lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;",
+		);
+	});
+
+	it("escapes HTML characters in addressLine1 to prevent XSS", async () => {
 		mocks.drizzleClient.query.usersTable.findFirst.mockResolvedValue({
 			role: "regular",
 		});
 
 		const UserWithHtml = {
-		...parent,
-		addressLine1: "<script>alert('xss')</script>",
-		} as UserType; 
+			...parent,
+			addressLine1: "<script>alert('xss')</script>",
+		} as UserType;
 
 		const result = await addressLine1Resolver(UserWithHtml, {}, ctx);
 
@@ -155,52 +156,52 @@ beforeEach(()=>{
 		expect(result).toContain("&lt;script&gt;");
 	});
 
-        it("rethrows TalawaGraphQLError from database layer without logging", async () => {
-            const talawaError = new TalawaGraphQLError({
-                extensions: { code: "unauthenticated" },
-            });
-    
-            mocks.drizzleClient.query.usersTable.findFirst.mockRejectedValue(
-                talawaError,
-            );
-    
-            await expect(addressLine1Resolver(parent, {}, ctx)).rejects.toBe(
-                talawaError,
-            );
-    
-            expect(ctx.log.error).not.toHaveBeenCalled();
-        });
+	it("rethrows TalawaGraphQLError from database layer without logging", async () => {
+		const talawaError = new TalawaGraphQLError({
+			extensions: { code: "unauthenticated" },
+		});
 
-        it("wraps unknown database errors as unexpected", async () => {
-            const dbError = new Error("DB crashed");
-    
-            mocks.drizzleClient.query.usersTable.findFirst.mockRejectedValue(dbError);
-    
-            await expect(addressLine1Resolver(parent, {}, ctx)).rejects.toThrow(
-                expect.objectContaining({
-                    extensions: expect.objectContaining({
-                        code: "unexpected",
-                    }),
-                }),
-            );
-            expect(ctx.log.error).toHaveBeenCalledWith(dbError);
-        });
-    
-        it("logs and wraps unknown database errors", async () => {
-            const unknownError = new Error("DB crash");
-    
-            mocks.drizzleClient.query.usersTable.findFirst.mockRejectedValue(
-                unknownError,
-            );
-    
-            await expect(addressLine1Resolver(parent, {}, ctx)).rejects.toThrow(
-                expect.objectContaining({
-                    extensions: expect.objectContaining({
-                        code: "unexpected",
-                    }),
-                }),
-            );
-    
-            expect(ctx.log.error).toHaveBeenCalledWith(unknownError);
-        });
+		mocks.drizzleClient.query.usersTable.findFirst.mockRejectedValue(
+			talawaError,
+		);
+
+		await expect(addressLine1Resolver(parent, {}, ctx)).rejects.toBe(
+			talawaError,
+		);
+
+		expect(ctx.log.error).not.toHaveBeenCalled();
+	});
+
+	it("wraps unknown database errors as unexpected", async () => {
+		const dbError = new Error("DB crashed");
+
+		mocks.drizzleClient.query.usersTable.findFirst.mockRejectedValue(dbError);
+
+		await expect(addressLine1Resolver(parent, {}, ctx)).rejects.toThrow(
+			expect.objectContaining({
+				extensions: expect.objectContaining({
+					code: "unexpected",
+				}),
+			}),
+		);
+		expect(ctx.log.error).toHaveBeenCalledWith(dbError);
+	});
+
+	it("logs and wraps unknown database errors", async () => {
+		const unknownError = new Error("DB crash");
+
+		mocks.drizzleClient.query.usersTable.findFirst.mockRejectedValue(
+			unknownError,
+		);
+
+		await expect(addressLine1Resolver(parent, {}, ctx)).rejects.toThrow(
+			expect.objectContaining({
+				extensions: expect.objectContaining({
+					code: "unexpected",
+				}),
+			}),
+		);
+
+		expect(ctx.log.error).toHaveBeenCalledWith(unknownError);
+	});
 });


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Test coverage improvement for src/graphql/types/User/addressLine1.ts.
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

<!--Add related issue number here.-->
Fixes #5074

**Snapshots/Videos:**
<img width="1392" height="504" alt="Screenshot from 2026-02-17 22-56-23" src="https://github.com/user-attachments/assets/eab60398-9318-49d9-914b-556e59da33c3" />


<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

No documentation changes needed.
<!--Add link to Talawa-Docs.-->

**Summary**

- Exports addressLine1Resolver from src/graphql/types/User/addressLine1.ts with try-catch error handling
- Adds 12 unit tests covering authentication, authorization, null handling, undefined handling, HTML escaping, and error wrapping
- Uses createMockGraphQLContext() for mocking

Test cases : 

1.Unauthenticated access throws unauthenticated error
2.User not in DB throws unauthenticated error
3.Non-admin accessing another user throws unauthorized_action
4.Self-access returns escaped addressLine1
5.Null addressLine1 returns null
6.Empty addressLine1 returns empty string
7.undefined addressLine1 returns undefined 
8.Admin access to another user returns escaped value
9.HTML characters are escaped (XSS prevention)
10.TalawaGraphQLError is rethrown without logging
11.Unknown errors are logged and wrapped as unexpected

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes

<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Access controls for viewing user address lines: only the user themself or administrators can retrieve this data; null/empty values handled consistently.

* **Bug Fixes / Reliability**
  * Improved resolver error handling and HTML-escaping to prevent XSS.
  * More robust CI startup and health checks with better diagnostics.

* **Chores / Breaking Changes**
  * OAuth config no longer exposes redirect URIs; token-exchange methods now require an explicit redirect URI.

* **Tests**
  * Added comprehensive tests for address resolver and updated OAuth tests to match config changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->