### PR TITLE
upgraded nodemailer from 6.10.1 to 7.0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "mercurius-upload": "^8.0.0",
     "minio": "^8.0.5",
     "node-cron": "^3.0.3",
-    "nodemailer": "^6.9.14",
+    "nodemailer": "^7.0.11",
     "pino": "^9.14.0",
     "postgres": "^3.4.7",
     "typebox": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@swc/core": "^1.15.3",
     "@types/node": "^22.13.17",
     "@types/node-cron": "^3.0.11",
-    "@types/nodemailer": "^6.4.14",
+    "@types/nodemailer": "^7.0.10",
     "@types/yauzl": "^2.10.3",
     "@vitest/coverage-v8": "^3.1.1",
     "drizzle-kit": "^0.31.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,8 +135,8 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       nodemailer:
-        specifier: ^6.9.14
-        version: 6.10.1
+        specifier: ^7.0.11
+        version: 7.0.11
       pino:
         specifier: ^9.14.0
         version: 9.14.0
@@ -3723,8 +3723,8 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
-  nodemailer@6.10.1:
-    resolution: {integrity: sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==}
+  nodemailer@7.0.11:
+    resolution: {integrity: sha512-gnXhNRE0FNhD7wPSCGhdNh46Hs6nm+uTyg+Kq0cZukNQiYdnCsoQjodNP9BQVG9XrcK/v6/MgpAPBUFyzh9pvw==}
     engines: {node: '>=6.0.0'}
 
   normalize-url@8.1.1:
@@ -8220,7 +8220,7 @@ snapshots:
 
   node-releases@2.0.27: {}
 
-  nodemailer@6.10.1: {}
+  nodemailer@7.0.11: {}
 
   normalize-url@8.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,8 +181,8 @@ importers:
         specifier: ^3.0.11
         version: 3.0.11
       '@types/nodemailer':
-        specifier: ^6.4.14
-        version: 6.4.22
+        specifier: ^7.0.10
+        version: 7.0.11
       '@types/yauzl':
         specifier: ^2.10.3
         version: 2.10.3
@@ -2263,8 +2263,8 @@ packages:
   '@types/node@22.19.9':
     resolution: {integrity: sha512-PD03/U8g1F9T9MI+1OBisaIARhSzeidsUjQaf51fOxrfjeiKN9bLVO06lHuHYjxdnqLWJijJHfqXPSJri2EM2A==}
 
-  '@types/nodemailer@6.4.22':
-    resolution: {integrity: sha512-HV16KRsW7UyZBITE07B62k8PRAKFqRSFXn1T7vslurVjN761tMDBhk5Lbt17ehyTzK6XcyJnAgUpevrvkcVOzw==}
+  '@types/nodemailer@7.0.11':
+    resolution: {integrity: sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -6691,7 +6691,7 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/nodemailer@6.4.22':
+  '@types/nodemailer@7.0.11':
     dependencies:
       '@types/node': 22.19.9
 

--- a/test/services/email/SMTPProvider.integration.test.ts
+++ b/test/services/email/SMTPProvider.integration.test.ts
@@ -1,37 +1,57 @@
 import nodemailer from "nodemailer";
-import { beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { SMTPProvider } from "~/src/services/email/providers/SMTPProvider";
 import type { NonEmptyString } from "~/src/services/email/types";
 
 describe("SMTPProvider Integration (Nodemailer v7)", () => {
-	let testAccount: Awaited<ReturnType<typeof nodemailer.createTestAccount>>;
-	let provider: SMTPProvider;
-	let transporter: ReturnType<typeof nodemailer.createTransport>;
+	let testAccount: Awaited<
+		ReturnType<typeof nodemailer.createTestAccount>
+	> | null = null;
+	let provider: SMTPProvider | null = null;
+	let transporter: ReturnType<typeof nodemailer.createTransport> | null = null;
+	let canRunSMTP = true;
+
 	beforeAll(async () => {
-		testAccount = await nodemailer.createTestAccount();
+		try {
+			testAccount = await nodemailer.createTestAccount();
 
-		provider = new SMTPProvider({
-			host: testAccount.smtp.host as NonEmptyString,
-			port: testAccount.smtp.port,
-			secure: testAccount.smtp.secure,
-			user: testAccount.user,
-			password: testAccount.pass,
-			fromEmail: testAccount.user,
-			fromName: "Talawa Integration",
-		});
-
-		transporter = nodemailer.createTransport({
-			host: testAccount.smtp.host,
-			port: testAccount.smtp.port,
-			secure: testAccount.smtp.secure,
-			auth: {
+			provider = new SMTPProvider({
+				host: testAccount.smtp.host as NonEmptyString,
+				port: testAccount.smtp.port,
+				secure: testAccount.smtp.secure,
 				user: testAccount.user,
-				pass: testAccount.pass,
-			},
-		});
+				password: testAccount.pass,
+				fromEmail: testAccount.user,
+				fromName: "Talawa Integration",
+			});
+
+			transporter = nodemailer.createTransport({
+				host: testAccount.smtp.host,
+				port: testAccount.smtp.port,
+				secure: testAccount.smtp.secure,
+				auth: {
+					user: testAccount.user,
+					pass: testAccount.pass,
+				},
+			});
+		} catch (err) {
+			console.warn(
+				"Skipping SMTP integration tests (Ethereal unavailable)",
+				err,
+			);
+			canRunSMTP = false;
+		}
+	});
+
+	afterAll(() => {
+		if (transporter) {
+			transporter.close();
+		}
 	});
 
 	it("should send real email using Ethereal test account", async () => {
+		if (!canRunSMTP || !provider || !testAccount) return;
+
 		const result = await provider.sendEmail({
 			id: "integration-1",
 			email: testAccount.user,
@@ -40,11 +60,15 @@ describe("SMTPProvider Integration (Nodemailer v7)", () => {
 			textBody: "Hello v7",
 			userId: "u1",
 		});
+
 		expect(result.success).toBe(true);
 		expect(typeof result.messageId).toBe("string");
 		expect(result.messageId?.length).toBeGreaterThan(0);
 	});
-	it("should handle large Data URI attachment (nodemailer v7)", async () => {
+
+	it("should handle large Data URI attachment (nodemailer v7 sanity check)", async () => {
+		if (!canRunSMTP || !transporter || !testAccount) return;
+
 		const largeBuffer = Buffer.alloc(200 * 1024, "a");
 		const base64Data = largeBuffer.toString("base64");
 
@@ -63,7 +87,10 @@ describe("SMTPProvider Integration (Nodemailer v7)", () => {
 
 		expect(info.messageId).toBeDefined();
 	});
+
 	it("should handle repeated SMTP sends without DNS-related failures", async () => {
+		if (!canRunSMTP || !provider || !testAccount) return;
+
 		for (let i = 0; i < 5; i++) {
 			const result = await provider.sendEmail({
 				id: `dns-test-${i}`,
@@ -77,16 +104,32 @@ describe("SMTPProvider Integration (Nodemailer v7)", () => {
 			expect(result.messageId).toBeDefined();
 		}
 	});
-	it("should correctly parse complex recipient formats (nodemailer v7)", async () => {
-		const info = await transporter.sendMail({
-			from: `"Sender Name" <${testAccount.user}>`,
-			to: `"User One" <${testAccount.user}>, ${testAccount.user}`,
-			cc: `"Another User" <${testAccount.user}>`,
+
+	it("should correctly handle complex recipient formats via provider", async () => {
+		if (!canRunSMTP || !provider || !testAccount) return;
+
+		const result = await provider.sendEmail({
+			id: "recipient-test",
+			email: `"User One" <${testAccount.user}>, ${testAccount.user}`,
 			subject: "Address Parsing Test",
-			text: "Testing address parser",
+			htmlBody: "<p>Testing address parser</p>",
+			userId: "u1",
 		});
 
-		expect(info.messageId).toBeDefined();
-		expect(Array.isArray(info.accepted)).toBe(true);
+		expect(result.success).toBe(true);
+		expect(result.messageId).toBeDefined();
+	});
+	it("should reject CRLF injection in recipient field", async () => {
+		if (!canRunSMTP || !provider || !testAccount) return;
+
+		const result = await provider.sendEmail({
+			id: "recipient-injection-test",
+			email: `${testAccount.user}\r\nBCC: evil@example.com`,
+			subject: "Injection Test",
+			htmlBody: "<p>Injection</p>",
+			userId: "u1",
+		});
+
+		expect(result.success).toBe(false);
 	});
 });

--- a/test/services/email/SMTPProvider.integration.test.ts
+++ b/test/services/email/SMTPProvider.integration.test.ts
@@ -49,8 +49,11 @@ describe("SMTPProvider Integration (Nodemailer v7)", () => {
 		}
 	});
 
-	it("should send real email using Ethereal test account", async () => {
-		if (!canRunSMTP || !provider || !testAccount) return;
+	it("should send real email using Ethereal test account", async (ctx) => {
+		if (!canRunSMTP || !provider || !testAccount) {
+			ctx.skip();
+			return;
+		}
 
 		const result = await provider.sendEmail({
 			id: "integration-1",
@@ -66,8 +69,11 @@ describe("SMTPProvider Integration (Nodemailer v7)", () => {
 		expect(result.messageId?.length).toBeGreaterThan(0);
 	});
 
-	it("should handle large Data URI attachment (nodemailer v7 sanity check)", async () => {
-		if (!canRunSMTP || !transporter || !testAccount) return;
+	it("should handle large Data URI attachment (nodemailer v7 sanity check)", async (ctx) => {
+		if (!canRunSMTP || !transporter || !testAccount) {
+			ctx.skip();
+			return;
+		}
 
 		const largeBuffer = Buffer.alloc(200 * 1024, "a");
 		const base64Data = largeBuffer.toString("base64");
@@ -88,8 +94,11 @@ describe("SMTPProvider Integration (Nodemailer v7)", () => {
 		expect(info.messageId).toBeDefined();
 	});
 
-	it("should handle repeated SMTP sends without DNS-related failures", async () => {
-		if (!canRunSMTP || !provider || !testAccount) return;
+	it("should handle repeated SMTP sends without DNS-related failures", async (ctx) => {
+		if (!canRunSMTP || !provider || !testAccount) {
+			ctx.skip();
+			return;
+		}
 
 		for (let i = 0; i < 5; i++) {
 			const result = await provider.sendEmail({
@@ -105,8 +114,11 @@ describe("SMTPProvider Integration (Nodemailer v7)", () => {
 		}
 	});
 
-	it("should correctly handle complex recipient formats via provider", async () => {
-		if (!canRunSMTP || !provider || !testAccount) return;
+	it("should correctly handle complex recipient formats via provider", async (ctx) => {
+		if (!canRunSMTP || !provider || !testAccount) {
+			ctx.skip();
+			return;
+		}
 
 		const result = await provider.sendEmail({
 			id: "recipient-test",
@@ -119,8 +131,11 @@ describe("SMTPProvider Integration (Nodemailer v7)", () => {
 		expect(result.success).toBe(true);
 		expect(result.messageId).toBeDefined();
 	});
-	it("should reject CRLF injection in recipient field", async () => {
-		if (!canRunSMTP || !provider || !testAccount) return;
+	it("should reject CRLF injection in recipient field", async (ctx) => {
+		if (!canRunSMTP || !provider || !testAccount) {
+			ctx.skip();
+			return;
+		}
 
 		const result = await provider.sendEmail({
 			id: "recipient-injection-test",

--- a/test/services/email/SMTPProvider.integration.test.ts
+++ b/test/services/email/SMTPProvider.integration.test.ts
@@ -1,0 +1,92 @@
+import nodemailer from "nodemailer";
+import { beforeAll, describe, expect, it } from "vitest";
+import { SMTPProvider } from "~/src/services/email/providers/SMTPProvider";
+import type { NonEmptyString } from "~/src/services/email/types";
+
+describe("SMTPProvider Integration (Nodemailer v7)", () => {
+	let testAccount: Awaited<ReturnType<typeof nodemailer.createTestAccount>>;
+	let provider: SMTPProvider;
+	let transporter: ReturnType<typeof nodemailer.createTransport>;
+	beforeAll(async () => {
+		testAccount = await nodemailer.createTestAccount();
+
+		provider = new SMTPProvider({
+			host: testAccount.smtp.host as NonEmptyString,
+			port: testAccount.smtp.port,
+			secure: testAccount.smtp.secure,
+			user: testAccount.user,
+			password: testAccount.pass,
+			fromEmail: testAccount.user,
+			fromName: "Talawa Integration",
+		});
+
+		transporter = nodemailer.createTransport({
+			host: testAccount.smtp.host,
+			port: testAccount.smtp.port,
+			secure: testAccount.smtp.secure,
+			auth: {
+				user: testAccount.user,
+				pass: testAccount.pass,
+			},
+		});
+	});
+
+	it("should send real email using Ethereal test account", async () => {
+		const result = await provider.sendEmail({
+			id: "integration-1",
+			email: testAccount.user,
+			subject: "Integration Test",
+			htmlBody: "<b>Hello v7</b>",
+			textBody: "Hello v7",
+			userId: "u1",
+		});
+		expect(result.success).toBe(true);
+		expect(typeof result.messageId).toBe("string");
+		expect(result.messageId?.length).toBeGreaterThan(0);
+	});
+	it("should handle large Data URI attachment (nodemailer v7)", async () => {
+		const largeBuffer = Buffer.alloc(200 * 1024, "a");
+		const base64Data = largeBuffer.toString("base64");
+
+		const info = await transporter.sendMail({
+			from: testAccount.user,
+			to: testAccount.user,
+			subject: "Data URI Test",
+			text: "Testing attachment",
+			attachments: [
+				{
+					filename: "large.txt",
+					path: `data:text/plain;base64,${base64Data}`,
+				},
+			],
+		});
+
+		expect(info.messageId).toBeDefined();
+	});
+	it("should handle repeated SMTP sends without DNS-related failures", async () => {
+		for (let i = 0; i < 5; i++) {
+			const result = await provider.sendEmail({
+				id: `dns-test-${i}`,
+				email: testAccount.user,
+				subject: `DNS Stability Test ${i}`,
+				htmlBody: "<p>Testing DNS resolution stability</p>",
+				userId: "u1",
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.messageId).toBeDefined();
+		}
+	});
+	it("should correctly parse complex recipient formats (nodemailer v7)", async () => {
+		const info = await transporter.sendMail({
+			from: `"Sender Name" <${testAccount.user}>`,
+			to: `"User One" <${testAccount.user}>, ${testAccount.user}`,
+			cc: `"Another User" <${testAccount.user}>`,
+			subject: "Address Parsing Test",
+			text: "Testing address parser",
+		});
+
+		expect(info.messageId).toBeDefined();
+		expect(Array.isArray(info.accepted)).toBe(true);
+	});
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**
depandancy upgrade

**Issue Number:**

<!--Add related issue number here.-->
Fixes #5265 

**If relevant, did you update the documentation?**
No 

**Summary**
upgraded nodemailer from 6.10.1 to 7.0.11
Added integration tests covering:
- Real SMTP handshake (Mailpit)
- Address parsing with display names and multiple recipients
- Data URI attachments (>100KB, validating v7 limit increase)
- Repeated sends to verify DNS resolution stability
- done manual testing sending indivisual mail and in group 
<img width="1918" height="1141" alt="image" src="https://github.com/user-attachments/assets/bef947be-50f4-40d4-b2e6-fccb32b3b403" />

**Does this PR introduce a breaking change?**
No breaking changes observed. All existing tests pass successfully after the upgrade.

## Checklist

### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [x] I have implemented or provided justification for each non-critical suggestion
- [x] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes 
<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the core email service dependency to the latest major release for improved stability and security.
* **Tests**
  * Added integration tests for SMTP email sending covering real sends, large attachments, repeated sends, complex recipient parsing, and CRLF injection protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->