### PR TITLE
fix(setup): remove duplicate logging and unreachable throw in cachingSetup error path

### DIFF
--- a/scripts/setup/services/cachingSetup.ts
+++ b/scripts/setup/services/cachingSetup.ts
@@ -27,8 +27,6 @@ export async function cachingSetup(answers: SetupAnswers): Promise<SetupAnswers>
 
 		return answers;
 	} catch (err) {
-		console.error(err);
-		await handlePromptError(err);
-		throw err;
+		return handlePromptError(err);
 	}
 }

--- a/scripts/setup/services/cachingSetup.ts
+++ b/scripts/setup/services/cachingSetup.ts
@@ -1,0 +1,34 @@
+import { promptInput, promptList } from "scripts/setup/promptHelpers";
+import { validatePositiveInteger } from "scripts/setup/validators";
+import {
+	handlePromptError,
+	type SetupAnswers,
+} from "scripts/setup/services/sharedSetup";
+
+export async function cachingSetup(answers: SetupAnswers): Promise<SetupAnswers> {
+	try {
+		const enableWarming = await promptList(
+			"enableWarming",
+			"Enable cache warming at startup?",
+			["true", "false"],
+			"false",
+		);
+
+		if (enableWarming === "true") {
+			answers.CACHE_WARMING_ORG_COUNT = await promptInput(
+				"CACHE_WARMING_ORG_COUNT",
+				"Number of top organizations to warm (by member count):",
+				"10",
+				validatePositiveInteger,
+			);
+		} else {
+			answers.CACHE_WARMING_ORG_COUNT = "0";
+		}
+
+		return answers;
+	} catch (err) {
+		console.error(err);
+		await handlePromptError(err);
+		throw err;
+	}
+}

--- a/scripts/setup/services/sharedSetup.ts
+++ b/scripts/setup/services/sharedSetup.ts
@@ -2,7 +2,7 @@ import type { SetupAnswers } from "../setup";
 
 export type { SetupAnswers };
 
-export async function logAndRethrowPromptError(err: unknown): Promise<never> {
+export async function handlePromptError(err: unknown): Promise<never> {
 	console.error(err);
 	throw err;
 }

--- a/scripts/setup/services/sharedSetup.ts
+++ b/scripts/setup/services/sharedSetup.ts
@@ -1,0 +1,8 @@
+import type { SetupAnswers } from "../setup";
+
+export type { SetupAnswers };
+
+export async function handlePromptError(err: unknown): Promise<never> {
+	console.error(err);
+	throw err;
+}

--- a/scripts/setup/services/sharedSetup.ts
+++ b/scripts/setup/services/sharedSetup.ts
@@ -2,7 +2,7 @@ import type { SetupAnswers } from "../setup";
 
 export type { SetupAnswers };
 
-export async function handlePromptError(err: unknown): Promise<never> {
+export async function logAndRethrowPromptError(err: unknown): Promise<never> {
 	console.error(err);
 	throw err;
 }

--- a/test/unit/setup/services/cachingSetup.test.ts
+++ b/test/unit/setup/services/cachingSetup.test.ts
@@ -18,10 +18,11 @@ vi.mock("scripts/setup/validators", () => ({
 }));
 
 // Mock sharedSetup's handlePromptError
+const mockHandlePromptError = vi.fn(async (err: unknown) => {
+	throw err;
+});
 vi.mock("scripts/setup/services/sharedSetup", () => ({
-	handlePromptError: vi.fn(async (err: unknown) => {
-		throw err;
-	}),
+	handlePromptError: (err: unknown) => mockHandlePromptError(err),
 }));
 
 import type { SetupAnswers } from "scripts/setup/services/sharedSetup";
@@ -150,15 +151,12 @@ describe("Setup -> cachingSetup", () => {
 		);
 		const answers: SetupAnswers = {};
 
-		mockPromptList.mockRejectedValue(new Error("Prompt failed"));
-		const consoleErrorSpy = vi
-			.spyOn(console, "error")
-			.mockImplementation(() => {});
+		const err = new Error("Prompt failed");
+		mockPromptList.mockRejectedValue(err);
 
 		await expect(cachingSetup(answers)).rejects.toThrow();
 
-		expect(consoleErrorSpy).toHaveBeenCalled();
-		consoleErrorSpy.mockRestore();
+		expect(mockHandlePromptError).toHaveBeenCalledWith(err);
 	});
 
 	it("should handle errors when retrieving count input", async () => {
@@ -168,15 +166,12 @@ describe("Setup -> cachingSetup", () => {
 		const answers: SetupAnswers = {};
 
 		mockPromptList.mockResolvedValue("true");
-		mockPromptInput.mockRejectedValue(new Error("Input failed"));
-		const consoleErrorSpy = vi
-			.spyOn(console, "error")
-			.mockImplementation(() => {});
+		const err = new Error("Input failed");
+		mockPromptInput.mockRejectedValue(err);
 
 		await expect(cachingSetup(answers)).rejects.toThrow();
 
-		expect(consoleErrorSpy).toHaveBeenCalled();
-		consoleErrorSpy.mockRestore();
+		expect(mockHandlePromptError).toHaveBeenCalledWith(err);
 	});
 
 	it("should return updated answers object", async () => {

--- a/test/unit/setup/services/cachingSetup.test.ts
+++ b/test/unit/setup/services/cachingSetup.test.ts
@@ -1,0 +1,212 @@
+vi.mock("inquirer");
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock promptHelpers
+const mockPromptList = vi.fn();
+const mockPromptInput = vi.fn();
+vi.mock("scripts/setup/promptHelpers", () => ({
+	promptList: (...args: unknown[]) => mockPromptList(...args),
+	promptInput: (...args: unknown[]) => mockPromptInput(...args),
+}));
+
+// Mock validators
+const mockValidatePositiveInteger = vi.fn();
+vi.mock("scripts/setup/validators", () => ({
+	validatePositiveInteger: (...args: unknown[]) =>
+		mockValidatePositiveInteger(...args),
+}));
+
+// Mock sharedSetup's handlePromptError
+vi.mock("scripts/setup/services/sharedSetup", () => ({
+	handlePromptError: vi.fn(async (err: unknown) => {
+		throw err;
+	}),
+}));
+
+import type { SetupAnswers } from "scripts/setup/services/sharedSetup";
+
+describe("Setup -> cachingSetup", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("should configure caching with warming disabled", async () => {
+		const { cachingSetup } = await import(
+			"scripts/setup/services/cachingSetup"
+		);
+		const answers: SetupAnswers = {};
+
+		// Mock user input: disable cache warming
+		mockPromptList.mockResolvedValue("false");
+
+		const result = await cachingSetup(answers);
+
+		// Verify promptList was called for enableWarming
+		expect(mockPromptList).toHaveBeenCalledWith(
+			"enableWarming",
+			"Enable cache warming at startup?",
+			["true", "false"],
+			"false",
+		);
+
+		// Verify CACHE_WARMING_ORG_COUNT is set to "0" when warming is disabled
+		expect(result.CACHE_WARMING_ORG_COUNT).toBe("0");
+
+		// Verify promptInput was NOT called (since warming is disabled)
+		expect(mockPromptInput).not.toHaveBeenCalled();
+	});
+
+	it("should configure caching with warming enabled and prompt for count", async () => {
+		const { cachingSetup } = await import(
+			"scripts/setup/services/cachingSetup"
+		);
+		const answers: SetupAnswers = {};
+
+		// Mock user input: enable cache warming
+		mockPromptList.mockResolvedValue("true");
+		mockPromptInput.mockResolvedValue("20");
+
+		const result = await cachingSetup(answers);
+
+		// Verify enableWarming prompt
+		expect(mockPromptList).toHaveBeenCalledWith(
+			"enableWarming",
+			"Enable cache warming at startup?",
+			["true", "false"],
+			"false",
+		);
+
+		// Verify CACHE_WARMING_ORG_COUNT prompt with validator
+		expect(mockPromptInput).toHaveBeenCalledWith(
+			"CACHE_WARMING_ORG_COUNT",
+			"Number of top organizations to warm (by member count):",
+			"10",
+			expect.any(Function),
+		);
+
+		// Verify result
+		expect(result.CACHE_WARMING_ORG_COUNT).toBe("20");
+	});
+
+	it("should pass validatePositiveInteger validator to promptInput", async () => {
+		const { cachingSetup } = await import(
+			"scripts/setup/services/cachingSetup"
+		);
+		const answers: SetupAnswers = {};
+
+		mockPromptList.mockResolvedValue("true");
+		mockPromptInput.mockResolvedValue("15");
+
+		await cachingSetup(answers);
+
+		// Verify the validator was passed as the last argument to promptInput
+		expect(mockPromptInput).toHaveBeenCalled();
+		const call = mockPromptInput.mock.calls[0]!;
+		expect(typeof call[3]).toBe("function");
+		const validator = call[3] as (value: string) => unknown;
+		validator("15");
+		expect(mockValidatePositiveInteger).toHaveBeenCalledWith("15");
+	});
+
+	it("should not prompt for count when warming is disabled (conditional logic)", async () => {
+		const { cachingSetup } = await import(
+			"scripts/setup/services/cachingSetup"
+		);
+		const answers: SetupAnswers = {};
+
+		mockPromptList.mockResolvedValue("false");
+
+		await cachingSetup(answers);
+
+		// Verify promptInput was never called
+		expect(mockPromptInput).not.toHaveBeenCalled();
+
+		// Verify CACHE_WARMING_ORG_COUNT is set to "0" directly
+		expect(answers.CACHE_WARMING_ORG_COUNT).toBe("0");
+	});
+
+	it("should accept different valid counts when warming is enabled", async () => {
+		const { cachingSetup } = await import(
+			"scripts/setup/services/cachingSetup"
+		);
+
+		mockPromptList.mockResolvedValue("true");
+		mockPromptInput.mockResolvedValue("50");
+
+		const answers: SetupAnswers = {};
+		const result = await cachingSetup(answers);
+
+		expect(result.CACHE_WARMING_ORG_COUNT).toBe("50");
+	});
+
+	it("should handle prompt errors gracefully", async () => {
+		const { cachingSetup } = await import(
+			"scripts/setup/services/cachingSetup"
+		);
+		const answers: SetupAnswers = {};
+
+		mockPromptList.mockRejectedValue(new Error("Prompt failed"));
+		const consoleErrorSpy = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+
+		await expect(cachingSetup(answers)).rejects.toThrow();
+
+		expect(consoleErrorSpy).toHaveBeenCalled();
+		consoleErrorSpy.mockRestore();
+	});
+
+	it("should handle errors when retrieving count input", async () => {
+		const { cachingSetup } = await import(
+			"scripts/setup/services/cachingSetup"
+		);
+		const answers: SetupAnswers = {};
+
+		mockPromptList.mockResolvedValue("true");
+		mockPromptInput.mockRejectedValue(new Error("Input failed"));
+		const consoleErrorSpy = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+
+		await expect(cachingSetup(answers)).rejects.toThrow();
+
+		expect(consoleErrorSpy).toHaveBeenCalled();
+		consoleErrorSpy.mockRestore();
+	});
+
+	it("should return updated answers object", async () => {
+		const { cachingSetup } = await import(
+			"scripts/setup/services/cachingSetup"
+		);
+		const answers: SetupAnswers = { CI: "true" };
+
+		mockPromptList.mockResolvedValue("false");
+
+		const result = await cachingSetup(answers);
+
+		// Verify it returns the same answers object with new properties
+		expect(result).toHaveProperty("CI", "true");
+		expect(result).toHaveProperty("CACHE_WARMING_ORG_COUNT", "0");
+	});
+
+	it("should use default value '10' when prompting for count", async () => {
+		const { cachingSetup } = await import(
+			"scripts/setup/services/cachingSetup"
+		);
+		const answers: SetupAnswers = {};
+
+		mockPromptList.mockResolvedValue("true");
+		mockPromptInput.mockResolvedValue("10");
+
+		await cachingSetup(answers);
+
+		// Verify the default value is passed to promptInput
+		const call = mockPromptInput.mock.calls[0]!;
+		expect(call[2]).toBe("10");
+	});
+});


### PR DESCRIPTION
**Summary**
This PR simplifies error handling in the caching setup flow by removing duplicate logging and unreachable code in the catch block.

**Changes**

1. Updated talawa-api\scripts\setup\services\cachingSetup.ts to use a single error path:

- Removed redundant [console.error(err)]

- Removed unreachable [throw err]

- Kept [handlePromptError(err)]

- Returned from catch to satisfy TypeScript control flow

2. Updated talawa-api\test\unit\setup\services\cachingSetup.test.ts

- Fixed mock typing for [handlePromptError]

- Changed assertions to verify [handlePromptError]

**Why**

- Avoids double-logging

- Removes unreachable code

- Aligns implementation with [handlePromptError]

- Resolves TypeScript diagnostics:
spread argument tuple/rest mismatch
missing return in async function path

**Testing**
I ran:
`pnpm vitest test/unit/setup/services/cachingSetup.test.ts`
Result:


- 1 file passed

- 9 tests passed

**Related Issue**
Closes #5295



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup now includes cache-warming configuration with a toggle and a configurable organization-count (default: 10).

* **Chores**
  * Added shared setup utility to centralize prompt error logging and rethrowing.

* **Tests**
  * New unit tests cover cache-warming flows, prompt validation, error handling, and returned configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->