### PR TITLE
test(setup): add cachingSetup unit coverage (#5295)

### DIFF
--- a/scripts/setup/services/cachingSetup.ts
+++ b/scripts/setup/services/cachingSetup.ts
@@ -1,0 +1,34 @@
+import { promptInput, promptList } from "scripts/setup/promptHelpers";
+import { validatePositiveInteger } from "scripts/setup/validators";
+import {
+	handlePromptError,
+	type SetupAnswers,
+} from "scripts/setup/services/sharedSetup";
+
+export async function cachingSetup(answers: SetupAnswers): Promise<SetupAnswers> {
+	try {
+		const enableWarming = await promptList(
+			"enableWarming",
+			"Enable cache warming at startup?",
+			["true", "false"],
+			"false",
+		);
+
+		if (enableWarming === "true") {
+			answers.CACHE_WARMING_ORG_COUNT = await promptInput(
+				"CACHE_WARMING_ORG_COUNT",
+				"Number of top organizations to warm (by member count):",
+				"10",
+				validatePositiveInteger,
+			);
+		} else {
+			answers.CACHE_WARMING_ORG_COUNT = "0";
+		}
+
+		return answers;
+	} catch (err) {
+		console.error(err);
+		await handlePromptError(err);
+		throw err;
+	}
+}

--- a/scripts/setup/services/sharedSetup.ts
+++ b/scripts/setup/services/sharedSetup.ts
@@ -1,0 +1,8 @@
+import type { SetupAnswers } from "../setup";
+
+export type { SetupAnswers };
+
+export async function handlePromptError(err: unknown): Promise<never> {
+	console.error(err);
+	throw err;
+}

--- a/test/unit/setup/services/cachingSetup.test.ts
+++ b/test/unit/setup/services/cachingSetup.test.ts
@@ -1,0 +1,212 @@
+vi.mock("inquirer");
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock promptHelpers
+const mockPromptList = vi.fn();
+const mockPromptInput = vi.fn();
+vi.mock("scripts/setup/promptHelpers", () => ({
+	promptList: (...args: unknown[]) => mockPromptList(...args),
+	promptInput: (...args: unknown[]) => mockPromptInput(...args),
+}));
+
+// Mock validators
+const mockValidatePositiveInteger = vi.fn();
+vi.mock("scripts/setup/validators", () => ({
+	validatePositiveInteger: (...args: unknown[]) =>
+		mockValidatePositiveInteger(...args),
+}));
+
+// Mock sharedSetup's handlePromptError
+vi.mock("scripts/setup/services/sharedSetup", () => ({
+	handlePromptError: vi.fn(async (err: unknown) => {
+		throw err;
+	}),
+}));
+
+import type { SetupAnswers } from "scripts/setup/services/sharedSetup";
+
+describe("Setup -> cachingSetup", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("should configure caching with warming disabled", async () => {
+		const { cachingSetup } = await import(
+			"scripts/setup/services/cachingSetup"
+		);
+		const answers: SetupAnswers = {};
+
+		// Mock user input: disable cache warming
+		mockPromptList.mockResolvedValue("false");
+
+		const result = await cachingSetup(answers);
+
+		// Verify promptList was called for enableWarming
+		expect(mockPromptList).toHaveBeenCalledWith(
+			"enableWarming",
+			"Enable cache warming at startup?",
+			["true", "false"],
+			"false",
+		);
+
+		// Verify CACHE_WARMING_ORG_COUNT is set to "0" when warming is disabled
+		expect(result.CACHE_WARMING_ORG_COUNT).toBe("0");
+
+		// Verify promptInput was NOT called (since warming is disabled)
+		expect(mockPromptInput).not.toHaveBeenCalled();
+	});
+
+	it("should configure caching with warming enabled and prompt for count", async () => {
+		const { cachingSetup } = await import(
+			"scripts/setup/services/cachingSetup"
+		);
+		const answers: SetupAnswers = {};
+
+		// Mock user input: enable cache warming
+		mockPromptList.mockResolvedValue("true");
+		mockPromptInput.mockResolvedValue("20");
+
+		const result = await cachingSetup(answers);
+
+		// Verify enableWarming prompt
+		expect(mockPromptList).toHaveBeenCalledWith(
+			"enableWarming",
+			"Enable cache warming at startup?",
+			["true", "false"],
+			"false",
+		);
+
+		// Verify CACHE_WARMING_ORG_COUNT prompt with validator
+		expect(mockPromptInput).toHaveBeenCalledWith(
+			"CACHE_WARMING_ORG_COUNT",
+			"Number of top organizations to warm (by member count):",
+			"10",
+			expect.any(Function),
+		);
+
+		// Verify result
+		expect(result.CACHE_WARMING_ORG_COUNT).toBe("20");
+	});
+
+	it("should pass validatePositiveInteger validator to promptInput", async () => {
+		const { cachingSetup } = await import(
+			"scripts/setup/services/cachingSetup"
+		);
+		const answers: SetupAnswers = {};
+
+		mockPromptList.mockResolvedValue("true");
+		mockPromptInput.mockResolvedValue("15");
+
+		await cachingSetup(answers);
+
+		// Verify the validator was passed as the last argument to promptInput
+		expect(mockPromptInput).toHaveBeenCalled();
+		const call = mockPromptInput.mock.calls[0]!;
+		expect(typeof call[3]).toBe("function");
+		const validator = call[3] as (value: string) => unknown;
+		validator("15");
+		expect(mockValidatePositiveInteger).toHaveBeenCalledWith("15");
+	});
+
+	it("should not prompt for count when warming is disabled (conditional logic)", async () => {
+		const { cachingSetup } = await import(
+			"scripts/setup/services/cachingSetup"
+		);
+		const answers: SetupAnswers = {};
+
+		mockPromptList.mockResolvedValue("false");
+
+		await cachingSetup(answers);
+
+		// Verify promptInput was never called
+		expect(mockPromptInput).not.toHaveBeenCalled();
+
+		// Verify CACHE_WARMING_ORG_COUNT is set to "0" directly
+		expect(answers.CACHE_WARMING_ORG_COUNT).toBe("0");
+	});
+
+	it("should accept different valid counts when warming is enabled", async () => {
+		const { cachingSetup } = await import(
+			"scripts/setup/services/cachingSetup"
+		);
+
+		mockPromptList.mockResolvedValue("true");
+		mockPromptInput.mockResolvedValue("50");
+
+		const answers: SetupAnswers = {};
+		const result = await cachingSetup(answers);
+
+		expect(result.CACHE_WARMING_ORG_COUNT).toBe("50");
+	});
+
+	it("should handle prompt errors gracefully", async () => {
+		const { cachingSetup } = await import(
+			"scripts/setup/services/cachingSetup"
+		);
+		const answers: SetupAnswers = {};
+
+		mockPromptList.mockRejectedValue(new Error("Prompt failed"));
+		const consoleErrorSpy = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+
+		await expect(cachingSetup(answers)).rejects.toThrow();
+
+		expect(consoleErrorSpy).toHaveBeenCalled();
+		consoleErrorSpy.mockRestore();
+	});
+
+	it("should handle errors when retrieving count input", async () => {
+		const { cachingSetup } = await import(
+			"scripts/setup/services/cachingSetup"
+		);
+		const answers: SetupAnswers = {};
+
+		mockPromptList.mockResolvedValue("true");
+		mockPromptInput.mockRejectedValue(new Error("Input failed"));
+		const consoleErrorSpy = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+
+		await expect(cachingSetup(answers)).rejects.toThrow();
+
+		expect(consoleErrorSpy).toHaveBeenCalled();
+		consoleErrorSpy.mockRestore();
+	});
+
+	it("should return updated answers object", async () => {
+		const { cachingSetup } = await import(
+			"scripts/setup/services/cachingSetup"
+		);
+		const answers: SetupAnswers = { CI: "true" };
+
+		mockPromptList.mockResolvedValue("false");
+
+		const result = await cachingSetup(answers);
+
+		// Verify it returns the same answers object with new properties
+		expect(result).toHaveProperty("CI", "true");
+		expect(result).toHaveProperty("CACHE_WARMING_ORG_COUNT", "0");
+	});
+
+	it("should use default value '10' when prompting for count", async () => {
+		const { cachingSetup } = await import(
+			"scripts/setup/services/cachingSetup"
+		);
+		const answers: SetupAnswers = {};
+
+		mockPromptList.mockResolvedValue("true");
+		mockPromptInput.mockResolvedValue("10");
+
+		await cachingSetup(answers);
+
+		// Verify the default value is passed to promptInput
+		const call = mockPromptInput.mock.calls[0]!;
+		expect(call[2]).toBe("10");
+	});
+});


### PR DESCRIPTION
Add comprehensive unit tests for caching setup flow, including conditional prompting, validator wiring, and error handling via shared setup utilities.

<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

<!--Add related issue number here.-->
Fixes #

**Snapshots/Videos:**

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

## Checklist

### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [x] I have implemented or provided justification for each non-critical suggestion
- [x] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added setup configuration option to enable or disable cache warming at application startup
  * Added configurable parameter to specify the number of organizations to pre-load during cache warming (default: 10)

* **Tests**
  * Added comprehensive unit tests for cache warming setup functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->