### PR TITLE
fix(#5248): exclude self-authored messages from unread count

### DIFF
--- a/src/graphql/types/Mutation/createChatMessage.ts
+++ b/src/graphql/types/Mutation/createChatMessage.ts
@@ -1,4 +1,6 @@
+import { and, eq } from "drizzle-orm";
 import { z } from "zod";
+import { chatMembershipsTable } from "~/src/drizzle/tables/chatMemberships";
 import { chatMessagesTable } from "~/src/drizzle/tables/chatMessages";
 import { builder } from "~/src/graphql/builder";
 import {
@@ -186,6 +188,18 @@ builder.mutationField("createChatMessage", (t) =>
 					},
 				});
 			}
+
+			await ctx.drizzleClient
+				.update(chatMembershipsTable)
+				.set({
+					lastReadAt: new Date(),
+				})
+				.where(
+					and(
+						eq(chatMembershipsTable.chatId, parsedArgs.input.chatId),
+						eq(chatMembershipsTable.memberId, currentUserId),
+					),
+				);
 
 			ctx.pubsub.publish({
 				payload: createdChatMessage,

--- a/test/graphql/types/Chat/Chat.test.ts
+++ b/test/graphql/types/Chat/Chat.test.ts
@@ -2,18 +2,9 @@
  * Integration tests for Chat computed fields (unreadMessagesCount, hasUnread,
  * firstUnreadMessageId, lastMessage).
  *
- * NOTE: Frontend currently marks self-authored messages as read. On the server-side
- * the computed fields treat a missing membership.lastReadAt as epoch (new Date(0)),
- * which means creators will see their own messages as unread until they explicitly
- * mark the chat as read. This behaviour is intentional for now and is covered by
- * these tests.
- *
- * TODO (future): Implement a humanized server-side behaviour so creators do not
- * see their own freshly-created messages as unread. Possible approaches:
- *  - Ignore messages authored by the current user when counting unread messages;
- *  - Update the author's chatMembership.lastReadAt when they create a message.
- *
- * This should be implemented carefully to preserve read-receipt semantics.
+ * NOTE: Creators do not see their own messages as unread because server-side
+ * logic automatically updates their `chatMembership.lastReadAt` when they create
+ * a new message.
  */
 
 import { faker } from "@faker-js/faker";
@@ -225,9 +216,9 @@ suite("Chat computed fields", () => {
 		});
 		assertToBeNonNullish(aliceChat.data?.chat);
 		const aliceNode = aliceChat.data.chat;
-		expect(aliceNode.unreadMessagesCount).toBe(2);
-		expect(aliceNode.hasUnread).toBe(true);
-		expect(aliceNode.firstUnreadMessageId).toBe(m1Id);
+		expect(aliceNode.unreadMessagesCount).toBe(0);
+		expect(aliceNode.hasUnread).toBe(false);
+		expect(aliceNode.firstUnreadMessageId).toBeNull();
 	});
 
 	suite("unauthenticated access to computed fields is denied", () => {


### PR DESCRIPTION
## Fixes

Fixes #5248

## Description

This PR implements a "humanized" server-side behavior where a user's own messages are not treated as unread by default, resolving the issue of "ghost" notifications.

As suggested in the issue, it implements the **Auto-update** pattern: It automatically sets the author's `chatMembership.lastReadAt` timestamp to the current time inside the `createChatMessage` resolver whenever they successfully send a new message.

This perfectly aligns the server-side logic with the frontend behavior while preserving read-receipt semantics for all participants.

### Changes:
- Utilized the `update` command along with `eq` and `and` from `drizzle-orm` in the `createChatMessage` resolver.
- Updated `chatMembershipsTable.lastReadAt` for the `currentUserId` immediately after an insertion.
- Refactored `Chat.test.ts` to assert that authors indeed have a zero unread count and `firstUnreadMessageId` is set to null after successfully creating a message. Resolved the associated TODO comment.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Performed
Executed the backend integration tests and ensured `Chat.test.ts` fully passes with the new assertions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unread message tracking so that messages you create in a chat are no longer marked as unread, resulting in accurate unread message counts and indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->