### PR TITLE
fix: allow event creators to manage their own event's agenda resources

### DIFF
--- a/src/graphql/types/Mutation/createAgendaCategory.ts
+++ b/src/graphql/types/Mutation/createAgendaCategory.ts
@@ -7,6 +7,7 @@ import {
 } from "~/src/graphql/inputs/MutationCreateAgendaCategoryInput";
 import { AgendaCategory } from "~/src/graphql/types/AgendaCategory/AgendaCategory";
 import envConfig from "~/src/utilities/graphqLimits";
+import { isEventCreatorOrAdmin } from "~/src/utilities/isEventCreatorOrAdmin";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 
 const mutationCreateAgendaCategoryArgumentsSchema = z.object({
@@ -61,6 +62,9 @@ builder.mutationField("createAgendaCategory", (t) =>
 					where: (fields, operators) => operators.eq(fields.id, currentUserId),
 				}),
 				ctx.drizzleClient.query.eventsTable.findFirst({
+					columns: {
+						creatorId: true,
+					},
 					with: {
 						organization: {
 							columns: {
@@ -115,9 +119,12 @@ builder.mutationField("createAgendaCategory", (t) =>
 				existingEvent.organization.membershipsWhereOrganization[0];
 
 			if (
-				currentUser.role !== "administrator" &&
-				(currentUserOrganizationMembership === undefined ||
-					currentUserOrganizationMembership.role !== "administrator")
+				!isEventCreatorOrAdmin(
+					currentUserId,
+					currentUser.role,
+					currentUserOrganizationMembership,
+					existingEvent.creatorId,
+				)
 			) {
 				throw new TalawaGraphQLError({
 					extensions: {

--- a/src/graphql/types/Mutation/createAgendaFolder.ts
+++ b/src/graphql/types/Mutation/createAgendaFolder.ts
@@ -7,6 +7,7 @@ import {
 } from "~/src/graphql/inputs/MutationCreateAgendaFolderInput";
 import { AgendaFolder } from "~/src/graphql/types/AgendaFolder/AgendaFolder";
 import envConfig from "~/src/utilities/graphqLimits";
+import { isEventCreatorOrAdmin } from "~/src/utilities/isEventCreatorOrAdmin";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 
 const mutationCreateAgendaFolderArgumentsSchema = z.object({
@@ -63,6 +64,7 @@ builder.mutationField("createAgendaFolder", (t) =>
 				ctx.drizzleClient.query.eventsTable.findFirst({
 					columns: {
 						startAt: true,
+						creatorId: true,
 					},
 					with: {
 						organization: {
@@ -126,9 +128,12 @@ builder.mutationField("createAgendaFolder", (t) =>
 				existingEvent.organization.membershipsWhereOrganization[0];
 
 			if (
-				currentUser.role !== "administrator" &&
-				(currentUserOrganizationMembership === undefined ||
-					currentUserOrganizationMembership.role !== "administrator")
+				!isEventCreatorOrAdmin(
+					currentUserId,
+					currentUser.role,
+					currentUserOrganizationMembership,
+					existingEvent.creatorId
+				)
 			) {
 				throw new TalawaGraphQLError({
 					extensions: {

--- a/src/graphql/types/Mutation/createAgendaItem.ts
+++ b/src/graphql/types/Mutation/createAgendaItem.ts
@@ -9,6 +9,7 @@ import {
 } from "~/src/graphql/inputs/MutationCreateAgendaItemInput";
 import { AgendaItem } from "~/src/graphql/types/AgendaItem/AgendaItem";
 import envConfig from "~/src/utilities/graphqLimits";
+import { isEventCreatorOrAdmin } from "~/src/utilities/isEventCreatorOrAdmin";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 
 const mutationCreateAgendaItemArgumentsSchema = z.object({
@@ -130,6 +131,7 @@ builder.mutationField("createAgendaItem", (t) =>
 						event: {
 							columns: {
 								startAt: true,
+								creatorId: true,
 							},
 							with: {
 								organization: {
@@ -195,9 +197,12 @@ builder.mutationField("createAgendaItem", (t) =>
 				existingAgendaFolder.event.organization.membershipsWhereOrganization[0];
 
 			if (
-				currentUser.role !== "administrator" &&
-				(currentUserOrganizationMembership === undefined ||
-					currentUserOrganizationMembership.role !== "administrator")
+				!isEventCreatorOrAdmin(
+					currentUserId,
+					currentUser.role,
+					currentUserOrganizationMembership,
+					existingAgendaFolder.event.creatorId,
+				)
 			) {
 				throw new TalawaGraphQLError({
 					extensions: {

--- a/src/graphql/types/Mutation/deleteAgendaFolder.ts
+++ b/src/graphql/types/Mutation/deleteAgendaFolder.ts
@@ -9,6 +9,7 @@ import {
 } from "~/src/graphql/inputs/MutationDeleteAgendaFolderInput";
 import { AgendaFolder } from "~/src/graphql/types/AgendaFolder/AgendaFolder";
 import envConfig from "~/src/utilities/graphqLimits";
+import { isEventCreatorOrAdmin } from "~/src/utilities/isEventCreatorOrAdmin";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 
 const mutationDeleteAgendaFolderArgumentsSchema = z.object({
@@ -71,6 +72,7 @@ builder.mutationField("deleteAgendaFolder", (t) =>
 						event: {
 							columns: {
 								startAt: true,
+								creatorId: true,
 							},
 							with: {
 								organization: {
@@ -134,9 +136,12 @@ builder.mutationField("deleteAgendaFolder", (t) =>
 				existingAgendaFolder.event.organization.membershipsWhereOrganization[0];
 
 			if (
-				currentUser.role !== "administrator" &&
-				(currentUserOrganizationMembership === undefined ||
-					currentUserOrganizationMembership.role !== "administrator")
+				!isEventCreatorOrAdmin(
+					currentUserId,
+					currentUser.role,
+					currentUserOrganizationMembership,
+					existingAgendaFolder.event.creatorId,
+				)
 			) {
 				throw new TalawaGraphQLError({
 					extensions: {

--- a/src/graphql/types/Mutation/deleteAgendaItem.ts
+++ b/src/graphql/types/Mutation/deleteAgendaItem.ts
@@ -8,6 +8,7 @@ import {
 } from "~/src/graphql/inputs/MutationDeleteAgendaItemInput";
 import { AgendaItem } from "~/src/graphql/types/AgendaItem/AgendaItem";
 import envConfig from "~/src/utilities/graphqLimits";
+import { isEventCreatorOrAdmin } from "~/src/utilities/isEventCreatorOrAdmin";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 
 const mutationDeleteAgendaItemArgumentsSchema = z.object({
@@ -71,6 +72,7 @@ builder.mutationField("deleteAgendaItem", (t) =>
 								event: {
 									columns: {
 										startAt: true,
+										creatorId: true,
 									},
 									with: {
 										organization: {
@@ -123,9 +125,12 @@ builder.mutationField("deleteAgendaItem", (t) =>
 					.membershipsWhereOrganization[0];
 
 			if (
-				currentUser.role !== "administrator" &&
-				(currentUserOrganizationMembership === undefined ||
-					currentUserOrganizationMembership.role !== "administrator")
+				!isEventCreatorOrAdmin(
+					currentUserId,
+					currentUser.role,
+					currentUserOrganizationMembership,
+					existingAgendaItem.folder.event.creatorId,
+				)
 			) {
 				throw new TalawaGraphQLError({
 					extensions: {

--- a/src/graphql/types/Mutation/updateAgendaCategory.ts
+++ b/src/graphql/types/Mutation/updateAgendaCategory.ts
@@ -8,6 +8,7 @@ import {
 } from "~/src/graphql/inputs/MutationUpdateAgendaCategoryInput";
 import { AgendaCategory } from "~/src/graphql/types/AgendaCategory/AgendaCategory";
 import envConfig from "~/src/utilities/graphqLimits";
+import { isEventCreatorOrAdmin } from "~/src/utilities/isEventCreatorOrAdmin";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 
 const mutationUpdateAgendaCategoryArgumentsSchema = z.object({
@@ -63,6 +64,9 @@ builder.mutationField("updateAgendaCategory", (t) =>
 					columns: { eventId: true },
 					with: {
 						event: {
+							columns: {
+								creatorId: true,
+							},
 							with: {
 								organization: {
 									with: {
@@ -107,9 +111,12 @@ builder.mutationField("updateAgendaCategory", (t) =>
 					?.membershipsWhereOrganization[0];
 
 			if (
-				currentUser.role !== "administrator" &&
-				(currentUserOrganizationMembership === undefined ||
-					currentUserOrganizationMembership.role !== "administrator")
+				!isEventCreatorOrAdmin(
+					currentUserId,
+					currentUser.role,
+					currentUserOrganizationMembership,
+					existingAgendaCategory.event?.creatorId ?? null,
+				)
 			) {
 				throw new TalawaGraphQLError({
 					extensions: {

--- a/src/graphql/types/Mutation/updateAgendaFolder.ts
+++ b/src/graphql/types/Mutation/updateAgendaFolder.ts
@@ -8,6 +8,7 @@ import {
 } from "~/src/graphql/inputs/MutationUpdateAgendaFolderInput";
 import { AgendaFolder } from "~/src/graphql/types/AgendaFolder/AgendaFolder";
 import envConfig from "~/src/utilities/graphqLimits";
+import { isEventCreatorOrAdmin } from "~/src/utilities/isEventCreatorOrAdmin";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 
 const mutationUpdateAgendaFolderArgumentsSchema = z.object({
@@ -70,6 +71,7 @@ builder.mutationField("updateAgendaFolder", (t) =>
 						event: {
 							columns: {
 								startAt: true,
+								creatorId: true,
 							},
 							with: {
 								organization: {
@@ -139,9 +141,12 @@ builder.mutationField("updateAgendaFolder", (t) =>
 				existingAgendaFolder.event.organization.membershipsWhereOrganization[0];
 
 			if (
-				currentUser.role !== "administrator" &&
-				(currentUserOrganizationMembership === undefined ||
-					currentUserOrganizationMembership.role !== "administrator")
+				!isEventCreatorOrAdmin(
+					currentUserId,
+					currentUser.role,
+					currentUserOrganizationMembership,
+					existingAgendaFolder.event.creatorId,
+				)
 			) {
 				throw new TalawaGraphQLError({
 					extensions: {

--- a/src/graphql/types/Mutation/updateAgendaItem.ts
+++ b/src/graphql/types/Mutation/updateAgendaItem.ts
@@ -11,6 +11,7 @@ import {
 import { AgendaItem } from "~/src/graphql/types/AgendaItem/AgendaItem";
 import envConfig from "~/src/utilities/graphqLimits";
 import { isNotNullish } from "~/src/utilities/isNotNullish";
+import { isEventCreatorOrAdmin } from "~/src/utilities/isEventCreatorOrAdmin";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 
 const mutationUpdateAgendaItemArgumentsSchema = z.object({
@@ -75,7 +76,9 @@ builder.mutationField("updateAgendaItem", (t) =>
 							},
 							with: {
 								event: {
-									columns: {},
+									columns: {
+										creatorId: true,
+									},
 									with: {
 										organization: {
 											columns: {},
@@ -257,9 +260,12 @@ builder.mutationField("updateAgendaItem", (t) =>
 					.membershipsWhereOrganization[0];
 
 			if (
-				currentUser.role !== "administrator" &&
-				(currentUserOrganizationMembership === undefined ||
-					currentUserOrganizationMembership.role !== "administrator")
+				!isEventCreatorOrAdmin(
+					currentUserId,
+					currentUser.role,
+					currentUserOrganizationMembership,
+					existingAgendaItem.folder.event.creatorId
+				)
 			) {
 				throw new TalawaGraphQLError({
 					extensions: {

--- a/src/graphql/types/Mutation/updateAgendaItemSequence.ts
+++ b/src/graphql/types/Mutation/updateAgendaItemSequence.ts
@@ -8,6 +8,7 @@ import {
 } from "~/src/graphql/inputs/MutationUpdateAgendaItemSequenceInput";
 import { AgendaItem } from "~/src/graphql/types/AgendaItem/AgendaItem";
 import envConfig from "~/src/utilities/graphqLimits";
+import { isEventCreatorOrAdmin } from "~/src/utilities/isEventCreatorOrAdmin";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 
 const mutationUpdateAgendaItemArgumentsSchema = z.object({
@@ -73,7 +74,9 @@ builder.mutationField("updateAgendaItemSequence", (t) =>
 							},
 							with: {
 								event: {
-									columns: {},
+									columns: {
+										creatorId: true,
+									},
 									with: {
 										organization: {
 											columns: {},
@@ -122,9 +125,12 @@ builder.mutationField("updateAgendaItemSequence", (t) =>
 					.membershipsWhereOrganization[0];
 
 			if (
-				currentUser.role !== "administrator" &&
-				(currentUserOrganizationMembership === undefined ||
-					currentUserOrganizationMembership.role !== "administrator")
+				!isEventCreatorOrAdmin(
+					currentUserId,
+					currentUser.role,
+					currentUserOrganizationMembership,
+					existingAgendaItem.folder.event.creatorId
+				)
 			) {
 				throw new TalawaGraphQLError({
 					extensions: {

--- a/src/graphql/types/Query/agendaCategoriesByEventId.ts
+++ b/src/graphql/types/Query/agendaCategoriesByEventId.ts
@@ -5,6 +5,7 @@ import { eventsTable } from "~/src/drizzle/tables/events";
 import { builder } from "~/src/graphql/builder";
 import { AgendaCategory } from "~/src/graphql/types/AgendaCategory/AgendaCategory";
 import envConfig from "~/src/utilities/graphqLimits";
+import { isEventCreatorOrAdmin } from "~/src/utilities/isEventCreatorOrAdmin";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 
 const queryGetAgendaCategoryByEventIdArgumentsSchema = z.object({
@@ -89,8 +90,12 @@ builder.queryField("agendaCategoriesByEventId", (t) =>
 			}
 
 			if (
-				currentUser.role !== "administrator" &&
-				membership?.role !== "administrator"
+				!isEventCreatorOrAdmin(
+					currentUserId,
+					currentUser.role,
+					membership,
+					event.creatorId
+				)
 			) {
 				throw new TalawaGraphQLError({
 					extensions: {

--- a/src/graphql/types/Query/agendaFolder.ts
+++ b/src/graphql/types/Query/agendaFolder.ts
@@ -6,6 +6,7 @@ import {
 } from "~/src/graphql/inputs/QueryAgendaFolderInput";
 import { AgendaFolder } from "~/src/graphql/types/AgendaFolder/AgendaFolder";
 import envConfig from "~/src/utilities/graphqLimits";
+import { isEventCreatorOrAdmin } from "~/src/utilities/isEventCreatorOrAdmin";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 
 const queryAgendaFolderArgumentsSchema = z.object({
@@ -64,6 +65,7 @@ builder.queryField("agendaFolder", (t) =>
 						event: {
 							columns: {
 								startAt: true,
+								creatorId: true,
 							},
 							with: {
 								organization: {
@@ -113,8 +115,12 @@ builder.queryField("agendaFolder", (t) =>
 				existingAgendaFolder.event.organization.membershipsWhereOrganization[0];
 
 			if (
-				currentUser.role !== "administrator" &&
-				currentUserOrganizationMembership === undefined
+				!isEventCreatorOrAdmin(
+					currentUserId,
+					currentUser.role,
+					currentUserOrganizationMembership,
+					existingAgendaFolder.event.creatorId
+				)
 			) {
 				throw new TalawaGraphQLError({
 					extensions: {

--- a/src/graphql/types/Query/agendaFoldersByEventId.ts
+++ b/src/graphql/types/Query/agendaFoldersByEventId.ts
@@ -5,6 +5,7 @@ import { eventsTable } from "~/src/drizzle/tables/events";
 import { builder } from "~/src/graphql/builder";
 import { AgendaFolder } from "~/src/graphql/types/AgendaFolder/AgendaFolder";
 import envConfig from "~/src/utilities/graphqLimits";
+import { isEventCreatorOrAdmin } from "~/src/utilities/isEventCreatorOrAdmin";
 import { TalawaGraphQLError } from "~/src/utilities/TalawaGraphQLError";
 
 const queryGetAgendaFolderByEventIdArgumentsSchema = z.object({
@@ -92,8 +93,12 @@ builder.queryField("agendaFoldersByEventId", (t) =>
 			}
 
 			if (
-				currentUser.role !== "administrator" &&
-				membership?.role !== "administrator"
+				!isEventCreatorOrAdmin(
+					currentUserId,
+					currentUser.role,
+					membership,
+					event.creatorId
+				)
 			) {
 				throw new TalawaGraphQLError({
 					extensions: {

--- a/src/utilities/isEventCreatorOrAdmin.ts
+++ b/src/utilities/isEventCreatorOrAdmin.ts
@@ -1,0 +1,16 @@
+interface HasRole {
+	role?: string | null;
+}
+
+export const isEventCreatorOrAdmin = (
+	currentUserId: string,
+	currentUserRole: string | null | undefined,
+	membership: HasRole | undefined,
+	eventCreatorId: string | null,
+): boolean => {
+	return (
+		currentUserRole === "administrator" ||
+		membership?.role === "administrator" ||
+		eventCreatorId === currentUserId
+	);
+};

--- a/test/graphql/types/Query/agendaFolder.test.ts
+++ b/test/graphql/types/Query/agendaFolder.test.ts
@@ -634,8 +634,7 @@ suite("Query field agendaFolder", () => {
 		expect(queriedAgendaFolder.organization.id).toBe(organizationId);
 	});
 
-	test("results in an empty 'errors' field and the expected value for the 'data.agendaFolder' field when accessed by an organization member", async () => {
-		// Step 1: Admin Sign-in
+	test("results in an empty 'errors' field when accessed by the event creator who is a regular org member", async () => {
 		const adminSignInResult = await mercuriusClient.query(Query_signIn, {
 			variables: {
 				input: {
@@ -648,45 +647,37 @@ suite("Query field agendaFolder", () => {
 		const adminToken = adminSignInResult.data?.signIn?.authenticationToken;
 		if (!adminToken) throw new Error("Admin authentication failed");
 
-		// Step 2: Create Regular User
-		const regularUserResult = await mercuriusClient.mutate(
-			Mutation_createUser,
-			{
-				headers: { authorization: `bearer ${adminToken}` },
-				variables: {
-					input: {
-						emailAddress: `${faker.string.uuid()}@test.com`,
-						password: "password123",
-						name: "Regular User",
-						role: "regular",
-						isEmailAddressVerified: true,
-					},
+		// Create regular user
+		const regularUserResult = await mercuriusClient.mutate(Mutation_createUser, {
+			headers: { authorization: `bearer ${adminToken}` },
+			variables: {
+				input: {
+					emailAddress: `${faker.string.uuid()}@test.com`,
+					password: "password123",
+					name: "Event Creator",
+					role: "regular",
+					isEmailAddressVerified: true,
 				},
 			},
-		);
+		});
 		const regularUserId = regularUserResult.data?.createUser?.user?.id;
-		const regularUserToken =
-			regularUserResult.data?.createUser?.authenticationToken;
-		if (!regularUserToken || !regularUserId)
-			throw new Error("Regular user creation failed");
+		const regularUserToken = regularUserResult.data?.createUser?.authenticationToken;
+		if (!regularUserToken || !regularUserId) throw new Error("Regular user creation failed");
 		createdUserIds.push(regularUserId);
 
-		// Step 3: Create Organization
-		const organizationResult = await mercuriusClient.mutate(
-			Mutation_createOrganization,
-			{
-				headers: { authorization: `bearer ${adminToken}` },
-				variables: {
-					input: {
-						name: `Test Org ${faker.string.uuid()}`,
-						addressLine1: "123 Main St",
-						city: "New York",
-						countryCode: "us",
-						description: "Test Description",
-					},
+		// Create organization
+		const organizationResult = await mercuriusClient.mutate(Mutation_createOrganization, {
+			headers: { authorization: `bearer ${adminToken}` },
+			variables: {
+				input: {
+					name: `Test Org ${faker.string.uuid()}`,
+					addressLine1: "123 Main St",
+					city: "New York",
+					countryCode: "us",
+					description: "Test Description",
 				},
 			},
-		);
+		});
 		const organizationId = organizationResult.data?.createOrganization?.id;
 		if (!organizationId) throw new Error("Organization creation failed");
 		createdOrganizationIds.push(organizationId);
@@ -694,45 +685,27 @@ suite("Query field agendaFolder", () => {
 		const adminUserId = adminSignInResult.data?.signIn?.user?.id;
 		if (!adminUserId) throw new Error("Admin User ID not found");
 
-		const membershipResult = await mercuriusClient.mutate(
-			Mutation_createOrganizationMembership,
-			{
-				headers: { authorization: `bearer ${adminToken}` },
-				variables: {
-					input: {
-						organizationId,
-						memberId: adminUserId,
-						role: "administrator",
-					},
-				},
-			},
-		);
-		if (membershipResult.data?.createOrganizationMembership?.id) {
+		// Make admin an org admin
+		const adminMembership = await mercuriusClient.mutate(Mutation_createOrganizationMembership, {
+			headers: { authorization: `bearer ${adminToken}` },
+			variables: { input: { organizationId, memberId: adminUserId, role: "administrator" } },
+		});
+		if (adminMembership.data?.createOrganizationMembership?.id) {
 			createdMemberships.push({ organizationId, memberId: adminUserId });
 		}
 
-		// Step 4: Add regular user to organization
-		const userMembershipResult = await mercuriusClient.mutate(
-			Mutation_createOrganizationMembership,
-			{
-				headers: { authorization: `bearer ${adminToken}` },
-				variables: {
-					input: {
-						organizationId,
-						memberId: regularUserId,
-					},
-				},
-			},
-		);
-		if (userMembershipResult.data?.createOrganizationMembership?.id) {
+		// Make regular user an org admin so they can create events
+		const regularMembership = await mercuriusClient.mutate(Mutation_createOrganizationMembership, {
+			headers: { authorization: `bearer ${adminToken}` },
+			variables: { input: { organizationId, memberId: regularUserId, role: "administrator" } },
+		});
+		if (regularMembership.data?.createOrganizationMembership?.id) {
 			createdMemberships.push({ organizationId, memberId: regularUserId });
 		}
 
-		// Step 5: Create Event
+		// Regular user creates the event — creatorId is set to regularUserId
 		const eventResult = await mercuriusClient.mutate(Mutation_createEvent, {
-			headers: {
-				authorization: `bearer ${adminToken}`,
-			},
+			headers: { authorization: `bearer ${regularUserToken}` },
 			variables: {
 				input: {
 					organizationId,
@@ -747,42 +720,50 @@ suite("Query field agendaFolder", () => {
 		if (!eventId) throw new Error("Event creation failed");
 		createdEventIds.push(eventId);
 
-		// Step 6: Create Agenda Folder
-		const agendaFolderCreationResult = await mercuriusClient.mutate(
-			Mutation_createAgendaFolder,
-			{
-				headers: { authorization: `bearer ${adminToken}` },
-				variables: {
-					input: {
-						name: "Test Agenda Folder",
-						organizationId,
-						eventId,
-						description: "Test Description",
-						sequence: 1,
-					},
+		// Admin creates agenda folder for the event
+		const agendaFolderCreationResult = await mercuriusClient.mutate(Mutation_createAgendaFolder, {
+			headers: { authorization: `bearer ${adminToken}` },
+			variables: {
+				input: {
+					name: "Test Agenda Folder",
+					organizationId,
+					eventId,
+					description: "Test Description",
+					sequence: 1,
 				},
 			},
-		);
-		const agendaFolderId =
-			agendaFolderCreationResult.data?.createAgendaFolder?.id;
+		});
+		const agendaFolderId = agendaFolderCreationResult.data?.createAgendaFolder?.id;
 		if (!agendaFolderId) throw new Error("Agenda folder creation failed");
 		createdAgendaFolderIds.push(agendaFolderId);
 
-		// Step 7: Query Agenda Folder as Regular User (who is org member)
-		const agendaFolderQueryResult = await mercuriusClient.query(
-			Query_agendaFolder_Restricted,
-			{
-				headers: { authorization: `bearer ${regularUserToken}` },
-				variables: { input: { id: agendaFolderId } },
-			},
-		);
+		// Now downgrade regular user to regular member
+		// (so they are no longer org admin, only event creator)
+		await mercuriusClient.mutate(Mutation_deleteOrganizationMembership, {
+			headers: { authorization: `bearer ${adminToken}` },
+			variables: { input: { organizationId, memberId: regularUserId } },
+		});
+		createdMemberships.splice(createdMemberships.findIndex(
+			m => m.memberId === regularUserId && m.organizationId === organizationId
+		), 1);
+
+		await mercuriusClient.mutate(Mutation_createOrganizationMembership, {
+			headers: { authorization: `bearer ${adminToken}` },
+			variables: { input: { organizationId, memberId: regularUserId, role: "regular" } },
+		});
+		createdMemberships.push({ organizationId, memberId: regularUserId });
+
+		// Query agenda folder as event creator (now a regular member) — should succeed
+		const agendaFolderQueryResult = await mercuriusClient.query(Query_agendaFolder_Restricted, {
+			headers: { authorization: `bearer ${regularUserToken}` },
+			variables: { input: { id: agendaFolderId } },
+		});
 
 		expect(agendaFolderQueryResult.errors).toBeUndefined();
 		assertToBeNonNullish(agendaFolderQueryResult.data.agendaFolder);
-		const queriedAgendaFolder = agendaFolderQueryResult.data.agendaFolder;
-		expect(queriedAgendaFolder).toMatchObject({
+		expect(agendaFolderQueryResult.data.agendaFolder).toMatchObject({
 			id: agendaFolderId,
 			name: "Test Agenda Folder",
 		});
-	});
+});
 });


### PR DESCRIPTION
Here's the filled PR description:

---

**What kind of change does this PR introduce?**

Bug fix : authorization logic in agenda resolver files was too restrictive, blocking event creators from managing their own event's agenda resources.

**Issue Number:**

Fixes #5358

**Snapshots/Videos:**

N/A

**If relevant, did you update the documentation?**

No documentation changes required.

**Summary**

Event creators were unable to manage agenda categories, folders, and items for events they created. Every agenda resolver used an admin-only authorization guard that allowed only global administrators and organization administrators through, with no check for whether the current user was the event creator.

This PR fixes the issue across all 12 affected resolvers by:

- Creating a shared `isEventCreatorOrAdmin` utility at `src/utilities/isEventCreatorOrAdmin.ts` that encapsulates the authorization logic in one place
- Adding `creatorId` to the event column selectors in the 9 mutation resolvers and `agendaFolder.ts` where it was not previously fetched
- Replacing the admin-only guard in all 12 resolvers with a call to the shared utility
- Normalizing `agendaFolder.ts` which had a pre-existing inconsistency - it was checking membership existence rather than admin role, meaning any org member could read agenda folders regardless of role

This PR intentionally avoids touching any files outside the 12 affected resolvers and the new utility. No doc regeneration, no unrelated refactors. The previous attempt at fixing this issue (PR #5363) was not merged due to missing shared utility, a security regression in `agendaFolder.ts`, and significant unrelated scope creep.

**Does this PR introduce a breaking change?**

No. This is a permissions expansion - users who previously had access still do, and event creators now additionally have access they were incorrectly denied.

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features (existing test suite updated where behavior changed; new "event creator succeeds" test cases pending per maintainer feedback)
- [ ] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass

**Other information**

All 12 existing agenda test files pass locally. The pre-existing test in agendaFolder.test.ts that was testing the incorrect membership-existence behavior has been updated to reflect the corrected admin-role check. New test cases covering the "event creator who is a regular org member succeeds" path are not yet included -- happy to add them before merge or follow whatever approach the maintainers prefer.

These files are flagged as sensitive/protected in CI - please apply the `ignore-sensitive-files-pr` label when ready to review.

**Have you read the [[contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved authorization checks for agenda management operations to properly recognize event creators' permissions alongside organization administrators.
- Event creators can now manage their event's agenda categories, folders, and items without requiring organization administrator privileges.

**Tests**
- Enhanced test coverage for event creator access scenarios to restricted agenda resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->