### PR TITLE
Oauth: Remove Oauth account linking from SignInWithOAuth

### DIFF
--- a/src/graphql/types/Mutation/signInWithOAuth.ts
+++ b/src/graphql/types/Mutation/signInWithOAuth.ts
@@ -1,6 +1,4 @@
-import { randomBytes } from "node:crypto";
 import { and, eq } from "drizzle-orm";
-import { uuidv7 } from "uuidv7";
 import { oauthAccountsTable } from "~/src/drizzle/tables/oauthAccount";
 import { usersTable } from "~/src/drizzle/tables/users";
 import { builder } from "~/src/graphql/builder";
@@ -202,126 +200,13 @@ builder.mutationField("signInWithOAuth", (t) =>
 						.set({ lastUsedAt: new Date() })
 						.where(eq(oauthAccountsTable.id, existingOAuthAccount.id));
 				} else {
-					// No existing OAuth account - check if user exists by email
-					let userByEmail: typeof usersTable.$inferSelect | undefined;
-					if (userProfile.email) {
-						[userByEmail] = await tx
-							.select()
-							.from(usersTable)
-							.where(eq(usersTable.emailAddress, userProfile.email));
-					}
-
-					if (userByEmail) {
-						// Path 2: User exists with matching email - link OAuth account
-						// SECURITY: Only link by email if the OAuth provider has verified the email
-						// to prevent account takeover attacks
-						if (!userProfile.emailVerified) {
-							throw new TalawaGraphQLError({
-								extensions: {
-									code: "forbidden_action",
-								},
-								message:
-									"A user with this email already exists. Please verify your email with the OAuth provider or sign in directly to link your account.",
-							});
-						}
-
-						user = userByEmail;
-
-						await tx.insert(oauthAccountsTable).values({
-							id: uuidv7(),
-							userId: user.id,
-							provider: args.input.provider.toLowerCase(),
-							providerId: userProfile.providerId,
-							email: userProfile.email,
-							profile: {
-								name: userProfile.name,
-								picture: userProfile.picture,
-								emailVerified: userProfile.emailVerified,
-							},
-							linkedAt: new Date(),
-							lastUsedAt: new Date(),
-						});
-
-						// If OAuth email is verified, mark user email as verified
-						if (userProfile.emailVerified && !user.isEmailAddressVerified) {
-							await tx
-								.update(usersTable)
-								.set({ isEmailAddressVerified: true })
-								.where(eq(usersTable.id, user.id));
-
-							// Update local user object to reflect change
-							user.isEmailAddressVerified = true;
-						}
-					} else {
-						// Path 3: New user - create user and link OAuth account
-						if (!userProfile.email) {
-							// We need an email to create a user
-							throw new TalawaGraphQLError({
-								extensions: {
-									code: "forbidden_action",
-								},
-								message:
-									"Your OAuth provider did not share your email address. Please grant email access or use a different sign-in method.",
-							});
-						}
-
-						if (!userProfile.name) {
-							// We need a name to create a user
-							throw new TalawaGraphQLError({
-								extensions: {
-									code: "forbidden_action",
-								},
-								message:
-									"Your OAuth provider did not share your name. Please update your profile on the provider or use a different sign-in method.",
-							});
-						}
-
-						const userId = uuidv7();
-
-						// Create the new user
-						const [createdUser] = await tx
-							.insert(usersTable)
-							.values({
-								id: userId,
-								creatorId: userId,
-								emailAddress: userProfile.email,
-								name: userProfile.name,
-								isEmailAddressVerified: userProfile.emailVerified ?? false,
-								role: "regular",
-								// Generate a cryptographically random placeholder that cannot be used for login
-								passwordHash: `$oauth$${randomBytes(32).toString("hex")}`,
-							})
-							.returning();
-
-						if (!createdUser) {
-							ctx.log.error(
-								"Postgres insert operation unexpectedly returned an empty array",
-							);
-							throw new TalawaGraphQLError({
-								extensions: {
-									code: "unexpected",
-								},
-							});
-						}
-
-						user = createdUser;
-
-						// Link the OAuth account
-						await tx.insert(oauthAccountsTable).values({
-							id: uuidv7(),
-							userId: user.id,
-							provider: args.input.provider.toLowerCase(),
-							providerId: userProfile.providerId,
-							email: userProfile.email,
-							profile: {
-								name: userProfile.name,
-								picture: userProfile.picture,
-								emailVerified: userProfile.emailVerified,
-							},
-							linkedAt: new Date(),
-							lastUsedAt: new Date(),
-						});
-					}
+					// Throw error if OAuth account is not linked
+					throw new TalawaGraphQLError({
+						extensions: {
+							code: "forbidden_action",
+						},
+						message: "OAuth account not found.",
+					});
 				}
 
 				// Reset failed login attempts on successful OAuth authentication

--- a/src/graphql/types/Mutation/signInWithOAuth.ts
+++ b/src/graphql/types/Mutation/signInWithOAuth.ts
@@ -21,15 +21,16 @@ import type { CurrentClient } from "../../context";
 import { AuthenticationPayload } from "../AuthenticationPayload";
 
 /**
- * Sign in or sign up using an OAuth provider.
- * Exchanges an authorization code for tokens, creates/links user, and returns AuthenticationPayload.
+ * Sign in using an OAuth provider.
+ * Requires a pre-linked OAuth account row in oauthAccountsTable and returns AuthenticationPayload.
+ * New OAuth links are created via linkOAuthAccount for authenticated users.
  */
 builder.mutationField("signInWithOAuth", (t) =>
 	t.field({
 		type: AuthenticationPayload,
 		complexity: envConfig.API_GRAPHQL_OBJECT_FIELD_COST,
 		description:
-			"Sign in or sign up using an OAuth provider. Exchanges an authorization code for tokens, creates/links user, and returns AuthenticationPayload.",
+			"Sign in with a pre-linked OAuth account by exchanging an authorization code for tokens. This is sign-in-only and requires an existing oauthAccountsTable record; onboarding/linking is handled via linkOAuthAccount for authenticated users.",
 		args: {
 			input: t.arg({
 				type: MutationOAuthLoginInput,
@@ -154,7 +155,7 @@ builder.mutationField("signInWithOAuth", (t) =>
 				});
 			}
 
-			// Use transaction for atomicity: find/create user and link OAuth account
+			// Use transaction for atomicity: find linked OAuth account and user
 			return await ctx.drizzleClient.transaction(async (tx) => {
 				// Try to find existing OAuth account
 				const [existingOAuthAccount] = await tx

--- a/test/graphql/types/Mutation/signInWithOAuth.test.ts
+++ b/test/graphql/types/Mutation/signInWithOAuth.test.ts
@@ -289,103 +289,112 @@ suite("Mutation signInWithOAuth", () => {
 
 		test("should set HTTP-Only cookies when cookie helper is available", async () => {
 			const testEmail = `cookie-test-${randomUUID()}@example.com`;
+			let testUserId: string | undefined;
+			let oauthAccountId: string | undefined;
 
-			// Setup: Create user and OAuth account first
-			const [testUser] = await server.drizzleClient
-				.insert(usersTable)
-				.values({
-					emailAddress: testEmail,
-					name: "Cookie Test User",
-					passwordHash: "test-hash",
-					role: "regular",
-					isEmailAddressVerified: true,
-				})
-				.returning();
+			try {
+				// Setup: Create user and OAuth account first
+				const [testUser] = await server.drizzleClient
+					.insert(usersTable)
+					.values({
+						emailAddress: testEmail,
+						name: "Cookie Test User",
+						passwordHash: "test-hash",
+						role: "regular",
+						isEmailAddressVerified: true,
+					})
+					.returning();
 
-			if (!testUser) {
-				throw new Error("Failed to create test user");
-			}
+				if (!testUser) {
+					throw new Error("Failed to create test user");
+				}
+				testUserId = testUser.id;
 
-			const [oauthAccount] = await server.drizzleClient
-				.insert(oauthAccountsTable)
-				.values({
-					userId: testUser.id,
-					provider: "google",
+				const [oauthAccount] = await server.drizzleClient
+					.insert(oauthAccountsTable)
+					.values({
+						userId: testUser.id,
+						provider: "google",
+						providerId: "google-cookie-test",
+						email: testEmail,
+						profile: {
+							name: "Cookie Test User",
+							picture: "https://example.com/cookie.jpg",
+						},
+					})
+					.returning();
+
+				if (!oauthAccount) {
+					throw new Error("Failed to create OAuth account");
+				}
+				oauthAccountId = oauthAccount.id;
+
+				// Mock OAuth provider responses
+				mockProvider.exchangeCodeForTokens.mockResolvedValueOnce({
+					access_token: "mock-access-token",
+					token_type: "Bearer",
+				});
+
+				mockProvider.getUserProfile.mockResolvedValueOnce({
 					providerId: "google-cookie-test",
 					email: testEmail,
-					profile: {
-						name: "Cookie Test User",
-						picture: "https://example.com/cookie.jpg",
-					},
-				})
-				.returning();
+					name: "Cookie Test User",
+					picture: "https://example.com/cookie.jpg",
+					emailVerified: true,
+				} as OAuthUserProfile);
 
-			if (!oauthAccount) {
-				throw new Error("Failed to create OAuth account");
-			}
-
-			// Mock OAuth provider responses
-			mockProvider.exchangeCodeForTokens.mockResolvedValueOnce({
-				access_token: "mock-access-token",
-				token_type: "Bearer",
-			});
-
-			mockProvider.getUserProfile.mockResolvedValueOnce({
-				providerId: "google-cookie-test",
-				email: testEmail,
-				name: "Cookie Test User",
-				picture: "https://example.com/cookie.jpg",
-				emailVerified: true,
-			} as OAuthUserProfile);
-
-			// Use server.inject to make direct HTTP request
-			const response = await server.inject({
-				method: "POST",
-				url: "/graphql",
-				payload: {
-					query: print(Mutation_signInWithOAuth),
-					variables: {
-						input: {
-							provider: "GOOGLE",
-							authorizationCode: "valid-auth-code",
-							redirectUri: "http://localhost:3000/callback",
+				// Use server.inject to make direct HTTP request
+				const response = await server.inject({
+					method: "POST",
+					url: "/graphql",
+					payload: {
+						query: print(Mutation_signInWithOAuth),
+						variables: {
+							input: {
+								provider: "GOOGLE",
+								authorizationCode: "valid-auth-code",
+								redirectUri: "http://localhost:3000/callback",
+							},
 						},
 					},
-				},
-			});
+				});
 
-			// Assert: HTTP response is successful
-			expect(response.statusCode).toBe(200);
+				// Assert: HTTP response is successful
+				expect(response.statusCode).toBe(200);
 
-			// Assert: Cookies are set correctly
-			const cookies = response.cookies;
-			expect(cookies).toBeDefined();
-			expect(cookies.length).toBeGreaterThanOrEqual(2);
+				// Assert: Cookies are set correctly
+				const cookies = response.cookies;
+				expect(cookies).toBeDefined();
+				expect(cookies.length).toBeGreaterThanOrEqual(2);
 
-			const accessTokenCookie = cookies.find(
-				(c) => c.name === COOKIE_NAMES.ACCESS_TOKEN,
-			);
-			const refreshTokenCookie = cookies.find(
-				(c) => c.name === COOKIE_NAMES.REFRESH_TOKEN,
-			);
+				const accessTokenCookie = cookies.find(
+					(c) => c.name === COOKIE_NAMES.ACCESS_TOKEN,
+				);
+				const refreshTokenCookie = cookies.find(
+					(c) => c.name === COOKIE_NAMES.REFRESH_TOKEN,
+				);
 
-			expect(accessTokenCookie).toBeDefined();
-			expect(accessTokenCookie?.httpOnly).toBe(true);
-			expect(accessTokenCookie?.path).toBe("/");
-			expect(accessTokenCookie?.sameSite).toBe("Lax");
+				expect(accessTokenCookie).toBeDefined();
+				expect(accessTokenCookie?.httpOnly).toBe(true);
+				expect(accessTokenCookie?.path).toBe("/");
+				expect(accessTokenCookie?.sameSite).toBe("Lax");
 
-			expect(refreshTokenCookie).toBeDefined();
-			expect(refreshTokenCookie?.httpOnly).toBe(true);
-			expect(refreshTokenCookie?.path).toBe("/");
-			expect(refreshTokenCookie?.sameSite).toBe("Lax");
-
-			// Cleanup
-			await server.drizzleClient
-				.delete(oauthAccountsTable)
-				.where(eq(oauthAccountsTable.id, oauthAccount.id));
-			await server.drizzleClient
-				.delete(usersTable)
-				.where(eq(usersTable.id, testUser.id));
+				expect(refreshTokenCookie).toBeDefined();
+				expect(refreshTokenCookie?.httpOnly).toBe(true);
+				expect(refreshTokenCookie?.path).toBe("/");
+				expect(refreshTokenCookie?.sameSite).toBe("Lax");
+			} finally {
+				if (oauthAccountId) {
+					await server.drizzleClient
+						.delete(oauthAccountsTable)
+						.where(eq(oauthAccountsTable.id, oauthAccountId));
+				}
+				if (testUserId) {
+					await server.drizzleClient
+						.delete(usersTable)
+						.where(eq(usersTable.id, testUserId));
+				}
+			}
 		});
 	});
 

--- a/test/graphql/types/Mutation/signInWithOAuth.test.ts
+++ b/test/graphql/types/Mutation/signInWithOAuth.test.ts
@@ -88,92 +88,102 @@ suite("Mutation signInWithOAuth", () => {
 		test("should sign in existing user with linked OAuth account", async () => {
 			// Setup: Create a user with linked OAuth account
 			const testEmail = `test-${randomUUID()}@example.com`;
-			const [existingUser] = await server.drizzleClient
-				.insert(usersTable)
-				.values({
-					emailAddress: testEmail,
-					name: "Existing User",
-					passwordHash: "test-hash",
-					role: "regular",
-					isEmailAddressVerified: true,
-				})
-				.returning();
-
-			if (!existingUser) {
-				throw new Error("Failed to create test user");
-			}
-
+			const uniqueProviderId = `google-${randomUUID()}`;
 			const seedLastUsedAt = new Date("2000-01-01T00:00:00.000Z");
-			const [existingOAuthAccount] = await server.drizzleClient
-				.insert(oauthAccountsTable)
-				.values({
-					userId: existingUser.id,
-					provider: "google",
-					providerId: "google-123",
-					email: testEmail,
-					profile: {
+			let existingUserId: string | undefined;
+			let existingOAuthAccountId: string | undefined;
+
+			try {
+				const [existingUser] = await server.drizzleClient
+					.insert(usersTable)
+					.values({
+						emailAddress: testEmail,
 						name: "Existing User",
-						picture: "https://example.com/pic.jpg",
+						passwordHash: "test-hash",
+						role: "regular",
+						isEmailAddressVerified: true,
+					})
+					.returning();
+
+				if (!existingUser) {
+					throw new Error("Failed to create test user");
+				}
+				existingUserId = existingUser.id;
+
+				const [existingOAuthAccount] = await server.drizzleClient
+					.insert(oauthAccountsTable)
+					.values({
+						userId: existingUser.id,
+						provider: "google",
+						providerId: uniqueProviderId,
+						email: testEmail,
+						profile: {
+							name: "Existing User",
+							picture: "https://example.com/pic.jpg",
+						},
+						lastUsedAt: seedLastUsedAt,
+					})
+					.returning();
+
+				if (!existingOAuthAccount) {
+					throw new Error("Failed to create OAuth account");
+				}
+				existingOAuthAccountId = existingOAuthAccount.id;
+
+				// Mock OAuth provider responses
+				mockProvider.exchangeCodeForTokens.mockResolvedValueOnce({
+					access_token: "mock-access-token",
+					token_type: "Bearer",
+				});
+
+				mockProvider.getUserProfile.mockResolvedValueOnce({
+					providerId: uniqueProviderId,
+					email: testEmail,
+					name: "Existing User",
+					emailVerified: true,
+				} as OAuthUserProfile);
+
+				const res = await mercuriusClient.mutate(Mutation_signInWithOAuth, {
+					variables: {
+						input: {
+							provider: "GOOGLE",
+							authorizationCode: "valid-auth-code",
+							redirectUri: "http://localhost:3000/callback",
+						},
 					},
-					lastUsedAt: seedLastUsedAt,
-				})
-				.returning();
+				});
 
-			// Mock OAuth provider responses
-			mockProvider.exchangeCodeForTokens.mockResolvedValueOnce({
-				access_token: "mock-access-token",
-				token_type: "Bearer",
-			});
+				expect(res.errors).toBeUndefined();
+				expect(res.data?.signInWithOAuth).toBeDefined();
+				expect(res.data?.signInWithOAuth?.authenticationToken).toBeDefined();
+				expect(res.data?.signInWithOAuth?.refreshToken).toBeDefined();
+				expect(res.data?.signInWithOAuth?.user?.id).toBe(existingUser?.id);
+				expect(res.data?.signInWithOAuth?.user?.emailAddress).toBe(testEmail);
 
-			mockProvider.getUserProfile.mockResolvedValueOnce({
-				providerId: "google-123",
-				email: testEmail,
-				name: "Existing User",
-				emailVerified: true,
-			} as OAuthUserProfile);
+				const [updatedOAuthAccount] = await server.drizzleClient
+					.select()
+					.from(oauthAccountsTable)
+					.where(eq(oauthAccountsTable.id, existingOAuthAccount.id));
 
-			const res = await mercuriusClient.mutate(Mutation_signInWithOAuth, {
-				variables: {
-					input: {
-						provider: "GOOGLE",
-						authorizationCode: "valid-auth-code",
-						redirectUri: "http://localhost:3000/callback",
-					},
-				},
-			});
+				if (!updatedOAuthAccount) {
+					throw new Error("Failed to find updated OAuth account");
+				}
 
-			expect(res.errors).toBeUndefined();
-			expect(res.data?.signInWithOAuth).toBeDefined();
-			expect(res.data?.signInWithOAuth?.authenticationToken).toBeDefined();
-			expect(res.data?.signInWithOAuth?.refreshToken).toBeDefined();
-			expect(res.data?.signInWithOAuth?.user?.id).toBe(existingUser?.id);
-			expect(res.data?.signInWithOAuth?.user?.emailAddress).toBe(testEmail);
-
-			// Verify lastUsedAt was updated
-			if (!existingOAuthAccount) {
-				throw new Error("Failed to create OAuth account");
+				expect(updatedOAuthAccount.lastUsedAt.getTime()).toBeGreaterThan(
+					seedLastUsedAt.getTime(),
+				);
+			} finally {
+				if (existingOAuthAccountId) {
+					await server.drizzleClient
+						.delete(oauthAccountsTable)
+						.where(eq(oauthAccountsTable.id, existingOAuthAccountId));
+				}
+				if (existingUserId) {
+					await server.drizzleClient
+						.delete(usersTable)
+						.where(eq(usersTable.id, existingUserId));
+				}
 			}
-
-			const [updatedOAuthAccount] = await server.drizzleClient
-				.select()
-				.from(oauthAccountsTable)
-				.where(eq(oauthAccountsTable.id, existingOAuthAccount.id));
-
-			if (!updatedOAuthAccount) {
-				throw new Error("Failed to find updated OAuth account");
-			}
-
-			expect(updatedOAuthAccount.lastUsedAt.getTime()).toBeGreaterThan(
-				seedLastUsedAt.getTime(),
-			);
-
-			// Cleanup
-			await server.drizzleClient
-				.delete(oauthAccountsTable)
-				.where(eq(oauthAccountsTable.id, existingOAuthAccount.id));
-			await server.drizzleClient
-				.delete(usersTable)
-				.where(eq(usersTable.id, existingUser.id));
 		});
 
 		test("should upgrade user role from regular to administrator when user has admin membership", async () => {
@@ -183,10 +193,6 @@ suite("Mutation signInWithOAuth", () => {
 			await server.drizzleClient.execute(
 				sql`INSERT INTO organizations (id, name, description) VALUES (${organizationId}, ${orgName}, 'Organization for role upgrade test')`,
 			);
-
-			if (!organizationId) {
-				throw new Error("Failed to create test organization");
-			}
 
 			// Setup: Create user with regular role
 			const testEmail = `admin-upgrade-${randomUUID()}@example.com`;
@@ -289,6 +295,7 @@ suite("Mutation signInWithOAuth", () => {
 
 		test("should set HTTP-Only cookies when cookie helper is available", async () => {
 			const testEmail = `cookie-test-${randomUUID()}@example.com`;
+			const cookieProviderId = `google-cookie-test-${randomUUID()}`;
 			let testUserId: string | undefined;
 			let oauthAccountId: string | undefined;
 
@@ -315,7 +322,7 @@ suite("Mutation signInWithOAuth", () => {
 					.values({
 						userId: testUser.id,
 						provider: "google",
-						providerId: "google-cookie-test",
+						providerId: cookieProviderId,
 						email: testEmail,
 						profile: {
 							name: "Cookie Test User",
@@ -336,7 +343,7 @@ suite("Mutation signInWithOAuth", () => {
 				});
 
 				mockProvider.getUserProfile.mockResolvedValueOnce({
-					providerId: "google-cookie-test",
+					providerId: cookieProviderId,
 					email: testEmail,
 					name: "Cookie Test User",
 					picture: "https://example.com/cookie.jpg",
@@ -649,11 +656,16 @@ suite("Mutation signInWithOAuth", () => {
 					})),
 				})),
 			};
+			type TransactionCallback = Parameters<
+				typeof server.drizzleClient.transaction
+			>[0];
+			type TransactionClient = Parameters<TransactionCallback>[0];
 
-			const originalTransaction = server.drizzleClient.transaction;
-			server.drizzleClient.transaction = vi.fn(async (callback) =>
-				callback(mockTx),
-			);
+			const transactionSpy = vi
+				.spyOn(server.drizzleClient, "transaction")
+				.mockImplementationOnce(async (callback: TransactionCallback) =>
+					callback(mockTx as unknown as TransactionClient),
+				);
 
 			try {
 				// Test with mock OAuth provider
@@ -681,7 +693,7 @@ suite("Mutation signInWithOAuth", () => {
 
 				expect(res.errors?.[0]?.extensions?.code).toBe("unexpected");
 			} finally {
-				server.drizzleClient.transaction = originalTransaction;
+				transactionSpy.mockRestore();
 			}
 		});
 	});
@@ -689,45 +701,50 @@ suite("Mutation signInWithOAuth", () => {
 	describe("edge cases", () => {
 		test("should use default refresh token expiry when not configured", async () => {
 			const testEmail = `default-expiry-${randomUUID()}@example.com`;
-
-			// Setup: Create user and OAuth account first
-			const [testUser] = await server.drizzleClient
-				.insert(usersTable)
-				.values({
-					emailAddress: testEmail,
-					name: "Default Expiry User",
-					passwordHash: "test-hash",
-					role: "regular",
-					isEmailAddressVerified: true,
-				})
-				.returning();
-
-			if (!testUser) {
-				throw new Error("Failed to create test user");
-			}
-
-			const [oauthAccount] = await server.drizzleClient
-				.insert(oauthAccountsTable)
-				.values({
-					userId: testUser.id,
-					provider: "google",
-					providerId: "google-default-expiry",
-					email: testEmail,
-					profile: {
-						name: "Default Expiry User",
-						picture: "https://example.com/pic.jpg",
-					},
-				})
-				.returning();
-
-			if (!oauthAccount) {
-				throw new Error("Failed to create OAuth account");
-			}
+			const defaultExpiryProviderId = `google-default-expiry-${randomUUID()}`;
+			let testUserId: string | undefined;
+			let oauthAccountId: string | undefined;
 
 			// Temporarily remove the config value
 			const originalExpiry = server.envConfig.API_REFRESH_TOKEN_EXPIRES_IN;
 
 			try {
+				// Setup: Create user and OAuth account first
+				const [testUser] = await server.drizzleClient
+					.insert(usersTable)
+					.values({
+						emailAddress: testEmail,
+						name: "Default Expiry User",
+						passwordHash: "test-hash",
+						role: "regular",
+						isEmailAddressVerified: true,
+					})
+					.returning();
+
+				if (!testUser) {
+					throw new Error("Failed to create test user");
+				}
+				testUserId = testUser.id;
+
+				const [oauthAccount] = await server.drizzleClient
+					.insert(oauthAccountsTable)
+					.values({
+						userId: testUser.id,
+						provider: "google",
+						providerId: defaultExpiryProviderId,
+						email: testEmail,
+						profile: {
+							name: "Default Expiry User",
+							picture: "https://example.com/pic.jpg",
+						},
+					})
+					.returning();
+
+				if (!oauthAccount) {
+					throw new Error("Failed to create OAuth account");
+				}
+				oauthAccountId = oauthAccount.id;
+
 				delete (server.envConfig as { API_REFRESH_TOKEN_EXPIRES_IN?: number })
 					.API_REFRESH_TOKEN_EXPIRES_IN;
 				mockProvider.exchangeCodeForTokens.mockResolvedValueOnce({
@@ -735,7 +752,7 @@ suite("Mutation signInWithOAuth", () => {
 					token_type: "Bearer",
 				});
 				mockProvider.getUserProfile.mockResolvedValueOnce({
-					providerId: "google-default-expiry",
+					providerId: defaultExpiryProviderId,
 					email: testEmail,
 					name: "Default Expiry User",
 					emailVerified: true,
@@ -752,20 +769,24 @@ suite("Mutation signInWithOAuth", () => {
 				expect(res.errors).toBeUndefined();
 				expect(res.data?.signInWithOAuth?.authenticationToken).toBeDefined();
 				expect(res.data?.signInWithOAuth?.refreshToken).toBeDefined();
-				// Cleanup
-				await server.drizzleClient
-					.delete(oauthAccountsTable)
-					.where(eq(oauthAccountsTable.id, oauthAccount.id));
-				await server.drizzleClient
-					.delete(usersTable)
-					.where(eq(usersTable.id, testUser.id));
 			} finally {
+				if (oauthAccountId) {
+					await server.drizzleClient
+						.delete(oauthAccountsTable)
+						.where(eq(oauthAccountsTable.id, oauthAccountId));
+				}
+				if (testUserId) {
+					await server.drizzleClient
+						.delete(usersTable)
+						.where(eq(usersTable.id, testUserId));
+				}
 				// Restore config
 				server.envConfig.API_REFRESH_TOKEN_EXPIRES_IN = originalExpiry;
 			}
 		});
 		test("should reset failed login attempts on successful OAuth authentication", async () => {
 			const testEmail = `locked-${randomUUID()}@example.com`;
+			const lockedProviderId = `google-unlock-${randomUUID()}`;
 			const futureDate = new Date(Date.now() + 60000); // 1 minute from now
 
 			const [lockedUser] = await server.drizzleClient
@@ -792,7 +813,7 @@ suite("Mutation signInWithOAuth", () => {
 				.values({
 					userId: lockedUser.id,
 					provider: "google",
-					providerId: "google-unlock",
+					providerId: lockedProviderId,
 					email: testEmail,
 					profile: { name: "Locked User" },
 				})
@@ -808,7 +829,7 @@ suite("Mutation signInWithOAuth", () => {
 			});
 
 			mockProvider.getUserProfile.mockResolvedValueOnce({
-				providerId: "google-unlock",
+				providerId: lockedProviderId,
 				email: testEmail,
 				name: "Locked User",
 				emailVerified: true,

--- a/test/graphql/types/Mutation/signInWithOAuth.test.ts
+++ b/test/graphql/types/Mutation/signInWithOAuth.test.ts
@@ -176,154 +176,6 @@ suite("Mutation signInWithOAuth", () => {
 				.where(eq(usersTable.id, existingUser.id));
 		});
 
-		test("should link OAuth account to existing user with matching email", async () => {
-			// Setup: Create user WITHOUT OAuth account
-			const testEmail = `test-link-${randomUUID()}@example.com`;
-			const [existingUser] = await server.drizzleClient
-				.insert(usersTable)
-				.values({
-					emailAddress: testEmail,
-					name: "User To Link",
-					passwordHash: "test-hash",
-					role: "regular",
-					isEmailAddressVerified: false,
-				})
-				.returning();
-			if (!existingUser) {
-				throw new Error("Failed to create test user");
-			}
-			// Mock OAuth provider responses
-			mockProvider.exchangeCodeForTokens.mockResolvedValueOnce({
-				access_token: "mock-access-token",
-				token_type: "Bearer",
-			});
-
-			mockProvider.getUserProfile.mockResolvedValueOnce({
-				providerId: "google-456",
-				email: testEmail,
-				name: "User To Link",
-				emailVerified: true,
-			} as OAuthUserProfile);
-
-			const res = await mercuriusClient.mutate(Mutation_signInWithOAuth, {
-				variables: {
-					input: {
-						provider: "GOOGLE",
-						authorizationCode: "valid-auth-code",
-						redirectUri: "http://localhost:3000/callback",
-					},
-				},
-			});
-
-			expect(res.errors).toBeUndefined();
-			expect(res.data?.signInWithOAuth).toBeDefined();
-			expect(res.data?.signInWithOAuth?.user?.id).toBe(existingUser?.id);
-			expect(res.data?.signInWithOAuth?.user?.isEmailAddressVerified).toBe(
-				true,
-			);
-
-			// Verify OAuth account was created
-			const [createdOAuthAccount] = await server.drizzleClient
-				.select()
-				.from(oauthAccountsTable)
-				.where(eq(oauthAccountsTable.userId, existingUser.id));
-
-			expect(createdOAuthAccount).toBeDefined();
-			expect(createdOAuthAccount?.userId).toBe(existingUser?.id);
-			expect(createdOAuthAccount?.email).toBe(testEmail);
-
-			// Verify user email was marked as verified
-			const [updatedUser] = await server.drizzleClient
-				.select()
-				.from(usersTable)
-				.where(eq(usersTable.id, existingUser.id));
-
-			expect(updatedUser).toBeDefined();
-			expect(updatedUser?.isEmailAddressVerified).toBe(true);
-
-			// Cleanup
-			if (createdOAuthAccount) {
-				await server.drizzleClient
-					.delete(oauthAccountsTable)
-					.where(eq(oauthAccountsTable.id, createdOAuthAccount.id));
-			}
-			await server.drizzleClient
-				.delete(usersTable)
-				.where(eq(usersTable.id, existingUser.id));
-		});
-
-		test("should create new user and link OAuth account", async () => {
-			const testEmail = `newuser-${randomUUID()}@example.com`;
-
-			// Mock OAuth provider responses
-			mockProvider.exchangeCodeForTokens.mockResolvedValueOnce({
-				access_token: "mock-access-token",
-				token_type: "Bearer",
-			});
-
-			mockProvider.getUserProfile.mockResolvedValueOnce({
-				providerId: "google-789",
-				email: testEmail,
-				name: "New OAuth User",
-				picture: "https://example.com/newuser.jpg",
-				emailVerified: true,
-			} as OAuthUserProfile);
-
-			const res = await mercuriusClient.mutate(Mutation_signInWithOAuth, {
-				variables: {
-					input: {
-						provider: "GOOGLE",
-						authorizationCode: "valid-auth-code",
-						redirectUri: "http://localhost:3000/callback",
-					},
-				},
-			});
-
-			expect(res.errors).toBeUndefined();
-			expect(res.data?.signInWithOAuth).toBeDefined();
-			expect(res.data?.signInWithOAuth?.authenticationToken).toBeDefined();
-			expect(res.data?.signInWithOAuth?.refreshToken).toBeDefined();
-			expect(res.data?.signInWithOAuth?.user?.emailAddress).toBe(testEmail);
-			expect(res.data?.signInWithOAuth?.user?.name).toBe("New OAuth User");
-			expect(res.data?.signInWithOAuth?.user?.isEmailAddressVerified).toBe(
-				true,
-			);
-
-			const userId = res.data?.signInWithOAuth?.user?.id;
-
-			expect(userId).toBeDefined();
-			if (!userId) throw new Error("User ID is undefined");
-
-			// Verify user was created
-			const [createdUser] = await server.drizzleClient
-				.select()
-				.from(usersTable)
-				.where(eq(usersTable.id, userId));
-
-			expect(createdUser).toBeDefined();
-			expect(createdUser?.emailAddress).toBe(testEmail);
-			expect(createdUser?.isEmailAddressVerified).toBe(true);
-
-			// Verify OAuth account was created
-			const [createdOAuthAccount] = await server.drizzleClient
-				.select()
-				.from(oauthAccountsTable)
-				.where(eq(oauthAccountsTable.userId, userId));
-
-			expect(createdOAuthAccount).toBeDefined();
-			expect(createdOAuthAccount?.userId).toBe(userId);
-
-			// Cleanup
-			if (createdOAuthAccount) {
-				await server.drizzleClient
-					.delete(oauthAccountsTable)
-					.where(eq(oauthAccountsTable.id, createdOAuthAccount.id));
-			}
-			await server.drizzleClient
-				.delete(usersTable)
-				.where(eq(usersTable.id, userId));
-		});
-
 		test("should upgrade user role from regular to administrator when user has admin membership", async () => {
 			// Setup: Create organization using raw SQL with proper UUID
 			const organizationId = uuidv7();
@@ -438,6 +290,40 @@ suite("Mutation signInWithOAuth", () => {
 		test("should set HTTP-Only cookies when cookie helper is available", async () => {
 			const testEmail = `cookie-test-${randomUUID()}@example.com`;
 
+			// Setup: Create user and OAuth account first
+			const [testUser] = await server.drizzleClient
+				.insert(usersTable)
+				.values({
+					emailAddress: testEmail,
+					name: "Cookie Test User",
+					passwordHash: "test-hash",
+					role: "regular",
+					isEmailAddressVerified: true,
+				})
+				.returning();
+
+			if (!testUser) {
+				throw new Error("Failed to create test user");
+			}
+
+			const [oauthAccount] = await server.drizzleClient
+				.insert(oauthAccountsTable)
+				.values({
+					userId: testUser.id,
+					provider: "google",
+					providerId: "google-cookie-test",
+					email: testEmail,
+					profile: {
+						name: "Cookie Test User",
+						picture: "https://example.com/cookie.jpg",
+					},
+				})
+				.returning();
+
+			if (!oauthAccount) {
+				throw new Error("Failed to create OAuth account");
+			}
+
 			// Mock OAuth provider responses
 			mockProvider.exchangeCodeForTokens.mockResolvedValueOnce({
 				access_token: "mock-access-token",
@@ -493,19 +379,13 @@ suite("Mutation signInWithOAuth", () => {
 			expect(refreshTokenCookie?.path).toBe("/");
 			expect(refreshTokenCookie?.sameSite).toBe("Lax");
 
-			// Parse response to get user info for cleanup
-			const responseData = JSON.parse(response.payload);
-			const userId = responseData.data?.signInWithOAuth?.user?.id;
-
-			if (userId) {
-				// Cleanup: Delete OAuth account and user
-				await server.drizzleClient
-					.delete(oauthAccountsTable)
-					.where(eq(oauthAccountsTable.userId, userId));
-				await server.drizzleClient
-					.delete(usersTable)
-					.where(eq(usersTable.id, userId));
-			}
+			// Cleanup
+			await server.drizzleClient
+				.delete(oauthAccountsTable)
+				.where(eq(oauthAccountsTable.id, oauthAccount.id));
+			await server.drizzleClient
+				.delete(usersTable)
+				.where(eq(usersTable.id, testUser.id));
 		});
 	});
 
@@ -705,15 +585,19 @@ suite("Mutation signInWithOAuth", () => {
 			expect(res.errors?.[0]?.message).toContain("Invalid user profile");
 		});
 
-		test("should throw error when creating new user without email", async () => {
+		test("should throw error when OAuth account is not linked", async () => {
+			const unlinkedProviderId = `google-unlinked-${randomUUID()}`;
+
 			mockProvider.exchangeCodeForTokens.mockResolvedValueOnce({
 				access_token: "mock-access-token",
 				token_type: "Bearer",
 			});
 
 			mockProvider.getUserProfile.mockResolvedValueOnce({
-				providerId: "google-no-email",
-				name: "User Without Email",
+				providerId: unlinkedProviderId,
+				email: `unlinked-${randomUUID()}@example.com`,
+				name: "Unlinked OAuth User",
+				emailVerified: true,
 			} as OAuthUserProfile);
 
 			const res = await mercuriusClient.mutate(Mutation_signInWithOAuth, {
@@ -728,33 +612,7 @@ suite("Mutation signInWithOAuth", () => {
 
 			expect(res.errors).toBeDefined();
 			expect(res.errors?.[0]?.extensions?.code).toBe("forbidden_action");
-			expect(res.errors?.[0]?.message).toContain("did not share your email");
-		});
-
-		test("should throw error when creating new user without name", async () => {
-			mockProvider.exchangeCodeForTokens.mockResolvedValueOnce({
-				access_token: "mock-access-token",
-				token_type: "Bearer",
-			});
-
-			mockProvider.getUserProfile.mockResolvedValueOnce({
-				providerId: "google-no-name",
-				email: "noname@example.com",
-			} as OAuthUserProfile);
-
-			const res = await mercuriusClient.mutate(Mutation_signInWithOAuth, {
-				variables: {
-					input: {
-						provider: "GOOGLE",
-						authorizationCode: "valid-code",
-						redirectUri: "http://localhost:3000/callback",
-					},
-				},
-			});
-
-			expect(res.errors).toBeDefined();
-			expect(res.errors?.[0]?.extensions?.code).toBe("forbidden_action");
-			expect(res.errors?.[0]?.message).toContain("did not share your name");
+			expect(res.errors?.[0]?.message).toContain("OAuth account not found.");
 		});
 
 		test("should handle database anomaly - OAuth account without user", async () => {
@@ -817,87 +675,45 @@ suite("Mutation signInWithOAuth", () => {
 				server.drizzleClient.transaction = originalTransaction;
 			}
 		});
-
-		test("should handle empty insert result with mock", async () => {
-			const testEmail = `mock-empty-${randomUUID()}@example.com`;
-
-			// Save original drizzleClient
-			const originalClient = server.drizzleClient;
-
-			// Mock server.drizzleClient to force empty insert result edge case for Mutation_signInWithOAuth.
-			// insertCallCount tracks insert calls to return empty array on first user insert, triggering
-			// the error path. DB-level mock required since this edge case is difficult to reproduce with
-			// real database. server.drizzleClient restored in finally to prevent test pollution.
-			let insertCallCount = 0;
-			const mockClient = {
-				...originalClient,
-				transaction: vi.fn(async (callback) => {
-					const mockTx = {
-						...originalClient,
-						select: vi.fn(() => ({
-							from: vi.fn(() => ({
-								where: vi.fn(async () => {
-									// Return empty array for all selects to simulate new user scenario
-									return [];
-								}),
-							})),
-						})),
-						insert: vi.fn(() => ({
-							values: vi.fn(() => ({
-								returning: vi.fn(async () => {
-									insertCallCount++;
-									// First insert is for user - return empty to trigger error
-									if (insertCallCount === 1) {
-										return [];
-									}
-									// Shouldn't get here but return something to avoid further errors
-									return [{ id: "test-id" }];
-								}),
-							})),
-						})),
-					};
-					return callback(mockTx);
-				}),
-			};
-
-			// Temporarily replace drizzleClient
-			server.drizzleClient =
-				mockClient as unknown as typeof server.drizzleClient;
-
-			mockProvider.exchangeCodeForTokens.mockResolvedValueOnce({
-				access_token: "mock-access-token",
-				token_type: "Bearer",
-			});
-
-			mockProvider.getUserProfile.mockResolvedValueOnce({
-				providerId: "google-empty-insert",
-				email: testEmail,
-				name: "Empty Insert User",
-				emailVerified: true,
-			} as OAuthUserProfile);
-
-			try {
-				const res = await mercuriusClient.mutate(Mutation_signInWithOAuth, {
-					variables: {
-						input: {
-							provider: "GOOGLE",
-							authorizationCode: "valid-code",
-							redirectUri: "http://localhost:3000/callback",
-						},
-					},
-				});
-				expect(res.errors).toBeDefined();
-				expect(res.errors?.[0]?.extensions?.code).toBe("unexpected");
-			} finally {
-				// Restore original client
-				server.drizzleClient = originalClient;
-			}
-		});
 	});
 
 	describe("edge cases", () => {
 		test("should use default refresh token expiry when not configured", async () => {
 			const testEmail = `default-expiry-${randomUUID()}@example.com`;
+
+			// Setup: Create user and OAuth account first
+			const [testUser] = await server.drizzleClient
+				.insert(usersTable)
+				.values({
+					emailAddress: testEmail,
+					name: "Default Expiry User",
+					passwordHash: "test-hash",
+					role: "regular",
+					isEmailAddressVerified: true,
+				})
+				.returning();
+
+			if (!testUser) {
+				throw new Error("Failed to create test user");
+			}
+
+			const [oauthAccount] = await server.drizzleClient
+				.insert(oauthAccountsTable)
+				.values({
+					userId: testUser.id,
+					provider: "google",
+					providerId: "google-default-expiry",
+					email: testEmail,
+					profile: {
+						name: "Default Expiry User",
+						picture: "https://example.com/pic.jpg",
+					},
+				})
+				.returning();
+
+			if (!oauthAccount) {
+				throw new Error("Failed to create OAuth account");
+			}
 
 			// Temporarily remove the config value
 			const originalExpiry = server.envConfig.API_REFRESH_TOKEN_EXPIRES_IN;
@@ -927,125 +743,16 @@ suite("Mutation signInWithOAuth", () => {
 				expect(res.errors).toBeUndefined();
 				expect(res.data?.signInWithOAuth?.authenticationToken).toBeDefined();
 				expect(res.data?.signInWithOAuth?.refreshToken).toBeDefined();
-				const userId = res.data?.signInWithOAuth?.user?.id;
-				if (!userId) {
-					throw new Error("User ID is undefined");
-				}
 				// Cleanup
 				await server.drizzleClient
 					.delete(oauthAccountsTable)
-					.where(eq(oauthAccountsTable.userId, userId));
+					.where(eq(oauthAccountsTable.id, oauthAccount.id));
 				await server.drizzleClient
 					.delete(usersTable)
-					.where(eq(usersTable.id, userId));
+					.where(eq(usersTable.id, testUser.id));
 			} finally {
 				// Restore config
 				server.envConfig.API_REFRESH_TOKEN_EXPIRES_IN = originalExpiry;
-			}
-		});
-
-		test("should handle user with unverified email linking verified OAuth account", async () => {
-			const testEmail = `unverified-${randomUUID()}@example.com`;
-			const [existingUser] = await server.drizzleClient
-				.insert(usersTable)
-				.values({
-					emailAddress: testEmail,
-					name: "Unverified User",
-					passwordHash: "test-hash",
-					role: "regular",
-					isEmailAddressVerified: false,
-				})
-				.returning();
-
-			if (!existingUser) {
-				throw new Error("Failed to create test user");
-			}
-
-			mockProvider.exchangeCodeForTokens.mockResolvedValueOnce({
-				access_token: "mock-access-token",
-				token_type: "Bearer",
-			});
-
-			mockProvider.getUserProfile.mockResolvedValueOnce({
-				providerId: "google-verified",
-				email: testEmail,
-				name: "Unverified User",
-				emailVerified: true,
-			} as OAuthUserProfile);
-
-			const res = await mercuriusClient.mutate(Mutation_signInWithOAuth, {
-				variables: {
-					input: {
-						provider: "GOOGLE",
-						authorizationCode: "valid-code",
-						redirectUri: "http://localhost:3000/callback",
-					},
-				},
-			});
-
-			expect(res.errors).toBeUndefined();
-			expect(res.data?.signInWithOAuth?.user?.isEmailAddressVerified).toBe(
-				true,
-			);
-
-			// Cleanup
-			if (existingUser) {
-				await server.drizzleClient
-					.delete(oauthAccountsTable)
-					.where(eq(oauthAccountsTable.userId, existingUser.id));
-				await server.drizzleClient
-					.delete(usersTable)
-					.where(eq(usersTable.id, existingUser.id));
-			}
-		});
-		test("should not update email verification if user already verified", async () => {
-			const testEmail = `already-verified-${randomUUID()}@example.com`;
-			const [existingUser] = await server.drizzleClient
-				.insert(usersTable)
-				.values({
-					emailAddress: testEmail,
-					name: "Already Verified User",
-					passwordHash: "test-hash",
-					role: "regular",
-					isEmailAddressVerified: true, // Already verified
-				})
-				.returning();
-
-			mockProvider.exchangeCodeForTokens.mockResolvedValueOnce({
-				access_token: "mock-access-token",
-				token_type: "Bearer",
-			});
-
-			mockProvider.getUserProfile.mockResolvedValueOnce({
-				providerId: "google-already-verified",
-				email: testEmail,
-				name: "Already Verified User",
-				emailVerified: true, // OAuth also verified
-			} as OAuthUserProfile);
-
-			const res = await mercuriusClient.mutate(Mutation_signInWithOAuth, {
-				variables: {
-					input: {
-						provider: "GOOGLE",
-						authorizationCode: "valid-code",
-						redirectUri: "http://localhost:3000/callback",
-					},
-				},
-			});
-
-			expect(res.errors).toBeUndefined();
-			expect(res.data?.signInWithOAuth?.user?.isEmailAddressVerified).toBe(
-				true,
-			);
-
-			// Cleanup
-			if (existingUser) {
-				await server.drizzleClient
-					.delete(oauthAccountsTable)
-					.where(eq(oauthAccountsTable.userId, existingUser.id));
-				await server.drizzleClient
-					.delete(usersTable)
-					.where(eq(usersTable.id, existingUser.id));
 			}
 		});
 		test("should reset failed login attempts on successful OAuth authentication", async () => {
@@ -1068,6 +775,22 @@ suite("Mutation signInWithOAuth", () => {
 
 			if (!lockedUser) {
 				throw new Error("Failed to create test user");
+			}
+
+			// Setup: Create OAuth account
+			const [oauthAccount] = await server.drizzleClient
+				.insert(oauthAccountsTable)
+				.values({
+					userId: lockedUser.id,
+					provider: "google",
+					providerId: "google-unlock",
+					email: testEmail,
+					profile: { name: "Locked User" },
+				})
+				.returning();
+
+			if (!oauthAccount) {
+				throw new Error("Failed to create OAuth account");
 			}
 
 			mockProvider.exchangeCodeForTokens.mockResolvedValueOnce({
@@ -1113,57 +836,6 @@ suite("Mutation signInWithOAuth", () => {
 			await server.drizzleClient
 				.delete(usersTable)
 				.where(eq(usersTable.id, lockedUser.id));
-		});
-
-		test("should reject linking unverified OAuth email to existing user", async () => {
-			const testEmail = `verified-${randomUUID()}@example.com`;
-			const [existingUser] = await server.drizzleClient
-				.insert(usersTable)
-				.values({
-					emailAddress: testEmail,
-					name: "Verified User",
-					passwordHash: "test-hash",
-					role: "regular",
-					isEmailAddressVerified: true,
-				})
-				.returning();
-
-			if (!existingUser) {
-				throw new Error("Failed to create test user");
-			}
-
-			mockProvider.exchangeCodeForTokens.mockResolvedValueOnce({
-				access_token: "mock-access-token",
-				token_type: "Bearer",
-			});
-
-			mockProvider.getUserProfile.mockResolvedValueOnce({
-				providerId: "google-unverified",
-				email: testEmail,
-				name: "Verified User",
-				emailVerified: false,
-			} as OAuthUserProfile);
-
-			const res = await mercuriusClient.mutate(Mutation_signInWithOAuth, {
-				variables: {
-					input: {
-						provider: "GOOGLE",
-						authorizationCode: "valid-code",
-						redirectUri: "http://localhost:3000/callback",
-					},
-				},
-			});
-
-			expect(res.errors).toBeDefined();
-			expect(res.errors?.[0]?.extensions?.code).toBe("forbidden_action");
-			expect(res.errors?.[0]?.message).toContain(
-				"A user with this email already exists. Please verify your email with the OAuth provider",
-			);
-
-			// Cleanup
-			await server.drizzleClient
-				.delete(usersTable)
-				.where(eq(usersTable.id, existingUser.id));
 		});
 	});
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Removed OAuth account linking from ```SignInWithOAuth```

**Issue Number:** #5333

Fixes #5333

**Snapshots/Videos:**
N/A

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**
Removed OAuth account linking from ```SignInWithOAuth``` as we already have ```linkOauthAccount``` mutation. Making this fallback redundant.

**Does this PR introduce a breaking change?**
NO

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth sign-in now requires a pre-existing linked account; automatic account creation and email-based linking during OAuth authentication have been removed. Attempts to use an unlinked OAuth account will return a forbidden "OAuth account not found" error.

* **Tests**
  * Test suite updated for sign-in-only behavior: removed auto-linking/creation tests, added/prepared pre-linked fixtures, and adjusted setup, cleanup, and error assertions to expect the new forbidden response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->