### PR TITLE
fix: map invalid_credentials error code to HTTP 401

### DIFF
--- a/src/utilities/errors/errorCodes.ts
+++ b/src/utilities/errors/errorCodes.ts
@@ -69,6 +69,8 @@ export enum ErrorCode {
 	UNEXPECTED = "unexpected",
 	/** Legacy error code for unauthorized action on associated resources (HTTP 403) */
 	UNAUTHORIZED_ACTION_ON_ARGUMENTS_ASSOCIATED_RESOURCES = "unauthorized_action_on_arguments_associated_resources",
+	/** Legacy error code for invalid login credentials (HTTP 401) */
+	INVALID_CREDENTIALS = "invalid_credentials",
 }
 
 /**
@@ -112,6 +114,7 @@ export const ERROR_CODE_TO_HTTP_STATUS: Record<ErrorCode, number> = {
 	[ErrorCode.UNEXPECTED]: 500,
 	[ErrorCode.DATABASE_ERROR]: 500,
 	[ErrorCode.EXTERNAL_SERVICE_ERROR]: 502,
+	[ErrorCode.INVALID_CREDENTIALS]: 401,
 };
 
 /**

--- a/test/utilities/errors/errorCodes.test.ts
+++ b/test/utilities/errors/errorCodes.test.ts
@@ -28,6 +28,7 @@ describe("ErrorCode enum", () => {
 			"forbidden_action",
 			"unexpected",
 			"unauthorized_action_on_arguments_associated_resources",
+			"invalid_credentials",
 		];
 
 		expectedCodes.forEach((code) => {
@@ -51,6 +52,7 @@ describe("ERROR_CODE_TO_HTTP_STATUS mapping", () => {
 		expect(ERROR_CODE_TO_HTTP_STATUS[ErrorCode.UNAUTHENTICATED]).toBe(401);
 		expect(ERROR_CODE_TO_HTTP_STATUS[ErrorCode.TOKEN_EXPIRED]).toBe(401);
 		expect(ERROR_CODE_TO_HTTP_STATUS[ErrorCode.TOKEN_INVALID]).toBe(401);
+		expect(ERROR_CODE_TO_HTTP_STATUS[ErrorCode.INVALID_CREDENTIALS]).toBe(401);
 	});
 
 	it("should map authorization errors to 403", () => {


### PR DESCRIPTION
## Summary

- Adds `INVALID_CREDENTIALS = "invalid_credentials"` to the `ErrorCode` enum in `src/utilities/errors/errorCodes.ts`
- Maps `ErrorCode.INVALID_CREDENTIALS` to HTTP 401 in `ERROR_CODE_TO_HTTP_STATUS`
- Updates tests to include the new error code in the exhaustiveness check and verify the 401 mapping

Fixes #5307

## Test plan

- [x] Added `"invalid_credentials"` to the expected codes array in `errorCodes.test.ts`
- [x] Added assertion that `ERROR_CODE_TO_HTTP_STATUS[ErrorCode.INVALID_CREDENTIALS]` equals 401
- [x] Existing exhaustiveness check (`expectedCodes.length === Object.keys(ErrorCode).length`) validates no enum members are missed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for invalid credential scenarios with proper HTTP 401 (Unauthorized) response status, ensuring consistent authentication failure responses across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->