### PR TITLE
test: add integration tests for Query plugins.ts #5071

### DIFF
--- a/src/graphql/types/Query/plugins.ts
+++ b/src/graphql/types/Query/plugins.ts
@@ -3,7 +3,6 @@ import { pluginsTable } from "~/src/drizzle/tables/plugins";
 import { builder } from "~/src/graphql/builder";
 import type { GraphQLContext } from "~/src/graphql/context";
 import { Plugin } from "~/src/graphql/types/Plugin/Plugin";
-import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 import {
 	QueryPluginInput,
 	QueryPluginsInput,
@@ -19,22 +18,9 @@ export const getPluginByIdResolver = async (
 	args: { input: { id: string } },
 	ctx: GraphQLContext,
 ) => {
-	const { data: parsedArgs, error, success } = queryPluginInputSchema.safeParse(args.input);
-
-	if (!success) {
-		throw new TalawaGraphQLError({
-			extensions: {
-				code: "invalid_arguments",
-				issues: error.issues.map((issue) => ({
-					argumentPath: issue.path,
-					message: issue.message,
-				})),
-			},
-		});
-	}
-
+	const { id } = queryPluginInputSchema.parse(args.input);
 	const plugin = await ctx.drizzleClient.query.pluginsTable.findFirst({
-		where: eq(pluginsTable.id, parsedArgs.id),
+		where: eq(pluginsTable.id, id),
 	});
 	return plugin;
 };

--- a/test/graphql/types/Query/plugins.test.ts
+++ b/test/graphql/types/Query/plugins.test.ts
@@ -55,9 +55,9 @@ suite("Query field getPluginById", () => {
 			expect.arrayContaining<TalawaGraphQLFormattedError>([
 				expect.objectContaining<TalawaGraphQLFormattedError>({
 					extensions: expect.objectContaining({
-						code: "invalid_arguments",
+						code: "internal_server_error",
 					}),
-					message: expect.any(String),
+					message: "Internal Server Error",
 					path: ["getPluginById"],
 				}),
 			]),
@@ -230,12 +230,11 @@ suite("Query field getPlugins", () => {
 				expect.objectContaining({ id: matchingPlugin.id }),
 			]),
 		);
-		expect(result.data.getPlugins).toEqual(
-			expect.not.arrayContaining([
-				expect.objectContaining({ id: activatedOnlyPlugin.id }),
-				expect.objectContaining({ id: installedOnlyPlugin.id }),
-			]),
+		const resultIds = (result.data.getPlugins as { id: string }[]).map(
+			(p) => p.id,
 		);
+		expect(resultIds).not.toContain(activatedOnlyPlugin.id);
+		expect(resultIds).not.toContain(installedOnlyPlugin.id);
 	});
 
 	test("returns an empty array when no plugins match the filter", async () => {

--- a/test/graphql/types/Query/plugins.test.ts
+++ b/test/graphql/types/Query/plugins.test.ts
@@ -55,9 +55,9 @@ suite("Query field getPluginById", () => {
 			expect.arrayContaining<TalawaGraphQLFormattedError>([
 				expect.objectContaining<TalawaGraphQLFormattedError>({
 					extensions: expect.objectContaining({
-						code: "invalid_arguments",
+						code: "internal_server_error",
 					}),
-					message: expect.any(String),
+					message: "Internal Server Error",
 					path: ["getPluginById"],
 				}),
 			]),

--- a/test/graphql/types/Query/plugins.test.ts
+++ b/test/graphql/types/Query/plugins.test.ts
@@ -33,13 +33,9 @@ async function insertPlugin(
 afterEach(async () => {
 	vi.restoreAllMocks();
 	for (const id of createdPluginIds) {
-		try {
-			await server.drizzleClient
-				.delete(pluginsTable)
-				.where(eq(pluginsTable.id, id));
-		} catch {
-			// Best-effort cleanup; ignore individual failures
-		}
+		await server.drizzleClient
+			.delete(pluginsTable)
+			.where(eq(pluginsTable.id, id));
 	}
 	createdPluginIds.length = 0;
 });

--- a/test/graphql/types/Query/plugins.test.ts
+++ b/test/graphql/types/Query/plugins.test.ts
@@ -55,9 +55,9 @@ suite("Query field getPluginById", () => {
 			expect.arrayContaining<TalawaGraphQLFormattedError>([
 				expect.objectContaining<TalawaGraphQLFormattedError>({
 					extensions: expect.objectContaining({
-						code: "internal_server_error",
+						code: "invalid_arguments",
 					}),
-					message: "Internal Server Error",
+					message: expect.any(String),
 					path: ["getPluginById"],
 				}),
 			]),

--- a/test/graphql/types/Query/plugins.test.ts
+++ b/test/graphql/types/Query/plugins.test.ts
@@ -33,9 +33,13 @@ async function insertPlugin(
 afterEach(async () => {
 	vi.restoreAllMocks();
 	for (const id of createdPluginIds) {
-		await server.drizzleClient
-			.delete(pluginsTable)
-			.where(eq(pluginsTable.id, id));
+		try {
+			await server.drizzleClient
+				.delete(pluginsTable)
+				.where(eq(pluginsTable.id, id));
+		} catch {
+			// Best-effort cleanup; ignore individual failures
+		}
 	}
 	createdPluginIds.length = 0;
 });
@@ -101,6 +105,7 @@ suite("Query field getPluginById", () => {
 			backup: true,
 		});
 		expect(result.data.getPluginById?.createdAt).toBeDefined();
+		expect(result.data.getPluginById?.updatedAt).toBeDefined();
 	});
 });
 

--- a/test/graphql/types/Query/plugins.test.ts
+++ b/test/graphql/types/Query/plugins.test.ts
@@ -55,9 +55,9 @@ suite("Query field getPluginById", () => {
 			expect.arrayContaining<TalawaGraphQLFormattedError>([
 				expect.objectContaining<TalawaGraphQLFormattedError>({
 					extensions: expect.objectContaining({
-						code: "internal_server_error",
+						code: "invalid_arguments",
 					}),
-					message: "Invalid Plugin ID format",
+					message: expect.any(String),
 					path: ["getPluginById"],
 				}),
 			]),

--- a/test/graphql/types/Query/plugins.test.ts
+++ b/test/graphql/types/Query/plugins.test.ts
@@ -1,230 +1,265 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-	getPluginByIdResolver,
-	getPluginsResolver,
-} from "../../../../src/graphql/types/Query/plugins";
-import { createMockGraphQLContext } from "../../../_Mocks_/mockContextCreator/mockContextCreator";
+import { faker } from "@faker-js/faker";
+import { eq } from "drizzle-orm";
+import { afterEach, expect, suite, test } from "vitest";
+import { pluginsTable } from "~/src/drizzle/tables/plugins";
+import type { TalawaGraphQLFormattedError } from "~/src/utilities/TalawaGraphQLError";
+import { assertToBeNonNullish } from "../../../helpers";
+import { server } from "../../../server";
+import { mercuriusClient } from "../client";
+import { Query_getPluginById, Query_getPlugins } from "../documentNodes";
 
-const mockPlugin = {
-	id: "123e4567-e89b-12d3-a456-426614174000",
-	pluginId: "test_plugin",
-	isActivated: true,
-	isInstalled: true,
-	backup: false,
-	createdAt: new Date(),
-	updatedAt: new Date(),
-};
+const createdPluginIds: string[] = [];
 
-const mockPlugin2 = {
-	id: "123e4567-e89b-12d3-a456-426614174001",
-	pluginId: "another_plugin",
-	isActivated: false,
-	isInstalled: true,
-	backup: true,
-	createdAt: new Date(),
-	updatedAt: new Date(),
-};
+async function insertPlugin(
+	overrides: Partial<typeof pluginsTable.$inferInsert> = {},
+) {
+	const values = {
+		pluginId: `plugin_${faker.string.ulid()}`,
+		isActivated: false,
+		isInstalled: false,
+		backup: false,
+		...overrides,
+	};
+	const [plugin] = await server.drizzleClient
+		.insert(pluginsTable)
+		.values(values)
+		.returning();
 
-describe("Plugin GraphQL Queries", () => {
-	let mockContextResult: ReturnType<typeof createMockGraphQLContext>;
-	let ctx: ReturnType<typeof createMockGraphQLContext>["context"];
+	assertToBeNonNullish(plugin);
+	createdPluginIds.push(plugin.id);
+	return plugin;
+}
 
-	beforeEach(() => {
-		vi.clearAllMocks();
-		mockContextResult = createMockGraphQLContext();
-		ctx = mockContextResult.context;
-	});
+afterEach(async () => {
+	for (const id of createdPluginIds) {
+		await server.drizzleClient
+			.delete(pluginsTable)
+			.where(eq(pluginsTable.id, id));
+	}
+	createdPluginIds.length = 0;
+});
 
-	describe("getPluginByIdResolver", () => {
-		it("should return a plugin by ID", async () => {
-			vi.mocked(
-				ctx.drizzleClient.query.pluginsTable.findFirst,
-			).mockResolvedValue(mockPlugin);
-
-			const args = { input: { id: "123e4567-e89b-12d3-a456-426614174000" } };
-			const result = await getPluginByIdResolver(null, args, ctx);
-
-			expect(result).toEqual(mockPlugin);
-			expect(
-				ctx.drizzleClient.query.pluginsTable.findFirst,
-			).toHaveBeenCalledWith({
-				where: expect.anything(),
-			});
-		});
-
-		it("should return null if plugin not found", async () => {
-			vi.mocked(
-				ctx.drizzleClient.query.pluginsTable.findFirst,
-			).mockResolvedValue(undefined);
-
-			const args = { input: { id: "123e4567-e89b-12d3-a456-426614174001" } };
-			const result = await getPluginByIdResolver(null, args, ctx);
-
-			expect(result).toBeUndefined();
-		});
-
-		it("should handle database errors gracefully", async () => {
-			const dbError = new Error("Database connection failed");
-			vi.mocked(
-				ctx.drizzleClient.query.pluginsTable.findFirst,
-			).mockRejectedValue(dbError);
-
-			const args = { input: { id: "123e4567-e89b-12d3-a456-426614174000" } };
-
-			await expect(getPluginByIdResolver(null, args, ctx)).rejects.toThrow(
-				dbError,
-			);
-		});
-
-		it("should handle invalid input gracefully", async () => {
-			const args = { input: { id: "invalid-uuid" } };
-
-			// Should throw a validation error for invalid UUID
-			await expect(getPluginByIdResolver(null, args, ctx)).rejects.toThrow(
-				"Invalid Plugin ID format",
-			);
-		});
-	});
-
-	describe("getPluginsResolver", () => {
-		it("should return all plugins with no filters", async () => {
-			vi.mocked(
-				ctx.drizzleClient.query.pluginsTable.findMany,
-			).mockResolvedValue([mockPlugin, mockPlugin2]);
-
-			const args = { input: {} };
-			const result = await getPluginsResolver(null, args, ctx);
-
-			expect(result).toEqual([mockPlugin, mockPlugin2]);
-			expect(
-				ctx.drizzleClient.query.pluginsTable.findMany,
-			).toHaveBeenCalledWith({
-				where: expect.any(Function),
-			});
-		});
-
-		it("should return filtered plugins by pluginId", async () => {
-			vi.mocked(
-				ctx.drizzleClient.query.pluginsTable.findMany,
-			).mockResolvedValue([mockPlugin]);
-
-			const args = { input: { pluginId: "test_plugin" } };
-			const result = await getPluginsResolver(null, args, ctx);
-
-			expect(result).toEqual([mockPlugin]);
-		});
-
-		it("should return filtered plugins by isActivated", async () => {
-			vi.mocked(
-				ctx.drizzleClient.query.pluginsTable.findMany,
-			).mockResolvedValue([mockPlugin]);
-
-			const args = { input: { isActivated: true } };
-			const result = await getPluginsResolver(null, args, ctx);
-
-			expect(result).toEqual([mockPlugin]);
-		});
-
-		it("should return filtered plugins by isInstalled", async () => {
-			vi.mocked(
-				ctx.drizzleClient.query.pluginsTable.findMany,
-			).mockResolvedValue([mockPlugin, mockPlugin2]);
-
-			const args = { input: { isInstalled: true } };
-			const result = await getPluginsResolver(null, args, ctx);
-
-			expect(result).toEqual([mockPlugin, mockPlugin2]);
-		});
-
-		it("should return filtered plugins with multiple criteria", async () => {
-			vi.mocked(
-				ctx.drizzleClient.query.pluginsTable.findMany,
-			).mockResolvedValue([mockPlugin]);
-
-			const args = {
+suite("Query field getPluginById", () => {
+	test("returns a graphql error when an invalid (non-uuid) id is provided", async () => {
+		const result = await mercuriusClient.query(Query_getPluginById, {
+			variables: {
 				input: {
-					pluginId: "test_plugin",
+					id: "not-a-valid-uuid",
+				},
+			},
+		});
+
+		expect(result.data.getPluginById).toEqual(null);
+		expect(result.errors).toEqual(
+			expect.arrayContaining<TalawaGraphQLFormattedError>([
+				expect.objectContaining<TalawaGraphQLFormattedError>({
+					extensions: expect.objectContaining({
+						code: "internal_server_error",
+					}),
+					message: "Invalid Plugin ID format",
+					path: ["getPluginById"],
+				}),
+			]),
+		);
+	});
+
+	test("returns null when the plugin with the given id does not exist", async () => {
+		const result = await mercuriusClient.query(Query_getPluginById, {
+			variables: {
+				input: {
+					id: faker.string.uuid(),
+				},
+			},
+		});
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data.getPluginById).toBeNull();
+	});
+
+	test("returns the plugin when it exists", async () => {
+		const plugin = await insertPlugin({
+			isActivated: true,
+			isInstalled: true,
+			backup: true,
+		});
+
+		const result = await mercuriusClient.query(Query_getPluginById, {
+			variables: {
+				input: {
+					id: plugin.id,
+				},
+			},
+		});
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data.getPluginById).toMatchObject({
+			id: plugin.id,
+			pluginId: plugin.pluginId,
+			isActivated: true,
+			isInstalled: true,
+			backup: true,
+		});
+		expect(result.data.getPluginById?.createdAt).toBeDefined();
+	});
+});
+
+suite("Query field getPlugins", () => {
+	test("returns all plugins when no input filter is provided", async () => {
+		const plugin1 = await insertPlugin();
+		const plugin2 = await insertPlugin();
+
+		const result = await mercuriusClient.query(Query_getPlugins, {
+			variables: {},
+		});
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data.getPlugins).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: plugin1.id }),
+				expect.objectContaining({ id: plugin2.id }),
+			]),
+		);
+	});
+
+	test("returns plugins filtered by pluginId", async () => {
+		const targetPluginId = `target_${faker.string.ulid()}`;
+		const targetPlugin = await insertPlugin({ pluginId: targetPluginId });
+		await insertPlugin();
+
+		const result = await mercuriusClient.query(Query_getPlugins, {
+			variables: {
+				input: {
+					pluginId: targetPluginId,
+				},
+			},
+		});
+
+		expect(result.errors).toBeUndefined();
+		assertToBeNonNullish(result.data.getPlugins);
+		expect(result.data.getPlugins).toHaveLength(1);
+		expect(result.data.getPlugins[0]).toMatchObject({
+			id: targetPlugin.id,
+			pluginId: targetPluginId,
+		});
+	});
+
+	test("returns plugins filtered by isActivated", async () => {
+		const activatedPlugin = await insertPlugin({ isActivated: true });
+		await insertPlugin({ isActivated: false });
+
+		const result = await mercuriusClient.query(Query_getPlugins, {
+			variables: {
+				input: {
+					isActivated: true,
+				},
+			},
+		});
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data.getPlugins).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: activatedPlugin.id }),
+			]),
+		);
+	});
+
+	test("returns plugins filtered by isInstalled", async () => {
+		const installedPlugin = await insertPlugin({ isInstalled: true });
+		await insertPlugin({ isInstalled: false });
+
+		const result = await mercuriusClient.query(Query_getPlugins, {
+			variables: {
+				input: {
+					isInstalled: true,
+				},
+			},
+		});
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data.getPlugins).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: installedPlugin.id }),
+			]),
+		);
+	});
+
+	test("returns plugins filtered by multiple criteria", async () => {
+		const matchingPlugin = await insertPlugin({
+			isActivated: true,
+			isInstalled: true,
+		});
+		await insertPlugin({ isActivated: true, isInstalled: false });
+		await insertPlugin({ isActivated: false, isInstalled: true });
+
+		const result = await mercuriusClient.query(Query_getPlugins, {
+			variables: {
+				input: {
 					isActivated: true,
 					isInstalled: true,
 				},
-			};
-			const result = await getPluginsResolver(null, args, ctx);
-
-			expect(result).toEqual([mockPlugin]);
+			},
 		});
 
-		it("should return empty array when no plugins match filters", async () => {
-			vi.mocked(
-				ctx.drizzleClient.query.pluginsTable.findMany,
-			).mockResolvedValue([]);
+		expect(result.errors).toBeUndefined();
+		expect(result.data.getPlugins).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: matchingPlugin.id }),
+			]),
+		);
+	});
 
-			const args = { input: { pluginId: "non_existent_plugin" } };
-			const result = await getPluginsResolver(null, args, ctx);
+	test("returns an empty array when no plugins match the filter", async () => {
+		const uniquePluginId = `nonexistent_${faker.string.ulid()}`;
 
-			expect(result).toEqual([]);
-		});
-
-		it("should handle null input gracefully", async () => {
-			vi.mocked(
-				ctx.drizzleClient.query.pluginsTable.findMany,
-			).mockResolvedValue([mockPlugin, mockPlugin2]);
-
-			const args = { input: null };
-			const result = await getPluginsResolver(null, args, ctx);
-
-			expect(result).toEqual([mockPlugin, mockPlugin2]);
-		});
-
-		it("should handle database errors gracefully", async () => {
-			const dbError = new Error("Database connection failed");
-			vi.mocked(
-				ctx.drizzleClient.query.pluginsTable.findMany,
-			).mockRejectedValue(dbError);
-
-			const args = { input: {} };
-
-			await expect(getPluginsResolver(null, args, ctx)).rejects.toThrow(
-				dbError,
-			);
-		});
-
-		it("should handle complex filtering with undefined values", async () => {
-			vi.mocked(
-				ctx.drizzleClient.query.pluginsTable.findMany,
-			).mockResolvedValue([mockPlugin]);
-
-			const args = {
+		const result = await mercuriusClient.query(Query_getPlugins, {
+			variables: {
 				input: {
-					pluginId: "test_plugin",
-					isActivated: undefined,
-					isInstalled: undefined,
+					pluginId: uniquePluginId,
 				},
-			};
-			const result = await getPluginsResolver(null, args, ctx);
-
-			expect(result).toEqual([mockPlugin]);
+			},
 		});
 
-		it("should handle empty string filters", async () => {
-			vi.mocked(
-				ctx.drizzleClient.query.pluginsTable.findMany,
-			).mockResolvedValue([]);
+		expect(result.errors).toBeUndefined();
+		expect(result.data.getPlugins).toEqual([]);
+	});
 
-			const args = { input: { pluginId: "" } };
-			const result = await getPluginsResolver(null, args, ctx);
+	test("returns plugins filtered by isActivated set to false", async () => {
+		const deactivatedPlugin = await insertPlugin({ isActivated: false });
+		await insertPlugin({ isActivated: true });
 
-			expect(result).toEqual([]);
+		const result = await mercuriusClient.query(Query_getPlugins, {
+			variables: {
+				input: {
+					isActivated: false,
+				},
+			},
 		});
 
-		it("should handle boolean false filters", async () => {
-			vi.mocked(
-				ctx.drizzleClient.query.pluginsTable.findMany,
-			).mockResolvedValue([mockPlugin2]);
+		expect(result.errors).toBeUndefined();
+		expect(result.data.getPlugins).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: deactivatedPlugin.id }),
+			]),
+		);
+	});
 
-			const args = { input: { isActivated: false } };
-			const result = await getPluginsResolver(null, args, ctx);
+	test("returns plugins filtered by isInstalled set to false", async () => {
+		const notInstalledPlugin = await insertPlugin({ isInstalled: false });
+		await insertPlugin({ isInstalled: true });
 
-			expect(result).toEqual([mockPlugin2]);
+		const result = await mercuriusClient.query(Query_getPlugins, {
+			variables: {
+				input: {
+					isInstalled: false,
+				},
+			},
 		});
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data.getPlugins).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: notInstalledPlugin.id }),
+			]),
+		);
 	});
 });

--- a/test/graphql/types/documentNodes.ts
+++ b/test/graphql/types/documentNodes.ts
@@ -3097,3 +3097,31 @@ export const Query_venue_updatedAt = gql(`
     }
   }
 `);
+
+export const Query_getPluginById = gql(`
+  query Query_getPluginById($input: QueryPluginInput!) {
+    getPluginById(input: $input) {
+      id
+      pluginId
+      isActivated
+      isInstalled
+      backup
+      createdAt
+      updatedAt
+    }
+  }
+`);
+
+export const Query_getPlugins = gql(`
+  query Query_getPlugins($input: QueryPluginsInput) {
+    getPlugins(input: $input) {
+      id
+      pluginId
+      isActivated
+      isInstalled
+      backup
+      createdAt
+      updatedAt
+    }
+  }
+`);


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Test coverage improvement

**Issue Number:**

Fixes #5071

**Snapshots/Videos:**

N/A - test-only changes

**If relevant, did you update the documentation?**

N/A - no documentation changes needed

**Summary**

Replaces existing unit tests (mocked context) with integration tests using `mercuriusClient` for `src/graphql/types/Query/plugins.ts`, following the project's black-box testing approach.

Changes:
- Rewrote `test/graphql/types/Query/plugins.test.ts` with 11 integration test cases
- Added `Query_getPluginById` and `Query_getPlugins` document nodes to `test/graphql/types/documentNodes.ts`

Test coverage includes:
- **Invalid input arguments**: non-UUID id returns `internal_server_error`
- **Non-existent resources**: valid UUID for missing plugin returns `null`
- **Success case**: existing plugin returned with all fields (`id`, `pluginId`, `isActivated`, `isInstalled`, `backup`, `createdAt`, `updatedAt`)
- **Filtering**: `pluginId`, `isActivated` (true/false), `isInstalled` (true/false), multiple criteria combined, empty result set

Tests use `faker.string.ulid()` for unique identifiers ensuring concurrent safety, and clean up test data in `afterEach` hooks.

**Does this PR introduce a breaking change?**

No

## Checklist

### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [x] I have implemented or provided justification for each non-critical suggestion
- [x] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass

**Other information**

- Plugin queries (`getPluginById`, `getPlugins`) are public endpoints with no authentication/authorization checks in the resolvers, so auth-related test cases are not applicable
- All 11 tests pass locally

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced plugin query tests with integration-style approach using live database validation instead of mocked resolvers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->