### PR TITLE
fix: add INVALID_CREDENTIALS to ErrorCode enum with HTTP 401 mapping

### DIFF
--- a/src/graphql/types/Query/signIn.ts
+++ b/src/graphql/types/Query/signIn.ts
@@ -17,6 +17,7 @@ import {
 	storeRefreshToken,
 } from "~/src/utilities/refreshTokenUtils";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
+import { ErrorCode } from "~/src/utilities/errors/errorCodes";
 import type { CurrentClient } from "../../context";
 
 const querySignInArgumentsSchema = z.object({
@@ -147,7 +148,7 @@ builder.queryField("signIn", (t) =>
 
 				throw new TalawaGraphQLError({
 					extensions: {
-						code: "invalid_credentials",
+						code: ErrorCode.INVALID_CREDENTIALS,
 						issues: [
 							{
 								argumentPath: ["input"],

--- a/src/services/auth/authService.ts
+++ b/src/services/auth/authService.ts
@@ -130,7 +130,7 @@ export type SignInResult =
 			access: string;
 			refresh: string;
 	  }
-	| { error: "invalid_credentials" };
+	| { error: ErrorCode.INVALID_CREDENTIALS };
 
 /**
  * Authenticates a user by email and password.
@@ -149,12 +149,12 @@ export async function signIn(
 		where: eq(usersTable.emailAddress, input.email),
 	});
 	if (!user?.passwordHash) {
-		return { error: "invalid_credentials" };
+		return { error: ErrorCode.INVALID_CREDENTIALS };
 	}
 
 	const ok = await verifyPassword(user.passwordHash, input.password);
 	if (!ok) {
-		return { error: "invalid_credentials" };
+		return { error: ErrorCode.INVALID_CREDENTIALS };
 	}
 
 	const access = await signAccessToken({

--- a/src/utilities/TalawaGraphQLError.ts
+++ b/src/utilities/TalawaGraphQLError.ts
@@ -3,7 +3,7 @@ import {
 	type GraphQLErrorOptions,
 	type GraphQLFormattedError,
 } from "graphql";
-import type { ErrorCode } from "./errors/errorCodes";
+import { ErrorCode } from "./errors/errorCodes";
 
 type JSONArgumentPathKey = PropertyKey;
 
@@ -164,7 +164,7 @@ export type InvalidArgumentsExtensions = {
  * });
  */
 export type InvalidCredentialsExtensions = {
-	code: "invalid_credentials";
+	code: ErrorCode.INVALID_CREDENTIALS;
 	issues: {
 		argumentPath: JSONArgumentPathKey[];
 		message: string;

--- a/src/utilities/errors/errorCodes.ts
+++ b/src/utilities/errors/errorCodes.ts
@@ -34,6 +34,9 @@ export enum ErrorCode {
 	/** User role is insufficient for the requested action (HTTP 403) */
 	INSUFFICIENT_PERMISSIONS = "insufficient_permissions",
 
+	/** Provided credentials (email/password) are incorrect (HTTP 401) */
+	INVALID_CREDENTIALS = "invalid_credentials",
+
 	/** Request arguments failed validation (HTTP 400) */
 	INVALID_ARGUMENTS = "invalid_arguments",
 	/** Input data validation failed (HTTP 400) */
@@ -93,6 +96,8 @@ export const ERROR_CODE_TO_HTTP_STATUS: Record<ErrorCode, number> = {
 	[ErrorCode.FORBIDDEN_ACTION_ON_ARGUMENTS_ASSOCIATED_RESOURCES]: 403,
 	[ErrorCode.FORBIDDEN_ACTION]: 403,
 	[ErrorCode.UNAUTHORIZED_ACTION_ON_ARGUMENTS_ASSOCIATED_RESOURCES]: 403,
+
+	[ErrorCode.INVALID_CREDENTIALS]: 401,
 
 	[ErrorCode.INVALID_ARGUMENTS]: 400,
 	[ErrorCode.INVALID_INPUT]: 400,


### PR DESCRIPTION
## Summary
- Adds `INVALID_CREDENTIALS` to the `ErrorCode` enum in `errorCodes.ts` with HTTP 401 status mapping
- Replaces hardcoded `"invalid_credentials"` string literals in `TalawaGraphQLError.ts`, `signIn.ts`, and `authService.ts` with `ErrorCode.INVALID_CREDENTIALS`
- Ensures consistent error code usage via the centralized enum, matching the pattern established by other error codes

## Test plan
- [ ] Verify `ErrorCode.INVALID_CREDENTIALS` resolves to `"invalid_credentials"` (same string value, no behavioral change)
- [ ] Verify `ERROR_CODE_TO_HTTP_STATUS[ErrorCode.INVALID_CREDENTIALS]` returns `401`
- [ ] Verify sign-in with wrong credentials still returns the expected GraphQL error

Closes #5307

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized error code handling in the authentication system by replacing string literals with centralized enums for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->